### PR TITLE
chore(release): prepare 0.11.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.10.41"
+version = "0.11.0-dev"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.10.41"
+version = "0.11.0-dev"
 dependencies = [
  "convert_case",
  "darling 0.23.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "es-entity"
 description = "Event Sourcing Entity Framework"
 repository = "https://github.com/GaloyMoney/es-entity"
 documentation = "https://docs.rs/es-entity"
-version = "0.10.41"
+version = "0.11.0-dev"
 edition = "2024"
 license = "Apache-2.0"
 categories = ["data-structures", "database"]
@@ -62,7 +62,7 @@ members = [
 
 [workspace.dependencies]
 
-es-entity-macros = { path = "es-entity-macros", version = "0.10.41" }
+es-entity-macros = { path = "es-entity-macros", version = "0.11.0-dev" }
 
 anyhow = "1.0"
 async-graphql = { version = "8.0.0-rc.5", default-features = false }

--- a/es-entity-macros/Cargo.toml
+++ b/es-entity-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "es-entity-macros"
 description = "Proc macros for es-entity"
 repository = "https://github.com/GaloyMoney/cala"
-version = "0.10.41"
+version = "0.11.0-dev"
 edition = "2024"
 license = "Apache-2.0"
 categories = ["data-structures", "database"]


### PR DESCRIPTION
## Summary
- prepare `es-entity` for the PR #94 minor release lane
- set `es-entity` and `es-entity-macros` to `0.11.0-dev`
- update the workspace lockfile entries for those local crates

## Context
PR #94 is already merged into `main` and crates.io latest is `0.10.41`. This change prepares the next release as `0.11.0` instead of another `0.10.x` patch release.

## Verification
- `cargo check --workspace`
- `git diff --check`
- migration scope checked: no migration files changed or added in this version-only prep
