### PR TITLE
feat: annotate SQL statements with OTel trace context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,12 +503,15 @@ version = "0.11.2-dev"
 dependencies = [
  "anyhow",
  "async-graphql",
+ "async-stream",
  "async-trait",
  "base64",
  "chrono",
  "derive_builder",
  "es-entity-macros",
  "futures",
+ "futures-core",
+ "futures-util",
  "im",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -500,6 +525,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1053,6 +1079,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1135,15 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2227,6 +2271,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-opentelemetry"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,9 +2301,16 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ instrument = ["es-entity-macros/instrument", "dep:tracing"]
 [dependencies]
 es-entity-macros = { workspace = true }
 
+async-stream = { workspace = true }
+futures-core = { workspace = true }
+futures-util = { workspace = true }
 base64 = { workspace = true, optional = true }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
@@ -53,6 +56,7 @@ tokio = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [workspace]
 resolver = "2"
@@ -65,6 +69,7 @@ members = [
 es-entity-macros = { path = "es-entity-macros", version = "0.11.2-dev" }
 
 anyhow = "1.0"
+async-stream = "0.3"
 async-graphql = { version = "8.0.0-rc.5", default-features = false }
 async-trait = "0.1"
 base64 = { version = "0.22" }
@@ -81,8 +86,11 @@ uuid = { version = "1.23", features = ["serde", "v7"] }
 im = { version = "15.1", features = ["serde"] }
 pin-project = "1.1"
 tracing = { version = "0.1.41", default-features = false }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-opentelemetry = { version = "0.33.0", default-features = false }
 opentelemetry = { version = "0.32.0", default-features = false }
 opentelemetry_sdk = { version = "0.32.0", features = ["rt-tokio"] }
 futures = "0.3"
+futures-core = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 parking_lot = "0.12"

--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -140,7 +140,7 @@ impl ToTokens for CreateAllFn<'_> {
                     sqlx::query(#query)
                        .bind(now)
                        #(#bindings)*
-                       .fetch_all(op.as_executor())
+                       .fetch_all(es_entity::annotate_executor(op.as_executor()))
                        .await
                        .map_err(|e| match &e {
                            sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
@@ -256,7 +256,7 @@ mod tests {
                         .bind(now)
                         .bind(id_collection)
                         .bind(name_collection)
-                        .fetch_all(op.as_executor())
+                        .fetch_all(es_entity::annotate_executor(op.as_executor()))
                         .await
                         .map_err(|e| match &e {
                             sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -155,7 +155,7 @@ impl ToTokens for CreateFn<'_> {
                          #(#args)*
                          op.maybe_now()
                     )
-                    .execute(op.as_executor())
+                    .execute(es_entity::annotate_executor(op.as_executor()))
                     .await
                     .map_err(|e| match &e {
                         sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
@@ -262,7 +262,7 @@ mod tests {
                         id as &EntityId,
                         op.maybe_now()
                     )
-                    .execute(op.as_executor())
+                    .execute(es_entity::annotate_executor(op.as_executor()))
                     .await
                     .map_err(|e| match &e {
                         sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
@@ -365,7 +365,7 @@ mod tests {
                         name as &String,
                         op.maybe_now()
                     )
-                    .execute(op.as_executor())
+                    .execute(es_entity::annotate_executor(op.as_executor()))
                     .await
                     .map_err(|e| match &e {
                         sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {

--- a/es-entity-macros/src/repo/delete_fn.rs
+++ b/es-entity-macros/src/repo/delete_fn.rs
@@ -108,7 +108,7 @@ impl ToTokens for DeleteFn<'_> {
                     #forget_query,
                     id as &#id_type
                 )
-                .execute(op.as_executor())
+                .execute(es_entity::annotate_executor(op.as_executor()))
                 .await?;
             }
         } else {
@@ -143,7 +143,7 @@ impl ToTokens for DeleteFn<'_> {
                         #query,
                         #(#args),*
                     )
-                        .execute(op.as_executor())
+                        .execute(es_entity::annotate_executor(op.as_executor()))
                         .await
                         .map_err(|e| match &e {
                             sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
@@ -241,7 +241,7 @@ mod tests {
                         "UPDATE entities SET deleted = TRUE WHERE id = $1",
                         id as &EntityId
                     )
-                        .execute(op.as_executor())
+                        .execute(es_entity::annotate_executor(op.as_executor()))
                         .await
                         .map_err(|e| match &e {
                             sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
@@ -337,7 +337,7 @@ mod tests {
                         id as &EntityId,
                         name as &String
                     )
-                        .execute(op.as_executor())
+                        .execute(es_entity::annotate_executor(op.as_executor()))
                         .await
                         .map_err(|e| match &e {
                             sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
@@ -425,7 +425,7 @@ mod tests {
                         "UPDATE entities SET deleted = TRUE WHERE id = $1",
                         id as &EntityId
                     )
-                        .execute(op.as_executor())
+                        .execute(es_entity::annotate_executor(op.as_executor()))
                         .await
                         .map_err(|e| match &e {
                             sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
@@ -442,7 +442,7 @@ mod tests {
                         "DELETE FROM entities_forgettable_payloads WHERE entity_id = $1",
                         id as &EntityId
                     )
-                    .execute(op.as_executor())
+                    .execute(es_entity::annotate_executor(op.as_executor()))
                     .await?;
 
                     let new_events = {

--- a/es-entity-macros/src/repo/forget_fn.rs
+++ b/es-entity-macros/src/repo/forget_fn.rs
@@ -62,7 +62,7 @@ impl ToTokens for ForgetFn<'_> {
                     #columns_query,
                     id as &#id_type
                 )
-                .execute(op.as_executor())
+                .execute(es_entity::annotate_executor(op.as_executor()))
                 .await?;
             }
         };
@@ -125,7 +125,7 @@ impl ToTokens for ForgetFn<'_> {
                         #query,
                         id as &#id_type
                     )
-                    .execute(op.as_executor())
+                    .execute(es_entity::annotate_executor(op.as_executor()))
                     .await?;
                     #forget_columns
                 }

--- a/es-entity-macros/src/repo/persist_events_batch_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_batch_fn.rs
@@ -103,7 +103,7 @@ impl ToTokens for PersistEventsBatchFn<'_> {
                         .bind(&payload_ids)
                         .bind(&payload_sequences)
                         .bind(&payload_values)
-                        .execute(op.as_executor())
+                        .execute(es_entity::annotate_executor(op.as_executor()))
                         .await?;
                 }
             }
@@ -156,7 +156,7 @@ impl ToTokens for PersistEventsBatchFn<'_> {
                         .bind(&all_types)
                         .bind(&all_serialized)
                         #ctx_bind
-                        .fetch_all(op.as_executor())
+                        .fetch_all(es_entity::annotate_executor(op.as_executor()))
                         .await?;
 
                 #forgettable_insert
@@ -243,7 +243,7 @@ mod tests {
                         } else {
                              Some(all_contexts)
                         })
-                        .fetch_all(op.as_executor())
+                        .fetch_all(es_entity::annotate_executor(op.as_executor()))
                         .await?;
 
                 let recorded_at = rows[0].try_get("recorded_at").expect("no recorded at");
@@ -315,7 +315,7 @@ mod tests {
                         .bind(&all_sequences)
                         .bind(&all_types)
                         .bind(&all_serialized)
-                        .fetch_all(op.as_executor())
+                        .fetch_all(es_entity::annotate_executor(op.as_executor()))
                         .await?;
 
                 let recorded_at = rows[0].try_get("recorded_at").expect("no recorded at");

--- a/es-entity-macros/src/repo/persist_events_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_fn.rs
@@ -76,7 +76,7 @@ impl ToTokens for PersistEventsFn<'_> {
                         &payload_sequences,
                         &payload_values,
                     )
-                    .execute(op.as_executor())
+                    .execute(es_entity::annotate_executor(op.as_executor()))
                     .await?;
                 }
             }
@@ -122,7 +122,7 @@ impl ToTokens for PersistEventsFn<'_> {
                         &events_types,
                         &serialized_events,
                         #ctx_arg
-                    ).fetch_all(op.as_executor()).await?;
+                    ).fetch_all(es_entity::annotate_executor(op.as_executor())).await?;
 
                 let recorded_at = rows[0].recorded_at;
                 let n_events = events.mark_new_events_persisted_at(recorded_at);
@@ -189,7 +189,7 @@ mod tests {
                         &events_types,
                         &serialized_events,
                         contexts.as_deref() as Option<&[es_entity::ContextData]>,
-                    ).fetch_all(op.as_executor()).await?;
+                    ).fetch_all(es_entity::annotate_executor(op.as_executor())).await?;
 
                 let recorded_at = rows[0].recorded_at;
                 let n_events = events.mark_new_events_persisted_at(recorded_at);
@@ -251,7 +251,7 @@ mod tests {
                         offset as i32,
                         &events_types,
                         &serialized_events,
-                    ).fetch_all(op.as_executor()).await?;
+                    ).fetch_all(es_entity::annotate_executor(op.as_executor())).await?;
 
                 let recorded_at = rows[0].recorded_at;
                 let n_events = events.mark_new_events_persisted_at(recorded_at);

--- a/es-entity-macros/src/repo/populate_nested.rs
+++ b/es-entity-macros/src/repo/populate_nested.rs
@@ -98,7 +98,7 @@ impl ToTokens for PopulateNested<'_> {
                             #include_deleted_query,
                             parent_ids.as_slice() as &[&#ty],
                             <#repo_types_mod::Repo__Event as EsEvent>::event_context(),
-                        ).fetch_all(op.as_executor()).await?
+                        ).fetch_all(es_entity::annotate_executor(op.as_executor())).await?
                     };
                     let n = rows.len();
                     let (mut res, _) = es_entity::EntityEvents::load_n::<<Self as EsRepo>::Entity>(rows.into_iter(), n)?;
@@ -132,7 +132,7 @@ impl ToTokens for PopulateNested<'_> {
                             #query,
                             parent_ids.as_slice() as &[&#ty],
                             <#repo_types_mod::Repo__Event as EsEvent>::event_context(),
-                        ).fetch_all(op.as_executor()).await?
+                        ).fetch_all(es_entity::annotate_executor(op.as_executor())).await?
                     };
                     let n = rows.len();
                     let (mut res, _) = es_entity::EntityEvents::load_n::<<Self as EsRepo>::Entity>(rows.into_iter(), n)?;
@@ -175,13 +175,13 @@ impl ToTokens for PopulateNested<'_> {
                         #payload_delete_query,
                         parent_id as &#ty,
                     )
-                    .execute(op.as_executor())
+                    .execute(es_entity::annotate_executor(op.as_executor()))
                     .await?;
                     sqlx::query!(
                         #cascade_query,
                         parent_id as &#ty,
                     )
-                    .execute(op.as_executor())
+                    .execute(es_entity::annotate_executor(op.as_executor()))
                     .await?;
                 }
             } else {
@@ -194,7 +194,7 @@ impl ToTokens for PopulateNested<'_> {
                         #cascade_query,
                         parent_id as &#ty,
                     )
-                    .execute(op.as_executor())
+                    .execute(es_entity::annotate_executor(op.as_executor()))
                     .await?;
                 }
             };

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -81,7 +81,7 @@ impl ToTokens for UpdateAllFn<'_> {
                 Some(quote! {
                     sqlx::query(#query)
                         #(#bind_tokens)*
-                        .execute(op.as_executor())
+                        .execute(es_entity::annotate_executor(op.as_executor()))
                         .await
                         .map_err(|e| match &e {
                             sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
@@ -285,7 +285,7 @@ mod tests {
                     sqlx::query("UPDATE entities SET name = unnested.name FROM UNNEST($1, $2) AS unnested(id, name) WHERE entities.id = unnested.id")
                         .bind(id_collection)
                         .bind(name_collection)
-                        .execute(op.as_executor())
+                        .execute(es_entity::annotate_executor(op.as_executor()))
                         .await
                         .map_err(|e| match &e {
                             sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -60,7 +60,7 @@ impl ToTokens for UpdateFn<'_> {
                 #query,
                 #(#args),*
             )
-                .execute(op.as_executor())
+                .execute(es_entity::annotate_executor(op.as_executor()))
                 .await
                 .map_err(|e| match &e {
                     sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
@@ -245,7 +245,7 @@ mod tests {
                         id as &EntityId,
                         name as &String
                     )
-                        .execute(op.as_executor())
+                        .execute(es_entity::annotate_executor(op.as_executor()))
                         .await
                         .map_err(|e| match &e {
                             sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {

--- a/src/annotating_executor.rs
+++ b/src/annotating_executor.rs
@@ -1,0 +1,130 @@
+//! Executor wrapper that annotates SQL statements with the current trace
+//! context.
+//!
+//! [`annotate_executor`] wraps any Postgres [`sqlx::Executor`] so that every
+//! statement executed through it carries the active span's `traceparent` as a
+//! SQL comment (see [`crate::sql_commenter`]). This is what allows statements
+//! observed server-side (`pg_stat_statements`, Postgres logs) to be matched to
+//! distributed traces.
+//!
+//! The wrapper rewrites the statement *text* only; bind arguments and row
+//! mapping flow through unchanged, so it is transparent to `sqlx::query!`
+//! macro-generated queries as well as dynamically built ones.
+//!
+//! When there is no active span context the original query is passed through
+//! untouched and the wrapper adds no overhead.
+
+use std::borrow::Cow;
+
+use async_stream::try_stream;
+use futures_core::stream::BoxStream;
+use futures_util::{TryStreamExt, future::BoxFuture};
+use sqlx::{Database, Describe, Error, Execute, Executor};
+
+use crate::{db, sql_commenter};
+
+/// An [`sqlx::Executor`] wrapper produced by [`annotate_executor`].
+#[derive(Debug)]
+pub struct TraceAnnotatingExecutor<E> {
+    inner: E,
+}
+
+/// Wraps `executor` so every statement executed through it is annotated with
+/// the current span's `traceparent` SQL comment.
+pub fn annotate_executor<'c, E>(inner: E) -> TraceAnnotatingExecutor<E>
+where
+    E: Executor<'c, Database = db::Db>,
+{
+    TraceAnnotatingExecutor { inner }
+}
+
+/// Returns the annotated statement text, or `None` when there is no active
+/// span context (in which case the query should be delegated untouched).
+fn annotated_sql<'q>(query: &impl Execute<'q, db::Db>) -> Option<String> {
+    match sql_commenter::annotate_sql(query.sql()) {
+        Cow::Borrowed(_) => None,
+        Cow::Owned(sql) => Some(sql),
+    }
+}
+
+/// Rebuilds a query with annotated SQL, moving out its bind arguments.
+///
+/// The trace context makes each statement's text unique, so the returned query
+/// is marked non-persistent to avoid thrashing sqlx's per-connection prepared
+/// statement cache.
+fn rebuild_annotated<'q>(
+    annotated: &str,
+    mut query: impl Execute<'q, db::Db>,
+) -> Result<sqlx::query::Query<'_, db::Db, sqlx::postgres::PgArguments>, Error> {
+    let args = query
+        .take_arguments()
+        .map_err(Error::Encode)?
+        .unwrap_or_default();
+    Ok(sqlx::query_with::<db::Db, _>(annotated, args).persistent(false))
+}
+
+impl<'c, E> Executor<'c> for TraceAnnotatingExecutor<E>
+where
+    E: Executor<'c, Database = db::Db> + 'c,
+{
+    type Database = db::Db;
+
+    fn fetch_many<'e, 'q: 'e, Q>(
+        self,
+        query: Q,
+    ) -> BoxStream<'e, Result<sqlx::Either<<db::Db as Database>::QueryResult, db::Row>, Error>>
+    where
+        'c: 'e,
+        Q: 'q + Execute<'q, db::Db>,
+    {
+        let Some(annotated) = annotated_sql(&query) else {
+            return self.inner.fetch_many(query);
+        };
+        Box::pin(try_stream! {
+            let q = rebuild_annotated(annotated.as_str(), query)?;
+            let mut stream = self.inner.fetch_many(q);
+            while let Some(step) = stream.try_next().await? {
+                yield step;
+            }
+        })
+    }
+
+    fn fetch_optional<'e, 'q: 'e, Q>(
+        self,
+        query: Q,
+    ) -> BoxFuture<'e, Result<Option<db::Row>, Error>>
+    where
+        'c: 'e,
+        Q: 'q + Execute<'q, db::Db>,
+    {
+        let Some(annotated) = annotated_sql(&query) else {
+            return self.inner.fetch_optional(query);
+        };
+        Box::pin(async move {
+            let q = rebuild_annotated(annotated.as_str(), query)?;
+            self.inner.fetch_optional(q).await
+        })
+    }
+
+    fn prepare_with<'e, 'q: 'e>(
+        self,
+        sql: &'q str,
+        parameters: &'e [<db::Db as Database>::TypeInfo],
+    ) -> BoxFuture<'e, Result<<db::Db as Database>::Statement<'q>, Error>>
+    where
+        'c: 'e,
+    {
+        // A prepared Statement<'q> may borrow `sql`; a locally allocated
+        // annotated string could not satisfy the 'q lifetime, so preparation
+        // is delegated unannotated.
+        self.inner.prepare_with(sql, parameters)
+    }
+
+    fn describe<'e, 'q: 'e>(self, sql: &'q str) -> BoxFuture<'e, Result<Describe<db::Db>, Error>>
+    where
+        'c: 'e,
+    {
+        // Not an execution path; delegated unannotated.
+        self.inner.describe(sql)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 #![cfg_attr(feature = "fail-on-warnings", deny(clippy::all))]
 #![forbid(unsafe_code)]
 
+mod annotating_executor;
 pub mod clock;
 pub mod context;
 pub mod db;
@@ -36,6 +37,7 @@ pub mod one_time_executor;
 pub mod operation;
 pub mod pagination;
 pub mod query;
+pub mod sql_commenter;
 pub mod traits;
 
 pub mod prelude {
@@ -51,6 +53,8 @@ pub mod prelude {
     pub use schemars;
 }
 
+#[doc(inline)]
+pub use annotating_executor::{TraceAnnotatingExecutor, annotate_executor};
 #[doc(inline)]
 pub use context::*;
 #[doc(inline)]

--- a/src/one_time_executor.rs
+++ b/src/one_time_executor.rs
@@ -23,7 +23,7 @@ use crate::{db, operation::AtomicOperation};
 /// ```
 pub struct OneTimeExecutor<'c, E>
 where
-    E: sqlx::Executor<'c, Database = db::Db>,
+    E: sqlx::Executor<'c, Database = db::Db> + 'c,
 {
     now: Option<chrono::DateTime<chrono::Utc>>,
     executor: E,
@@ -32,7 +32,7 @@ where
 
 impl<'c, E> OneTimeExecutor<'c, E>
 where
-    E: sqlx::Executor<'c, Database = db::Db>,
+    E: sqlx::Executor<'c, Database = db::Db> + 'c,
 {
     fn new(executor: E, now: Option<chrono::DateTime<chrono::Utc>>) -> Self {
         OneTimeExecutor {
@@ -56,7 +56,9 @@ where
         O: Send + Unpin,
         A: 'q + Send + sqlx::IntoArguments<'q, db::Db>,
     {
-        query.fetch_one(self.executor).await
+        query
+            .fetch_one(crate::annotate_executor(self.executor))
+            .await
     }
 
     /// Proxy call to `query.fetch_all` but guarantees the inner executor will only be used once.
@@ -69,7 +71,9 @@ where
         O: Send + Unpin,
         A: 'q + Send + sqlx::IntoArguments<'q, sqlx::Postgres>,
     {
-        query.fetch_all(self.executor).await
+        query
+            .fetch_all(crate::annotate_executor(self.executor))
+            .await
     }
 
     /// Proxy call to `query.fetch_optional` but guarantees the inner executor will only be used once.
@@ -82,7 +86,9 @@ where
         O: Send + Unpin,
         A: 'q + Send + sqlx::IntoArguments<'q, sqlx::Postgres>,
     {
-        query.fetch_optional(self.executor).await
+        query
+            .fetch_optional(crate::annotate_executor(self.executor))
+            .await
     }
 }
 

--- a/src/sql_commenter.rs
+++ b/src/sql_commenter.rs
@@ -1,0 +1,96 @@
+//! Correlate SQL statements with OpenTelemetry traces.
+//!
+//! [`annotate_sql`] appends a [sqlcommenter](https://google.github.io/sqlcommenter)-style
+//! `traceparent` comment carrying the currently active span's trace context to
+//! a SQL statement, e.g.
+//!
+//! ```text
+//! SELECT * FROM users WHERE id = $1 /*traceparent='00-<32-hex>-<16-hex>-01'*/
+//! ```
+//!
+//! The comment survives Postgres query normalization and is retained in the
+//! representative query text stored by `pg_stat_statements`, and appears in
+//! Postgres logs (slow query log, `auto_explain`, lock waits). A statement
+//! observed server-side can therefore be matched back to a distributed trace:
+//!
+//! ```sql
+//! SELECT * FROM pg_stat_statements WHERE query LIKE '%<trace_id>%';
+//! ```
+//!
+//! Annotation only happens when there is a valid span context (i.e. tracing
+//! with an OpenTelemetry layer is initialized and a span is active) and the
+//! `tracing-context` feature is enabled. Otherwise [`annotate_sql`] is a
+//! zero-cost pass-through.
+
+use std::borrow::Cow;
+
+/// W3C `traceparent` of the currently active span, e.g.
+/// `00-<32-hex-trace-id>-<16-hex-span-id>-01`.
+///
+/// Returns `None` when there is no valid span context (outside any span, or
+/// tracing/OTEL not initialized) or the `tracing-context` feature is disabled.
+#[cfg(feature = "tracing-context")]
+pub fn current_traceparent() -> Option<String> {
+    crate::context::TracingContext::current().map(|ctx| ctx.traceparent)
+}
+
+/// W3C `traceparent` of the currently active span. Always `None` without the
+/// `tracing-context` feature.
+#[cfg(not(feature = "tracing-context"))]
+pub fn current_traceparent() -> Option<String> {
+    None
+}
+
+/// Appends the current span's `traceparent` as a SQL comment to `sql`.
+///
+/// Returns [`Cow::Borrowed`] (no allocation) when there is no active span
+/// context; callers can use this to skip any annotation-dependent work.
+pub fn annotate_sql(sql: &str) -> Cow<'_, str> {
+    match current_traceparent() {
+        Some(traceparent) => Cow::Owned(format!("{sql} /*traceparent='{traceparent}'*/")),
+        None => Cow::Borrowed(sql),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "tracing-context")]
+    #[test]
+    fn no_span_context_is_noop() {
+        assert!(current_traceparent().is_none());
+        assert_eq!(annotate_sql("SELECT 1"), "SELECT 1");
+    }
+
+    #[cfg(feature = "tracing-context")]
+    #[test]
+    fn annotates_within_active_span() {
+        use opentelemetry::trace::TracerProvider as _;
+        use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+        let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+            .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn)
+            .build();
+        let tracer = provider.tracer("sql-commenter-test");
+        tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer))
+            .init();
+
+        let span = tracing::info_span!("test_span");
+        let _guard = span.enter();
+
+        let tp = current_traceparent().expect("should have traceparent in span");
+        let parts: Vec<&str> = tp.split('-').collect();
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0], "00");
+        assert_eq!(parts[1].len(), 32);
+        assert_eq!(parts[2].len(), 16);
+        assert_eq!(parts[3], "01");
+
+        assert_eq!(
+            annotate_sql("SELECT 1"),
+            format!("SELECT 1 /*traceparent='{tp}'*/")
+        );
+    }
+}

--- a/tests/trace_annotation.rs
+++ b/tests/trace_annotation.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "tracing-context")]
+//! End-to-end proof that statements executed through [`annotate_executor`]
+//! carry the active span's `traceparent` comment all the way to Postgres.
+
+mod helpers;
+
+use es_entity::*;
+use helpers::init_pool;
+
+#[tokio::test]
+async fn trace_context_reaches_postgres() -> anyhow::Result<()> {
+    use opentelemetry::trace::TracerProvider as _;
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn)
+        .build();
+    let tracer = provider.tracer("trace-annotation-test");
+    let _ = tracing_subscriber::registry()
+        .with(tracing_opentelemetry::layer().with_tracer(tracer))
+        .try_init();
+
+    let pool = init_pool().await?;
+
+    let span = tracing::info_span!("trace_annotation_test");
+
+    // Instrument the future rather than holding a `span.enter()` guard across
+    // awaits: `Entered` is thread-local and must not migrate between worker
+    // threads on the multi-threaded runtime.
+    use tracing::Instrument as _;
+    async {
+        let traceparent = sql_commenter::current_traceparent().expect("valid span context");
+        let trace_id = traceparent.split('-').nth(1).unwrap().to_string();
+
+        // Both futures are polled on this task (where the span is the current
+        // context), so the slow query is executed with the span active.
+        let slow = sqlx::query("SELECT pg_sleep(2)").execute(annotate_executor(&pool));
+        let poll = async {
+            for _ in 0..100 {
+                let row: Option<(String,)> = sqlx::query_as(
+                    "SELECT query FROM pg_stat_activity \
+                     WHERE query LIKE $1 AND pid <> pg_backend_pid()",
+                )
+                .bind(format!("%traceparent='00-{trace_id}-%"))
+                .fetch_optional(&pool)
+                .await?;
+                if row.is_some() {
+                    return Ok::<bool, sqlx::Error>(true);
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            Ok(false)
+        };
+
+        let (slow_result, found) = tokio::join!(slow, poll);
+        slow_result?;
+        assert!(
+            found?,
+            "annotated statement should be visible in pg_stat_activity"
+        );
+        Ok(())
+    }
+    .instrument(span)
+    .await
+}


### PR DESCRIPTION
## Summary

Adds opt-in [sqlcommenter](https://google.github.io/sqlcommenter)-style trace
correlation: every statement executed through es-entity carries the active
span's W3C `traceparent` as a trailing SQL comment:

```sql
INSERT INTO user_events (...) VALUES (...) /*traceparent='00-<32-hex>-<16-hex>-01'*/
```

The comment survives Postgres query normalization and is retained in
`pg_stat_statements`' representative query text and in server logs (slow query
log, `auto_explain`, lock waits), so a statement observed **server-side** can
be matched back to a distributed trace:

```sql
SELECT * FROM pg_stat_statements WHERE query LIKE '%<trace_id>%';
```

## Design

The constraint that shaped this: `sqlx::query!` macros bake SQL literals at
compile time, so runtime trace context can't be appended to the SQL string in
generated code without giving up compile-time verification.

Instead, annotation happens in a new **`TraceAnnotatingExecutor`**
(`src/annotating_executor.rs`), an `sqlx::Executor` wrapper that intercepts
`fetch_many` / `fetch_optional`, rewrites only the statement *text* via
`Execute::sql()` + `take_arguments()`, and delegates. Bind arguments and row
mapping flow through unchanged — so this is transparent to macro-generated and
dynamic queries alike, and **no compile-time checking is lost**.

The wrapper is applied centrally:

- `OneTimeExecutor::{fetch_one, fetch_all, fetch_optional}` — covers **all
  reads** (`es_query!`, `find_by_*`, `list_by_*`, ...)
- generated write paths (`persist_events*`, `create*`, `update*`, `delete`,
  `populate_nested`) via `es_entity::annotate_executor(op.as_executor())`

`sql_commenter::current_traceparent()` extracts the context from the current
span via `tracing-opentelemetry` (existing `tracing-context` feature). Without
the feature, or without an active span, `annotate_sql` returns `Cow::Borrowed`
and the wrapper **passes the original query through untouched** — zero
overhead when not in use.

## Notes / trade-offs

- Annotated statements are executed with `persistent(false)`: the unique
  comment makes each statement text distinct, which would otherwise thrash
  sqlx's per-connection prepared statement cache. This means a server-side
  parse per annotated statement (sub-millisecond for typical entity SQL).
- `prepare_with` / `describe` are delegated unannotated (a prepared
  `Statement<'q>` may borrow the SQL; a locally-allocated annotated string
  can't satisfy that lifetime). Neither is an execution path used by generated
  code.
- Live, per-connection correlation via `application_name` is complementary and
  belongs to the application side (connection pool setup), not this crate.

## Test plan

- New integration test `tests/trace_annotation.rs`: proves the active span's
  traceparent is visible in `pg_stat_activity` while a query is in flight.
- Full `cargo test --all-features` suite passes against Postgres (all existing
  integration tests exercise the wrapped executor paths, proving transparency).
- 85 macro codegen token tests updated and passing.
- `cargo clippy --all-features` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every generated persistence path and changes execution semantics (non-persistent queries, extra parse per annotated statement); behavior is gated on tracing-context but still affects hot DB infrastructure.
> 
> **Overview**
> Adds **sqlcommenter-style trace correlation** so Postgres can tie statements back to distributed traces. When `tracing-context` is on and a span is active, SQL gets a trailing `/*traceparent='...'*/` comment via new `sql_commenter` helpers.
> 
> **`annotate_executor` / `TraceAnnotatingExecutor`** wraps any `sqlx::Executor`, rewrites statement text at execution time (keeping binds and `query!` compile-time checks), and runs annotated queries with **`persistent(false)`** so per-trace SQL text does not thrash the prepared-statement cache. With no span context, queries pass through unchanged.
> 
> **Wiring:** `OneTimeExecutor` read paths and all generated repo writes/reads (`create`/`update`/`delete`/`forget`, event persistence, nested populate/cascade) now use `es_entity::annotate_executor(op.as_executor())` instead of the raw executor.
> 
> Adds an integration test that asserts the comment shows up in `pg_stat_activity`, plus unit tests for `annotate_sql`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4874468f5ea83519ba1c941fec61c2b4b9fea8d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->