### PR TITLE
perf: use uuid v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,4 +67,4 @@ serde_with = "3.14.0"
 sqlx = { version = "0.8.3", default-features = false, features = ["macros", "runtime-tokio-rustls", "postgres", "uuid", "chrono", "json" ] }
 tokio = { version = "1.46", features = ["rt-multi-thread", "macros"] }
 thiserror = "2.0.12"
-uuid = { version = "1.16", features = ["serde", "v4"] }
+uuid = { version = "1.17", features = ["serde", "v7"] }

--- a/book/src/transactions.md
+++ b/book/src/transactions.md
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
     let mut tx = pool.begin().await?;
     let _ = count_users(&mut tx).await?;
 
-    let some_existing_user_id = uuid::Uuid::new_v4();
+    let some_existing_user_id = uuid::Uuid::now_v7();
     let _ = delete_and_count(&mut tx, some_existing_user_id).await?;
 
     // Don't forget to commit the operation or the change won't become visible

--- a/src/events.rs
+++ b/src/events.rs
@@ -289,7 +289,7 @@ mod tests {
     impl IntoEvents<DummyEntityEvent> for NewDummyEntity {
         fn into_events(self) -> EntityEvents<DummyEntityEvent> {
             EntityEvents::init(
-                Uuid::new_v4(),
+                Uuid::now_v7(),
                 vec![DummyEntityEvent::Created("".to_owned())],
             )
         }
@@ -305,7 +305,7 @@ mod tests {
     #[test]
     fn load_first() {
         let generic_events = vec![GenericEvent {
-            entity_id: uuid::Uuid::new_v4(),
+            entity_id: uuid::Uuid::now_v7(),
             sequence: 1,
             event: serde_json::to_value(DummyEntityEvent::Created("dummy-name".to_owned()))
                 .expect("Could not serialize"),
@@ -319,14 +319,14 @@ mod tests {
     fn load_n() {
         let generic_events = vec![
             GenericEvent {
-                entity_id: uuid::Uuid::new_v4(),
+                entity_id: uuid::Uuid::now_v7(),
                 sequence: 1,
                 event: serde_json::to_value(DummyEntityEvent::Created("dummy-name".to_owned()))
                     .expect("Could not serialize"),
                 recorded_at: chrono::Utc::now(),
             },
             GenericEvent {
-                entity_id: uuid::Uuid::new_v4(),
+                entity_id: uuid::Uuid::now_v7(),
                 sequence: 1,
                 event: serde_json::to_value(DummyEntityEvent::Created("other-name".to_owned()))
                     .expect("Could not serialize"),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -212,7 +212,7 @@ macro_rules! __entity_id_common_impls {
         impl $name {
             #[allow(clippy::new_without_default)]
             pub fn new() -> Self {
-                $crate::prelude::uuid::Uuid::new_v4().into()
+                $crate::prelude::uuid::Uuid::now_v7().into()
             }
         }
 

--- a/tests/from_async_trait.rs
+++ b/tests/from_async_trait.rs
@@ -23,7 +23,7 @@ impl RunJob for TestJob {
     fn execute(&self) -> std::pin::Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + '_>> {
         let pool = self.pool.clone();
         Box::pin(async move {
-            let name = uuid::Uuid::new_v4().to_string();
+            let name = uuid::Uuid::now_v7().to_string();
 
             let users = Users::new(pool.clone());
             let new_user = NewUser::builder()
@@ -35,7 +35,7 @@ impl RunJob for TestJob {
             let mut user = users.create(new_user).await?;
             let mut op = users.begin_op().await?;
 
-            let new_name = uuid::Uuid::new_v4().to_string();
+            let new_name = uuid::Uuid::now_v7().to_string();
             if user.update_name(new_name.clone()).did_execute() {
                 users.update_in_op(&mut op, &mut user).await?;
             }


### PR DESCRIPTION
https://docs.rs/uuid/1.17.0/uuid/#which-uuid-version-should-i-use

```
If you want to use UUIDs as database keys or need to sort them then consider version 7 (v7) UUIDs.
```

note: cargo.lock was not updated because it is already using 1.17 https://github.com/GaloyMoney/cala/blob/main/Cargo.lock#L4223

## Security 
apply the same security concerns of mongodb ids but:
- Performance and storage efficiency are more important for a financial ledger
- if there are security concerns, they should be handled by the main service (ex: Lana) at the end this is an internal service/lib that is not exposed directly to final users