### PR TITLE
ci: fix release script

### DIFF
--- a/ci/vendor/tasks/prep-release-src.sh
+++ b/ci/vendor/tasks/prep-release-src.sh
@@ -35,16 +35,20 @@ echo -n "Prev Version: "
 cat version/version
 echo ""
 
-# Initial Version
 if [[ $(cat version/version) == "0.0.0" ]]; then
   echo "0.1.0" > version/version
-# Figure out proper version to release
-elif [[ $(cat artifacts/gh-release-notes.md | grep breaking) != '' ]] || [[ $(cat artifacts/gh-release-notes.md | grep feature) != '' ]]; then
-  echo "Breaking change / Feature Addition found, bumping minor version..."
-  bump2version minor --current-version $(cat version/version) --allow-dirty version/version
+
+elif grep -q '\[**breaking**\]' artifacts/gh-release-notes.md; then
+  echo "Breaking change found, bumping minor version..."
+  bump2version minor --current-version "$(cat version/version)" --allow-dirty version/version
+
+elif grep -q '^### Features' artifacts/gh-release-notes.md; then
+  echo "Feature section found, bumping minor version..."
+  bump2version minor --current-version "$(cat version/version)" --allow-dirty version/version
+
 else
-  echo "Only patches and fixes found - no breaking changes, bumping patch version..."
-  bump2version patch --current-version $(cat version/version) --allow-dirty version/version
+  echo "Only patches and fixes found - bumping patch version..."
+  bump2version patch --current-version "$(cat version/version)" --allow-dirty version/version
 fi
 
 echo -n "Release Version: "


### PR DESCRIPTION
The reason this changelog:
```
### Miscellaneous Tasks

- Bump deps in book
- Declare crate for serde
- Declare crate for schemars feature

```
bumps minor is because the script used to blindly grep on "feature". 

This PR fixes this behavior and only matches on `### Features` and `[**breaking**]`