### PR TITLE
chore(ci): exclude rust/docker shared files from vendir

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,7 +1,6 @@
 #@ load("@ytt:data", "data")
 
 #@ load("vendor/pipeline-fragments.lib.yml",
-#@   "public_docker_registry",
 #@   "repo_resource",
 #@   "version_resource",
 #@   "pipeline_tasks_resource",

--- a/ci/tasks/prep-docker-build-env.sh
+++ b/ci/tasks/prep-docker-build-env.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [[ -f version/version ]]; then
-  echo "VERSION=$(cat version/version)" >> repo/.env
-fi
-
-echo "COMMITHASH=$(cat repo/.git/ref)" >> repo/.env
-echo "BUILDTIME=$(date -u '+%F-%T')" >> repo/.env

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -4,8 +4,6 @@ git_uri: git@github.com:GaloyMoney/es-entity.git
 git_branch: main
 github_private_key: ((github.private_key))
 github_token: ((github.api_token))
-github_app_id: ((github.github_app_id))
-github_app_private_key: ((github.github_app_private_key))
 
 gar_registry_user: ((gar-creds.username))
 gar_registry_password: ((gar-creds.password))

--- a/ci/vendir.yml
+++ b/ci/vendir.yml
@@ -13,6 +13,8 @@ directories:
     - shared/actions/*
     excludePaths:
     - shared/actions/nodejs-*
+    - shared/actions/rust-*
+    - shared/actions/docker-*
     - shared/actions/chart-*
     newRootPath: shared/actions
 
@@ -26,5 +28,7 @@ directories:
     - shared/ci/**/*
     excludePaths:
     - shared/ci/**/nodejs-*
+    - shared/ci/**/rust-*
+    - shared/ci/**/docker-*
     - shared/ci/**/chart-*
     newRootPath: shared/ci


### PR DESCRIPTION
## What

Exclude `rust-*` and `docker-*` prefixed files from the vendored shared CI in `ci/vendir.yml`, and drop the now-unused docker build wiring:

- `ci/vendir.yml`: add `rust-*` and `docker-*` to `excludePaths` for both `shared/actions/*` and `shared/ci/**/*`.
- `ci/pipeline.yml`: remove the unused `public_docker_registry` import.
- `ci/tasks/prep-docker-build-env.sh`: delete — only used by the docker image build path, which es-entity doesn't have.

## Why

es-entity is a published library crate, not a deployable service. It builds no container image and ships no Helm chart, so the docker (and rust workflow) shared CI files don't apply. It maintains its own GitHub workflows (`check-code.yml` runs `nix flake check`, plus `deploy-book.yml`, `test.yml`).

## Notes

es-entity is **not** in `src_repos` in `galoy-concourse-shared`, so these vendored files are manually managed (frozen at the pinned ref). This change keeps the local vendir config consistent with what es-entity actually uses. Auto-linking to shared concourse is deferred: the base `check-code.sh` sources `helpers.sh`, which is only provided by the `rust` flag, so a clean `[]` registration isn't possible until `helpers.sh` is split out as a base file in the shared repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and vendir configuration only; no application runtime, auth, or publish logic changes.
> 
> **Overview**
> Trims **Concourse/vendir** integration so it no longer pulls or references **Docker/Rust image-build** shared assets this crate does not use.
> 
> **`ci/vendir.yml`** now excludes `rust-*` and `docker-*` paths from both vendored **GitHub actions** and **shared CI** trees, alongside existing nodejs/chart exclusions. **`ci/pipeline.yml`** drops the unused `public_docker_registry` import. **`ci/tasks/prep-docker-build-env.sh`** is removed (only relevant to container builds). **`ci/values.yml`** removes unused **GitHub App** credential fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbce8435e31eb858c73960b0354593fd6becf5ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->