### PR TITLE
feat(operation): add AtomicOperation::commit_hook typed read access to registered commit hooks

### DIFF
--- a/src/operation/hooks.rs
+++ b/src/operation/hooks.rs
@@ -252,6 +252,8 @@ trait DynHook: Send {
 
     fn try_merge(&mut self, other: &mut dyn DynHook) -> bool;
 
+    fn as_any(&self) -> &dyn Any;
+
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
@@ -276,6 +278,10 @@ impl<H: CommitHook> DynHook for H {
             .downcast_mut::<H>()
             .expect("hook type mismatch");
         self.merge(other_h)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
@@ -307,6 +313,14 @@ impl CommitHooks {
         }
 
         hooks_vec.push(new_hook);
+    }
+
+    pub(super) fn get_last<H: CommitHook>(&self) -> Option<&H> {
+        self.hooks
+            .get(&TypeId::of::<H>())?
+            .last()?
+            .as_any()
+            .downcast_ref::<H>()
     }
 
     pub(super) async fn execute_pre(

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -138,6 +138,10 @@ impl<'o> AtomicOperation for DbOp<'o> {
         self.commit_hooks.as_mut().expect("no hooks").add(hook);
         Ok(())
     }
+
+    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
+        self.commit_hooks.as_ref()?.get_last::<H>()
+    }
 }
 
 /// Equivileant of [`DbOp`] just that the time is guaranteed to be cached.
@@ -191,6 +195,10 @@ impl<'o> AtomicOperation for DbOpWithTime<'o> {
     fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
         self.inner.add_commit_hook(hook)
     }
+
+    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
+        self.inner.commit_hook::<H>()
+    }
 }
 
 impl<'o> AtomicOperationWithTime for DbOpWithTime<'o> {
@@ -241,6 +249,13 @@ pub trait AtomicOperation: Send {
     /// Returns Ok(()) if the hook was registered, Err(hook) if hooks are not supported.
     fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
         Err(hook)
+    }
+
+    /// Typed shared access to the currently-accumulating commit hook of type `H`,
+    /// if this operation supports commit hooks and one is registered.
+    /// Returns the hook a subsequent `add_commit_hook::<H>` call would merge into.
+    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
+        None
     }
 }
 

--- a/src/operation/with_time.rs
+++ b/src/operation/with_time.rs
@@ -71,4 +71,8 @@ impl<'a, Op: AtomicOperation + ?Sized> AtomicOperation for OpWithTime<'a, Op> {
     fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
         self.inner.add_commit_hook(hook)
     }
+
+    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
+        self.inner.commit_hook::<H>()
+    }
 }

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1,7 +1,7 @@
 mod helpers;
 
 use es_entity::operation::{
-    AtomicOperation, DbOp,
+    AtomicOperation, DbOp, OpWithTime,
     hooks::{CommitHook, HookOperation, PreCommitRet},
 };
 use std::sync::{Arc, Mutex};
@@ -162,6 +162,186 @@ async fn hooks_execute_separately_when_not_merged() -> anyhow::Result<()> {
 
     assert_eq!(*pre_count.lock().unwrap(), 3);
     assert_eq!(*post_count.lock().unwrap(), 3);
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct MergingGetterHook {
+    payloads: Vec<String>,
+}
+
+impl CommitHook for MergingGetterHook {
+    fn merge(&mut self, other: &mut Self) -> bool {
+        self.payloads.append(&mut other.payloads);
+        true
+    }
+}
+
+#[derive(Debug)]
+struct NonMergingGetterHook {
+    label: &'static str,
+}
+
+impl CommitHook for NonMergingGetterHook {}
+
+#[tokio::test]
+async fn commit_hook_returns_registered_hook() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    assert!(op.commit_hook::<MergingGetterHook>().is_none());
+
+    op.add_commit_hook(MergingGetterHook {
+        payloads: vec!["e1".into()],
+    })
+    .unwrap();
+
+    let hook = op
+        .commit_hook::<MergingGetterHook>()
+        .expect("hook should be registered");
+    assert_eq!(hook.payloads, vec!["e1"]);
+
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn commit_hook_returns_none_for_different_type() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    op.add_commit_hook(MergingGetterHook {
+        payloads: vec!["e1".into()],
+    })
+    .unwrap();
+
+    assert!(op.commit_hook::<NonMergingGetterHook>().is_none());
+
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn commit_hook_sees_merged_contents() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    op.add_commit_hook(MergingGetterHook {
+        payloads: vec!["e1".into()],
+    })
+    .unwrap();
+    op.add_commit_hook(MergingGetterHook {
+        payloads: vec!["e2".into(), "e3".into()],
+    })
+    .unwrap();
+
+    let hook = op
+        .commit_hook::<MergingGetterHook>()
+        .expect("hook should be registered");
+    assert_eq!(hook.payloads, vec!["e1", "e2", "e3"]);
+
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn commit_hook_returns_last_non_merging_hook() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    op.add_commit_hook(NonMergingGetterHook { label: "first" })
+        .unwrap();
+    op.add_commit_hook(NonMergingGetterHook { label: "second" })
+        .unwrap();
+
+    let hook = op
+        .commit_hook::<NonMergingGetterHook>()
+        .expect("hook should be registered");
+    assert_eq!(hook.label, "second");
+
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn commit_hook_default_returns_none_for_bare_transaction() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let tx = pool.begin().await?;
+
+    assert!(tx.commit_hook::<MergingGetterHook>().is_none());
+
+    tx.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn commit_hook_delegates_through_time_wrappers() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let op = DbOp::init(&pool).await?;
+    let mut op = op.with_db_time().await?;
+
+    op.add_commit_hook(MergingGetterHook {
+        payloads: vec!["e1".into()],
+    })
+    .unwrap();
+
+    let hook = op
+        .commit_hook::<MergingGetterHook>()
+        .expect("DbOpWithTime should delegate to inner op");
+    assert_eq!(hook.payloads, vec!["e1"]);
+
+    let wrapped = OpWithTime::cached_or_clock_time(&mut op);
+    let hook = wrapped
+        .commit_hook::<MergingGetterHook>()
+        .expect("OpWithTime should delegate to wrapped op");
+    assert_eq!(hook.payloads, vec!["e1"]);
+    drop(wrapped);
+
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct SiblingProbeHook {
+    saw_sibling: Arc<Mutex<Option<bool>>>,
+}
+
+impl CommitHook for SiblingProbeHook {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        *self.saw_sibling.lock().unwrap() = Some(op.commit_hook::<MergingGetterHook>().is_some());
+        PreCommitRet::ok(self, op)
+    }
+}
+
+#[tokio::test]
+async fn commit_hook_not_visible_inside_pre_commit() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let saw_sibling = Arc::new(Mutex::new(None));
+
+    op.add_commit_hook(MergingGetterHook {
+        payloads: vec!["e1".into()],
+    })
+    .unwrap();
+    op.add_commit_hook(SiblingProbeHook {
+        saw_sibling: saw_sibling.clone(),
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    assert_eq!(*saw_sibling.lock().unwrap(), Some(false));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Additive, **non-breaking** (minor release) method giving typed **SHARED (read-only)** access to the currently-accumulating registered commit hook of concrete type `H`:

```rust
fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> { None }
```

Implements the obix-dev handoff **`handoff-es-entity-commit-hook-getter.md`** — lets downstream callers (obix) read hook-buffered state before commit. No public API removed or changed.

## Surface

- `DynHook::as_any` (crate-private, alongside existing `as_any_mut`)
- `CommitHooks::get_last::<H>()` — `TypeId::of::<H>()` → `.last()` → `downcast_ref`; `last()` because `add()` merges into the last vec element (the current merge target)
- Defaulted `AtomicOperation::commit_hook` (returns `None`) + overrides: `DbOp` (via `commit_hooks.as_ref()?` — correctly `None` during/after commit since `commit_hooks` is `.take()`n at commit start), `DbOpWithTime` and `OpWithTime` delegate to the inner op
- `HookOperation` and `sqlx::Transaction` **deliberately keep the `None` default** — hooks must not read sibling hooks (cross-type execution order is nondeterministic), and bare transactions have no hook storage

## Tests

7 new tests in `tests/hooks.rs`: registered hook → `Some`; different type → `None`; merging double-add → merged contents in order; non-merging double-add → last; bare `sqlx::Transaction` → `None`; `DbOpWithTime`/`OpWithTime` delegation; `commit_hook` inside a hook's `pre_commit` → `None`.

CI-relevant checks pass locally: `nix flake check` (fmt, clippy, deny, audit) and `nix run .#nextest` (178/178 incl. the 7 new; doc tests green).

## Out of scope

obix adoption (`Outbox::{cursor, new_events, map_new, peek_new}`) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive trait API with safe defaults; behavior is scoped to hook introspection and covered by new tests, with no changes to commit or merge execution paths.
> 
> **Overview**
> Adds a **defaulted** `AtomicOperation::commit_hook::<H>()` that returns read-only `Option<&H>` for the in-flight commit hook of type `H`—the same instance a later `add_commit_hook::<H>` would merge into.
> 
> Hook storage gains immutable downcasting (`DynHook::as_any`, `CommitHooks::get_last`) so `DbOp` can resolve the last hook per type; `DbOpWithTime` and `OpWithTime` delegate. **`HookOperation` and bare `sqlx::Transaction` keep the default `None`** so hooks cannot observe sibling hooks during `pre_commit` (order is nondeterministic).
> 
> Seven integration tests cover registration, type mismatch, merged vs last-non-merging behavior, wrapper delegation, and the pre-commit isolation rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87746b7e113927e14a941c43afa14fdc9bb471c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->