### PR TITLE
feat(macros): nullable column attribute for non-Option<T> Rust types

### DIFF
--- a/es-entity-macros/src/repo/list_by_fn.rs
+++ b/es-entity-macros/src/repo/list_by_fn.rs
@@ -45,7 +45,7 @@ impl CursorStruct<'_> {
         let nulls = if ascending { "FIRST" } else { "LAST" };
         if self.column.is_id() {
             format!("id {dir}")
-        } else if self.column.is_optional() {
+        } else if self.column.is_nullable_column() {
             format!("{0} {dir} NULLS {nulls}, id {dir}", self.column.name())
         } else {
             format!("{} {dir}, id {dir}", self.column.name())
@@ -59,7 +59,7 @@ impl CursorStruct<'_> {
 
         if self.column.is_id() {
             format!("COALESCE(id {comp} ${id_offset}, true)")
-        } else if self.column.is_optional() {
+        } else if self.column.is_nullable_column() {
             // The OR-clause's COALESCE fires when `col {comp} ${cursor}` is NULL,
             // which happens whenever either side of the comparison is NULL. The
             // fallback decides whether the row is "after" the cursor in
@@ -865,6 +865,114 @@ mod tests {
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
                                 value as Option<rust_decimal::Decimal>,
+                            )
+                                .fetch_n(op, first)
+                                .await?
+                        },
+                    };
+
+                    let end_cursor = entities.last().map(cursor_mod::EntityByValueCursor::from);
+
+                    Ok(es_entity::PaginatedQueryRet {
+                        entities,
+                        has_next_page,
+                        end_cursor,
+                    })
+                }.await;
+
+                __result
+            }
+        };
+
+        assert_eq!(tokens.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn list_by_fn_nullable_attribute_emits_nullable_aware_sql_for_non_option_type() {
+        // The `nullable` attribute lets non-Option<T> Rust types (e.g. domain
+        // enums whose custom sqlx::Encode writes NULL for one variant) opt
+        // into the nullable-aware cursor SQL form. The Rust type is NOT
+        // syntactically Option<T>, but the emitted SQL should match what an
+        // Option<T> column would get: `NULLS FIRST/LAST` ordering, the
+        // `IS NOT DISTINCT FROM` cursor form, and the direction-aware NULL
+        // fallback.
+        //
+        // The query parameter cast (else branch of query_arg_tokens) still
+        // wraps the Rust type in Option<...> because is_optional() remains
+        // false — the type itself drives binding, while the new
+        // is_nullable_column() drives SQL shape.
+        let id_type = Ident::new("EntityId", Span::call_site());
+        let entity = Ident::new("Entity", Span::call_site());
+        let query_error = syn::Ident::new("EntityQueryError", Span::call_site());
+        let column = Column::new_nullable(
+            syn::Ident::new("value", proc_macro2::Span::call_site()),
+            syn::parse_str("DomainEnum").unwrap(),
+        );
+        let cursor_mod = Ident::new("cursor_mod", Span::call_site());
+
+        let persist_fn = ListByFn {
+            ignore_prefix: None,
+            column: &column,
+            id: &id_type,
+            entity: &entity,
+            table_name: "entities",
+            query_error,
+            delete: DeleteOption::No,
+            cursor_mod,
+            any_nested: false,
+            post_hydrate_error: None,
+            #[cfg(feature = "instrument")]
+            repo_name_snake: "test_repo".to_string(),
+        };
+
+        let mut tokens = TokenStream::new();
+        persist_fn.to_tokens(&mut tokens);
+
+        let expected = quote! {
+            pub async fn list_by_value(
+                &self,
+                cursor: es_entity::PaginatedQueryArgs<cursor_mod::EntityByValueCursor>,
+                direction: es_entity::ListDirection,
+            ) -> Result<es_entity::PaginatedQueryRet<Entity, cursor_mod::EntityByValueCursor>, EntityQueryError> {
+                self.list_by_value_in_op(self.pool(), cursor, direction).await
+            }
+
+            pub async fn list_by_value_in_op<'a, OP>(
+                &self,
+                op: OP,
+                cursor: es_entity::PaginatedQueryArgs<cursor_mod::EntityByValueCursor>,
+                direction: es_entity::ListDirection,
+            ) -> Result<es_entity::PaginatedQueryRet<Entity, cursor_mod::EntityByValueCursor>, EntityQueryError>
+                where
+                    OP: es_entity::IntoOneTimeExecutor<'a>
+            {
+                let __result: Result<es_entity::PaginatedQueryRet<Entity, cursor_mod::EntityByValueCursor>, EntityQueryError> = async {
+                    let es_entity::PaginatedQueryArgs { first, after } = cursor;
+                    let (id, value) = if let Some(after) = after {
+                        (Some(after.id), Some(after.value))
+                    } else {
+                        (None, None)
+                    };
+
+                    let (entities, has_next_page) = match direction {
+                        es_entity::ListDirection::Ascending => {
+                            es_entity::es_query!(
+                                entity = Entity,
+                                "SELECT value, id FROM entities WHERE ((value IS NOT DISTINCT FROM $3) AND COALESCE(id > $2, true) OR COALESCE(value > $3, value IS NOT NULL)) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1",
+                                (first + 1) as i64,
+                                id as Option<EntityId>,
+                                value as Option<DomainEnum>,
+                            )
+                                .fetch_n(op, first)
+                                .await?
+                        },
+                        es_entity::ListDirection::Descending => {
+                            es_entity::es_query!(
+                                entity = Entity,
+                                "SELECT value, id FROM entities WHERE ((value IS NOT DISTINCT FROM $3) AND COALESCE(id < $2, true) OR COALESCE(value < $3, $2 IS NULL OR (value IS NULL AND $3 IS NOT NULL))) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1",
+                                (first + 1) as i64,
+                                id as Option<EntityId>,
+                                value as Option<DomainEnum>,
                             )
                                 .fetch_n(op, first)
                                 .await?

--- a/es-entity-macros/src/repo/options/columns.rs
+++ b/es-entity-macros/src/repo/options/columns.rs
@@ -379,6 +379,17 @@ impl Column {
         }
     }
 
+    #[cfg(test)]
+    pub fn new_nullable(name: syn::Ident, ty: syn::Type) -> Self {
+        Column {
+            name,
+            opts: ColumnOpts {
+                nullable: Some(true),
+                ..ColumnOpts::new(ty)
+            },
+        }
+    }
+
     pub fn for_id(ty: syn::Type) -> Self {
         Column {
             name: syn::Ident::new("id", proc_macro2::Span::call_site()),
@@ -387,6 +398,7 @@ impl Column {
                 is_id: true,
                 list_by: Some(true),
                 find_by: Some(true),
+                nullable: None,
                 list_for_opts: None,
                 parent_opts: None,
                 create_opts: Some(CreateOpts {
@@ -412,6 +424,7 @@ impl Column {
                 is_id: false,
                 list_by: Some(true),
                 find_by: Some(false),
+                nullable: None,
                 list_for_opts: None,
                 parent_opts: None,
                 create_opts: Some(CreateOpts {
@@ -443,6 +456,12 @@ impl Column {
         self.opts.is_id
     }
 
+    /// True iff the Rust type is syntactically `Option<T>`.
+    ///
+    /// Drives how the macro casts query parameters and destructures the
+    /// cursor — both of which depend on the Rust type's shape (Option vs.
+    /// bare). For the SQL question "is this column nullable?" use
+    /// [`Self::is_nullable_column`] instead.
     pub fn is_optional(&self) -> bool {
         if let syn::Type::Path(type_path) = self.ty()
             && type_path.path.segments.len() == 1
@@ -453,6 +472,20 @@ impl Column {
             }
         }
         false
+    }
+
+    /// True iff the underlying SQL column can hold NULL.
+    ///
+    /// Returns true when the Rust type is `Option<T>` *or* the column was
+    /// explicitly annotated `nullable` in the repo declaration. The latter
+    /// covers types like a domain enum whose custom `sqlx::Encode`
+    /// implementation maps one variant to SQL NULL — the macro otherwise
+    /// can't see that nullability via syntactic inspection.
+    ///
+    /// Drives `ORDER BY ... NULLS FIRST/LAST` emission and the nullable-aware
+    /// cursor `WHERE` clause in [`Self::condition`].
+    pub fn is_nullable_column(&self) -> bool {
+        self.is_optional() || self.opts.nullable()
     }
 
     pub fn name(&self) -> &syn::Ident {
@@ -551,6 +584,16 @@ struct ColumnOpts {
     find_by: Option<bool>,
     #[darling(default)]
     list_by: Option<bool>,
+    /// Opt-in flag for columns whose Rust type is not syntactically `Option<T>`
+    /// but whose underlying SQL column is nullable. When set, the macro emits
+    /// the same nullable-aware cursor SQL (`IS NOT DISTINCT FROM`, `NULLS
+    /// FIRST/LAST` ordering, direction-aware NULL fallback) as it would for an
+    /// `Option<T>` column. The Rust type itself must implement `sqlx::Encode`
+    /// in a way that maps to a nullable database column — typically by
+    /// encoding one variant as `IsNull::Yes` or by exposing a `Type::type_info`
+    /// matching `Option<Inner>`.
+    #[darling(default)]
+    nullable: Option<bool>,
     #[darling(default, rename = "list_for")]
     list_for_opts: Option<ListForOpts>,
     #[darling(default, rename = "parent")]
@@ -570,6 +613,7 @@ impl ColumnOpts {
             is_id: false,
             find_by: None,
             list_by: None,
+            nullable: None,
             list_for_opts: None,
             parent_opts: None,
             create_opts: None,
@@ -584,6 +628,10 @@ impl ColumnOpts {
 
     fn list_by(&self) -> bool {
         self.list_by.unwrap_or(false)
+    }
+
+    fn nullable(&self) -> bool {
+        self.nullable.unwrap_or(false)
     }
 
     fn list_for(&self) -> bool {


### PR DESCRIPTION
## Summary

`Column::is_optional()` checks the Rust type syntactically — true only when the type literally begins with `Option<`. That misses a real shape: a domain type whose custom `sqlx::Encode` impl maps one variant to SQL NULL (e.g. an enum `Finite(Decimal) | Infinite` that encodes `Infinite` as `IsNull::Yes`). Such columns are nullable in SQL but look non-optional to the macro, so they receive the non-nullable cursor SQL form which silently drops NULL rows from page 2+.

The downstream workaround (see [GaloyMoney/lana-bank#5898](https://github.com/GaloyMoney/lana-bank/pull/5898)) is to declare `ty = "Option<Decimal>"` at the storage edge and convert to/from the domain type via a boundary accessor. That works but leaks storage shape into the cursor and the repo accessor, and introduces a separate type at every call site.

Stacks on #137 (direction-aware NULL fallback in cursor condition).

## Fix

Add an opt-in `nullable` attribute on the column declaration:

```rust
columns(
    loan_to_collateral_ratio(
        ty = "LoanToCollateralRatio",
        nullable,
        list_by,
        // ...
    ),
)
```

Now the macro detects nullability from either signal: the syntactic `Option<T>` shape OR the explicit annotation. Two methods carry the two semantics:

- `Column::is_optional()` — Rust type is `Option<T>`. Drives query parameter casting (avoid double-wrapping in Option) and cursor destructuring (the field is already optional).
- `Column::is_nullable_column()` — SQL column can hold NULL. Returns true if either `is_optional()` or `nullable`. Drives `ORDER BY ... NULLS FIRST/LAST` emission and the nullable-aware cursor `WHERE` form (see #137).

For a column declared `ty = "DomainEnum", nullable`:

- **SQL shape**: nullable-aware (`NULLS FIRST/LAST`, `IS NOT DISTINCT FROM`, direction-aware NULL fallback from #137 — same as `Option<T>`).
- **Query parameter binding**: `value as Option<DomainEnum>` (else branch of `query_arg_tokens`). sqlx encodes the variant that maps to `IsNull::Yes` as NULL, the rest as their normal payload.
- **Cursor field type**: the raw `DomainEnum` (no Option wrap in the cursor struct — keeps the domain type at the read boundary).

## Downstream impact

Once both #137 and this PR land + a release ships, [GaloyMoney/lana-bank#5898](https://github.com/GaloyMoney/lana-bank/pull/5898) can revert its `ty = "Option<rust_decimal::Decimal>"` workaround back to the cleaner `ty = "LoanToCollateralRatio", nullable` and restore the custom `sqlx::Encode` impls on the domain type.

## Test plan

- [x] New unit test `list_by_fn_nullable_attribute_emits_nullable_aware_sql_for_non_option_type` verifies the emitted SQL matches `Option<T>`'s (`NULLS FIRST/LAST`, `IS NOT DISTINCT FROM`, direction-aware fallback) while the parameter binding stays as `Option<DomainEnum>`.
- [x] All 83 macro tests pass (82 existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)