### PR TITLE
feat(context): transient (non-persisted) EventContext entries

### DIFF
--- a/book/src/database-tables.md
+++ b/book/src/database-tables.md
@@ -36,8 +36,9 @@ The `context` column stores out-of-band metadata (like request ids or audit info
 Entries are added via `EventContext::insert` and serialized as a plain JSON map alongside every persisted event.
 
 Not everything that is useful in-process should end up in an immutable event stream though.
-Request-scoped personal data (client IP, user agent, ...) may need to be readable by in-process consumers during the request but must not be persisted forever.
+Request-scoped personal data (client IP, user agent, ...) may well need to be stored - but in a *mutable* table that can honor an erasure request (e.g. an audit table), not fanned out as a side effect into every append-only events table, where erasure would mean rewriting immutable history.
 For this use case `EventContext::insert_transient` adds a *transient* entry: it propagates exactly like a persisted entry (across `fork()`, threads, and async boundaries via `WithEventContext`) and is visible through `ContextData::lookup`, but it is excluded whenever `ContextData` is serialized - so it never reaches the `context` column.
+In-process consumers can still read the entry during the request and persist it deliberately wherever erasure can be honored; *transient* only means the event-context machinery itself will never write it anywhere.
 The exclusion is enforced by the `Serialize` implementation of `ContextData` itself, not by call-site discipline.
 
 Note that the `context` column is never used for rehydrating an `Entity` - state is rebuilt exclusively from the `event` column.

--- a/book/src/database-tables.md
+++ b/book/src/database-tables.md
@@ -30,6 +30,18 @@ CREATE TABLE user_events (
 
 In fact we could persist all events to a global table with that schema but partitioning the events per `Entity` gives us some benefits when querying (like read performance and referential integrity).
 
+### The Event Context
+
+The `context` column stores out-of-band metadata (like request ids or audit information) that was present in the ambient `EventContext` when the event was appended.
+Entries are added via `EventContext::insert` and serialized as a plain JSON map alongside every persisted event.
+
+Not everything that is useful in-process should end up in an immutable event stream though.
+Request-scoped personal data (client IP, user agent, ...) may need to be readable by in-process consumers during the request but must not be persisted forever.
+For this use case `EventContext::insert_transient` adds a *transient* entry: it propagates exactly like a persisted entry (across `fork()`, threads, and async boundaries via `WithEventContext`) and is visible through `ContextData::lookup`, but it is excluded whenever `ContextData` is serialized - so it never reaches the `context` column.
+The exclusion is enforced by the `Serialize` implementation of `ContextData` itself, not by call-site discipline.
+
+Note that the `context` column is never used for rehydrating an `Entity` - state is rebuilt exclusively from the `event` column.
+
 Intuitively you might think this is all we need as we can very easily query all the events for a specific `Entity`:
 ```sql
 SELECT * FROM user_events WHERE id = $1 ORDER BY sequence

--- a/es-entity-macros/src/event.rs
+++ b/es-entity-macros/src/event.rs
@@ -87,12 +87,15 @@ mod tests {
         let mut tokens = TokenStream::new();
         event.to_tokens(&mut tokens);
 
+        // With no `event_context` attribute the default depends on the
+        // `event-context` feature
+        let event_context = cfg!(feature = "event-context");
         let expected = quote! {
             impl es_entity::EsEvent for UserEvent {
                 type EntityId = UserId;
 
                 fn event_context() -> bool {
-                    false
+                    #event_context
                 }
 
                 fn event_type(&self) -> &'static str {

--- a/flake.nix
+++ b/flake.nix
@@ -318,7 +318,7 @@
         CARGO_MANIFEST_DIR=$(pwd) mdbook test book -L ''${CARGO_TARGET_DIR:-./target}/mdbook-test,''${CARGO_TARGET_DIR:-./target}/mdbook-test/deps
 
         echo "Running nextest..."
-        cargo nextest run --workspace --verbose
+        cargo nextest run --workspace --verbose --features event-context
 
         echo "Running doc tests..."
         cargo test --doc --workspace

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -67,6 +67,32 @@
 //! When events are persisted using repositories with `event_context = true`, the current
 //! context is automatically serialized to JSON and stored in a `context` column
 //! alongside the event data, enabling comprehensive audit trails and debugging.
+//!
+//! # Transient Entries / PII
+//!
+//! Entries added via [`EventContext::insert_transient`] participate in all of the
+//! propagation above (forks, threads, async boundaries) but are excluded whenever
+//! `ContextData` is serialized — in particular they are never written to the
+//! `context` column. Use transient entries for request-scoped metadata that
+//! in-process consumers need but that must not be persisted into immutable event
+//! streams, such as client IPs, user agents, or other personal data:
+//!
+//! ```rust
+//! use es_entity::context::EventContext;
+//!
+//! let mut ctx = EventContext::current();
+//! ctx.insert("request_id", &"req-123").unwrap();          // persisted with events
+//! ctx.insert_transient("client_ip", &"203.0.113.7").unwrap(); // in-process only
+//!
+//! // Both are visible via lookup...
+//! let ip: Option<String> = ctx.data().lookup("client_ip").unwrap();
+//! assert_eq!(ip.as_deref(), Some("203.0.113.7"));
+//!
+//! // ...but only persisted entries survive serialization.
+//! let json = serde_json::to_value(ctx.data()).unwrap();
+//! assert!(json.get("request_id").is_some());
+//! assert!(json.get("client_ip").is_none());
+//! ```
 
 mod sqlx;
 mod tracing;
@@ -88,17 +114,63 @@ pub use with_event_context::*;
 /// `ContextData` is `Send` and can be passed between threads, unlike [`EventContext`]
 /// which is thread-local. This makes it suitable for transferring context across
 /// async boundaries via the [`WithEventContext`] trait.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct ContextData(im::HashMap<Cow<'static, str>, serde_json::Value>);
+///
+/// # Persisted vs transient entries
+///
+/// Entries come in two flavors:
+///
+/// - **Persisted** entries (added via [`EventContext::insert`]) are serialized
+///   into the `context` column when events are stored.
+/// - **Transient** entries (added via [`EventContext::insert_transient`]) behave
+///   identically in-process — they propagate across forks, threads, and async
+///   boundaries — but are excluded from serialization, so they never leave the
+///   process. Use them for data that must not end up in immutable event streams
+///   (e.g. request IP / user agent and other personal data).
+///
+/// The exclusion is enforced by the `Serialize` implementation itself: any code
+/// path that serializes `ContextData` (the repository persist path, sqlx
+/// encoding, `serde_json::to_value`, ...) only ever sees persisted entries.
+#[derive(Debug, Clone)]
+pub struct ContextData {
+    persisted: im::HashMap<Cow<'static, str>, serde_json::Value>,
+    transient: im::HashMap<Cow<'static, str>, serde_json::Value>,
+}
+
+/// The wire format is the plain JSON map of the persisted entries — identical
+/// to the format written before transient entries existed. Transient entries
+/// are deliberately excluded.
+impl Serialize for ContextData {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.persisted.serialize(serializer)
+    }
+}
+
+/// Deserializes the plain JSON map into persisted entries; transient entries
+/// start out empty (they never survive serialization boundaries).
+impl<'de> Deserialize<'de> for ContextData {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let persisted = im::HashMap::deserialize(deserializer)?;
+        Ok(Self {
+            persisted,
+            transient: im::HashMap::new(),
+        })
+    }
+}
 
 impl ContextData {
     fn new() -> Self {
-        Self(im::HashMap::new())
+        Self {
+            persisted: im::HashMap::new(),
+            transient: im::HashMap::new(),
+        }
     }
 
     fn insert(&mut self, key: &'static str, value: serde_json::Value) {
-        self.0 = self.0.update(Cow::Borrowed(key), value);
+        self.persisted = self.persisted.update(Cow::Borrowed(key), value);
+    }
+
+    fn insert_transient(&mut self, key: &'static str, value: serde_json::Value) {
+        self.transient = self.transient.update(Cow::Borrowed(key), value);
     }
 
     #[cfg(feature = "tracing-context")]
@@ -111,11 +183,14 @@ impl ContextData {
         self
     }
 
+    /// Looks up a value by key, checking transient entries first, then
+    /// persisted ones (a transient entry shadows a persisted entry with the
+    /// same key). Callers do not need to know which insert produced the key.
     pub fn lookup<T: serde::de::DeserializeOwned>(
         &self,
         key: &'static str,
     ) -> Result<Option<T>, serde_json::Error> {
-        let Some(val) = self.0.get(key) else {
+        let Some(val) = self.transient.get(key).or_else(|| self.persisted.get(key)) else {
             return Ok(None);
         };
         serde_json::from_value(val.clone()).map(Some)
@@ -327,6 +402,70 @@ impl EventContext {
         Ok(())
     }
 
+    /// Inserts a transient key-value pair into the current context.
+    ///
+    /// Transient entries behave exactly like entries added via
+    /// [`insert`](Self::insert) while in-process: they are visible through
+    /// [`ContextData::lookup`], are inherited by [`fork`](Self::fork)ed
+    /// contexts, and propagate across threads and async boundaries via
+    /// [`seed`](Self::seed) / [`WithEventContext`]. However, they are **never
+    /// serialized** — when events are persisted, transient entries are
+    /// excluded from the `context` column (and from any other serialization
+    /// of [`ContextData`]).
+    ///
+    /// Use this for request-scoped metadata that must not be written into
+    /// immutable event streams, such as client IP addresses, user agents, or
+    /// other personal data kept for in-process consumers only.
+    ///
+    /// On key collision a transient entry shadows a persisted entry in
+    /// [`ContextData::lookup`].
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - A static string key to identify the value
+    /// * `value` - Any serializable value to store in the context
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` on success or a `serde_json::Error` if serialization fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use es_entity::context::EventContext;
+    ///
+    /// let mut ctx = EventContext::current();
+    /// ctx.insert_transient("client_ip", &"203.0.113.7").unwrap();
+    ///
+    /// // Visible in-process...
+    /// let ip: Option<String> = ctx.data().lookup("client_ip").unwrap();
+    /// assert_eq!(ip.as_deref(), Some("203.0.113.7"));
+    ///
+    /// // ...but excluded from serialization.
+    /// let json = serde_json::to_value(ctx.data()).unwrap();
+    /// assert!(json.get("client_ip").is_none());
+    /// ```
+    pub fn insert_transient<T: Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), serde_json::Error> {
+        let json_value = serde_json::to_value(value)?;
+
+        CONTEXT_STACK.with(|c| {
+            let mut stack = c.borrow_mut();
+            for entry in stack.iter_mut().rev() {
+                if Rc::ptr_eq(&entry.id, &self.id) {
+                    entry.data.insert_transient(key, json_value);
+                    return;
+                }
+            }
+            panic!("EventContext missing on CONTEXT_STACK")
+        });
+
+        Ok(())
+    }
+
     /// Returns a copy of the current context data.
     ///
     /// This method returns a snapshot of all key-value pairs stored in this context.
@@ -379,6 +518,10 @@ mod tests {
         serde_json::to_value(EventContext::current().data()).unwrap()
     }
 
+    fn current_lookup(key: &'static str) -> Option<serde_json::Value> {
+        EventContext::current().data().lookup(key).unwrap()
+    }
+
     #[test]
     fn assert_stack_depth() {
         fn assert_inner() {
@@ -424,10 +567,62 @@ mod tests {
     }
 
     #[test]
+    fn insert_transient() {
+        let mut ctx = EventContext::current();
+        ctx.insert("persisted", &serde_json::json!("value"))
+            .unwrap();
+        ctx.insert_transient("transient", &serde_json::json!("secret"))
+            .unwrap();
+
+        // Both entries are visible via lookup
+        assert_eq!(
+            current_lookup("persisted"),
+            Some(serde_json::json!("value"))
+        );
+        assert_eq!(
+            current_lookup("transient"),
+            Some(serde_json::json!("secret"))
+        );
+
+        // Serialization only contains persisted entries
+        assert_eq!(current_json(), serde_json::json!({ "persisted": "value" }));
+    }
+
+    #[test]
+    fn transient_shadows_persisted_on_lookup() {
+        let mut ctx = EventContext::current();
+        ctx.insert("key", &serde_json::json!("persisted")).unwrap();
+        ctx.insert_transient("key", &serde_json::json!("transient"))
+            .unwrap();
+
+        assert_eq!(current_lookup("key"), Some(serde_json::json!("transient")));
+
+        // The wire format still carries the persisted value
+        assert_eq!(current_json(), serde_json::json!({ "key": "persisted" }));
+    }
+
+    #[test]
+    fn legacy_wire_format_roundtrip() {
+        let json = serde_json::json!({ "audit_info": { "sub": "user-1" } });
+        let data: ContextData = serde_json::from_value(json.clone()).unwrap();
+
+        // Plain-map JSON deserializes into persisted entries
+        assert_eq!(
+            data.lookup::<serde_json::Value>("audit_info").unwrap(),
+            Some(serde_json::json!({ "sub": "user-1" }))
+        );
+
+        // Re-serializing produces the identical plain map
+        assert_eq!(serde_json::to_value(&data).unwrap(), json);
+    }
+
+    #[test]
     fn thread_isolation() {
         let mut ctx = EventContext::current();
         let value = serde_json::json!({ "main": "thread" });
         ctx.insert("data", &value).unwrap();
+        ctx.insert_transient("secret", &serde_json::json!("pii"))
+            .unwrap();
         assert_eq!(stack_depth(), 1);
 
         let ctx_data = ctx.data();
@@ -440,6 +635,8 @@ mod tests {
                 current_json(),
                 serde_json::json!({ "data": { "main": "thread" }, "thread": "local" }),
             );
+            // Transient entry crossed the thread boundary but stays out of serialization
+            assert_eq!(current_lookup("secret"), Some(serde_json::json!("pii")));
         });
 
         handle.join().unwrap();
@@ -456,6 +653,10 @@ mod tests {
                 current_json(),
                 serde_json::json!({ "async_data": { "test": "async" }, "async_inner": "value" })
             );
+            assert_eq!(
+                current_lookup("async_secret"),
+                Some(serde_json::json!("pii"))
+            );
         }
 
         let mut ctx = EventContext::current();
@@ -463,6 +664,8 @@ mod tests {
 
         let value = serde_json::json!({ "test": "async" });
         ctx.insert("async_data", &value).unwrap();
+        ctx.insert_transient("async_secret", &serde_json::json!("pii"))
+            .unwrap();
         assert_eq!(current_json(), serde_json::json!({ "async_data": value }));
 
         inner_async().await;
@@ -471,35 +674,55 @@ mod tests {
             current_json(),
             serde_json::json!({ "async_data": value, "async_inner": "value" })
         );
+        assert_eq!(
+            current_lookup("async_secret"),
+            Some(serde_json::json!("pii"))
+        );
     }
 
     #[test]
     fn fork() {
         let mut ctx = EventContext::current();
         ctx.insert("original", &serde_json::json!("value")).unwrap();
+        ctx.insert_transient("secret", &serde_json::json!("pii"))
+            .unwrap();
         assert_eq!(stack_depth(), 1);
         assert_eq!(current_json(), serde_json::json!({ "original": "value" }));
 
         let mut forked = EventContext::fork();
         assert_eq!(stack_depth(), 2);
         assert_eq!(current_json(), serde_json::json!({ "original": "value" }));
+        // Transient entries are inherited by forked contexts
+        assert_eq!(current_lookup("secret"), Some(serde_json::json!("pii")));
 
         forked.insert("forked", &serde_json::json!("data")).unwrap();
+        forked
+            .insert_transient("forked_secret", &serde_json::json!("pii2"))
+            .unwrap();
         assert_eq!(
             current_json(),
             serde_json::json!({ "original": "value", "forked": "data" })
+        );
+        assert_eq!(
+            current_lookup("forked_secret"),
+            Some(serde_json::json!("pii2"))
         );
 
         drop(forked);
 
         assert_eq!(stack_depth(), 1);
         assert_eq!(current_json(), serde_json::json!({ "original": "value" }));
+        // Transient entries respect the same fork isolation as persisted ones
+        assert_eq!(current_lookup("secret"), Some(serde_json::json!("pii")));
+        assert_eq!(current_lookup("forked_secret"), None);
     }
 
     #[tokio::test]
     async fn with_event_context_spawned() {
         let mut ctx = EventContext::current();
         ctx.insert("parent", &serde_json::json!("context")).unwrap();
+        ctx.insert_transient("secret", &serde_json::json!("pii"))
+            .unwrap();
 
         let handle = tokio::spawn(
             async {
@@ -513,7 +736,10 @@ mod tests {
                     current_json(),
                     serde_json::json!({ "parent": "context", "spawned": "value" })
                 );
+                // Transient entry propagated into the spawned task
+                assert_eq!(current_lookup("secret"), Some(serde_json::json!("pii")));
                 tokio::task::yield_now().await;
+                assert_eq!(current_lookup("secret"), Some(serde_json::json!("pii")));
                 current_json()
             }
             .with_event_context(ctx.data()),
@@ -532,6 +758,8 @@ mod tests {
     async fn with_event_context_spawned_multi_thread() {
         let mut ctx = EventContext::current();
         ctx.insert("parent", &serde_json::json!("context")).unwrap();
+        ctx.insert_transient("secret", &serde_json::json!("pii"))
+            .unwrap();
 
         let handle = tokio::spawn(
             async {
@@ -545,8 +773,11 @@ mod tests {
                     current_json(),
                     serde_json::json!({ "parent": "context", "spawned": "value" })
                 );
+                // Transient entry survived tokio::spawn onto another thread
+                assert_eq!(current_lookup("secret"), Some(serde_json::json!("pii")));
                 let data = EventContext::current().data();
                 tokio::task::yield_now().with_event_context(data).await;
+                assert_eq!(current_lookup("secret"), Some(serde_json::json!("pii")));
                 current_json()
             }
             .with_event_context(ctx.data()),

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -75,7 +75,10 @@
 //! `ContextData` is serialized — in particular they are never written to the
 //! `context` column. Use transient entries for request-scoped metadata that
 //! in-process consumers need but that must not be persisted into immutable event
-//! streams, such as client IPs, user agents, or other personal data:
+//! streams, such as client IPs, user agents, or other personal data. Consumers
+//! may still store such data explicitly in mutable tables that can honor
+//! erasure requests; transient entries just guarantee the event-context
+//! machinery never writes it anywhere on its own:
 //!
 //! ```rust
 //! use es_entity::context::EventContext;
@@ -414,8 +417,11 @@ impl EventContext {
     /// of [`ContextData`]).
     ///
     /// Use this for request-scoped metadata that must not be written into
-    /// immutable event streams, such as client IP addresses, user agents, or
-    /// other personal data kept for in-process consumers only.
+    /// immutable event streams, such as client IP addresses or user agents.
+    /// In-process consumers can still read the entry via
+    /// [`ContextData::lookup`] and persist it deliberately in a mutable store
+    /// that can honor erasure requests (e.g. an audit table) — transient only
+    /// means the event-context machinery itself never serializes it.
     ///
     /// On key collision a transient entry shadows a persisted entry in
     /// [`ContextData::lookup`].

--- a/src/context/sqlx.rs
+++ b/src/context/sqlx.rs
@@ -15,7 +15,7 @@ impl<'q> sqlx::Encode<'q, db::Db> for ContextData {
         &self,
         buf: &mut db::ArgumentBuffer,
     ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Send + Sync + 'static>> {
-        let json_value = serde_json::to_value(&self.0)?;
+        let json_value = serde_json::to_value(self)?;
         <serde_json::Value as sqlx::Encode<db::Db>>::encode_by_ref(&json_value, buf)
     }
 }

--- a/tests/transient_context.rs
+++ b/tests/transient_context.rs
@@ -1,0 +1,66 @@
+mod entities;
+mod helpers;
+
+use entities::user::*;
+use es_entity::*;
+use sqlx::PgPool;
+
+#[derive(EsRepo, Debug)]
+#[es_repo(entity = "User", columns(name(ty = "String", list_for)))]
+pub struct Users {
+    pool: PgPool,
+}
+
+impl Users {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[tokio::test]
+async fn transient_context_is_not_persisted() -> anyhow::Result<()> {
+    let mut ctx = es_entity::EventContext::current();
+    ctx.insert("persisted_key", &"persisted-value").unwrap();
+    ctx.insert_transient("transient_key", &"transient-value")
+        .unwrap();
+
+    let pool = helpers::init_pool().await?;
+    let users = Users::new(pool.clone());
+
+    let id = UserId::new();
+    let new_user = NewUser::builder()
+        .id(id)
+        .name("TransientContext")
+        .build()
+        .unwrap();
+    let mut user = users.create(new_user).await?;
+
+    // Also cover the update path (`EntityEvents::push`)
+    assert!(user.update_name("TransientContextUpdated").did_execute());
+    users.update(&mut user).await?;
+
+    let contexts: Vec<Option<serde_json::Value>> =
+        sqlx::query_scalar("SELECT context FROM user_events WHERE id = $1 ORDER BY sequence")
+            .bind(uuid::Uuid::from(id))
+            .fetch_all(&pool)
+            .await?;
+
+    assert_eq!(contexts.len(), 2);
+
+    if cfg!(feature = "event-context") {
+        for context in contexts {
+            let context = context.expect("context column should be populated");
+            assert_eq!(
+                context.get("persisted_key"),
+                Some(&serde_json::json!("persisted-value"))
+            );
+            // The transient entry must never reach the database
+            assert!(context.get("transient_key").is_none());
+        }
+    } else {
+        // Without the `event-context` feature the repo does not persist contexts
+        assert!(contexts.iter().all(Option::is_none));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

[lana-bank#6740](https://github.com/GaloyMoney/lana-bank/pull/6740) records request IP + user agent on audit entries by carrying them through `es_entity::EventContext`. Side effect: every repo with `event_context = true` copies that metadata — personal data under GDPR — into the immutable `context` column of **every event** persisted during the request.

This PR adds a context entry flavor that behaves exactly like today's context data in-process but is never serialized out of the process.

## Design

- `ContextData` now holds two maps: `persisted` and `transient` (field was already private — non-breaking).
- **Serialization is the enforcement point**: the manual `Serialize` impl emits only the persisted map, in the same plain-map wire format as before. `Deserialize` reads a plain map into `persisted`. Consequences:
  - Old DB rows decode unchanged; new rows are byte-identical minus transient keys. No migration, no format versioning.
  - The sqlx `Encode` impl and the derived repo persist path (`data_for_storing()`) exclude transient entries with **zero changes** — any future serde path is safe by construction.
- `EventContext::insert_transient` — mirror of `insert`, writes to the transient map.
- `ContextData::lookup` stays **unified**: transient first, then persisted (transient shadows on collision). Consumers work unchanged regardless of which insert produced the key, making downstream cutover painless.
- Propagation (`fork` / `seed` / `WithEventContext` / per-poll re-seeding) is untouched — it clones `ContextData` wholesale, which is exactly what carries transient entries across polls/tasks/threads.

## Erasure design rule (for the docs)

- **Payload PII** (domain state, must be readable until erasure) → per-entity data key + codec (forgettable-payloads direction). Recoverable until shredded.
- **Context PII** (request metadata, observability) → transient context. Never persisted; nothing to shred later.

## Testing

- Unit: transient insert/lookup roundtrip, shadowing, serde exclusion, legacy wire-format roundtrip.
- Boundary tests extended: transient entries survive `fork`, thread `seed`, `tokio::spawn` via `WithEventContext` (current-thread + multi-thread).
- New Postgres integration test asserts at the DB level that the `context` column contains the persisted key and lacks the transient one (create + update paths).
- CI change: nextest now runs with `--features event-context` — previously the context persistence path was never integration-tested in CI. The macro codegen snapshot test is feature-aware accordingly.

## Versioning

Additive API, unchanged wire format → 0.10.x minor bump (`0.10.41`).

## Out of scope (follow-up)

- `#[es_event_context(transient(arg))]` macro syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event-context serialization and persistence paths used on every append; wire format is unchanged but behavior for PII-bearing metadata changes materially.
> 
> **Overview**
> Adds **`EventContext::insert_transient`** so request-scoped metadata (e.g. client IP, user agent) propagates like normal context in-process but **never** lands in the immutable events `context` column.
> 
> **`ContextData`** is split into persisted vs transient maps; a custom **`Serialize`** impl still emits only the persisted map (same JSON wire format as before), so sqlx encoding, repo persist via `data_for_storing()`, and existing DB rows stay compatible without migration. **`lookup`** checks transient first (shadowing persisted keys); **`Deserialize`** loads a plain map into persisted only.
> 
> Docs cover persisted vs transient context and PII/erasure guidance. CI **`nextest`** runs with **`--features event-context`**; macro snapshot test matches that default. New Postgres integration test asserts transient keys are absent from `user_events.context` on create and update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc397bdd06310ebfe64c81222d73b08163f228a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->