### PR TITLE
feat(operation): add AtomicOperation::supports_hooks() probe

### DIFF
--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -142,6 +142,10 @@ impl<'o> AtomicOperation for DbOp<'o> {
     fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
         self.commit_hooks.as_ref()?.get_last::<H>()
     }
+
+    fn supports_hooks(&self) -> bool {
+        true
+    }
 }
 
 /// Equivileant of [`DbOp`] just that the time is guaranteed to be cached.
@@ -198,6 +202,10 @@ impl<'o> AtomicOperation for DbOpWithTime<'o> {
 
     fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
         self.inner.commit_hook::<H>()
+    }
+
+    fn supports_hooks(&self) -> bool {
+        self.inner.supports_hooks()
     }
 }
 
@@ -256,6 +264,18 @@ pub trait AtomicOperation: Send {
     /// Returns the hook a subsequent `add_commit_hook::<H>` call would merge into.
     fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
         None
+    }
+
+    /// Whether this operation supports commit hooks.
+    ///
+    /// `true` iff [`add_commit_hook`](Self::add_commit_hook) can register a hook
+    /// (i.e. the operation is backed by a [`DbOp`]-style commit-hook buffer, not
+    /// a bare [`sqlx::Transaction`]). Unlike [`commit_hook`](Self::commit_hook) —
+    /// whose `None` is ambiguous between "hooks unsupported" and "supported but
+    /// none registered yet" — this reports support directly, with no registration
+    /// attempt and no `&mut` access.
+    fn supports_hooks(&self) -> bool {
+        false
     }
 }
 

--- a/src/operation/with_time.rs
+++ b/src/operation/with_time.rs
@@ -75,4 +75,8 @@ impl<'a, Op: AtomicOperation + ?Sized> AtomicOperation for OpWithTime<'a, Op> {
     fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
         self.inner.commit_hook::<H>()
     }
+
+    fn supports_hooks(&self) -> bool {
+        self.inner.supports_hooks()
+    }
 }

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -345,3 +345,28 @@ async fn commit_hook_not_visible_inside_pre_commit() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn supports_hooks_reflects_op_capability() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+
+    // A DbOp is backed by a commit-hook buffer.
+    let op = DbOp::init(&pool).await?;
+    assert!(op.supports_hooks());
+
+    // Time wrappers delegate to the inner op. (The `OpWithTime` temporary
+    // borrows `with_time` only for the duration of the statement.)
+    let mut with_time = op.with_db_time().await?;
+    assert!(with_time.supports_hooks());
+    assert!(OpWithTime::cached_or_clock_time(&mut with_time).supports_hooks());
+    with_time.commit().await?;
+
+    // A bare sqlx::Transaction has no hook buffer, so it reports no support —
+    // distinct from a hook-capable op that merely has nothing registered yet
+    // (both of which `commit_hook` would report as `None`).
+    let tx = pool.begin().await?;
+    assert!(!tx.supports_hooks());
+    tx.rollback().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## What

Adds a read-only capability probe to `AtomicOperation`:

```rust
fn supports_hooks(&self) -> bool { false } // default
```

- `DbOp` → `true`
- `DbOpWithTime` / `OpWithTime` → delegate to their inner op
- default (bare `sqlx::Transaction`, `HookOperation`) → `false`

## Why

`commit_hook::<H>(&self) -> Option<&H>` is the only `&self` window into hook state, but its `None` is **ambiguous**: it means *either* "this op doesn't support hooks" *or* "it does, but nothing of type `H` is registered yet." The only unambiguous support signal today is `add_commit_hook`, which returns `Err` iff unsupported — but that requires `&mut` and consumes a hook value.

`supports_hooks()` reports capability directly, with `&self` and no registration side effect.

## Consumer

obix's new `OpCursor` marks a position in an op's publish buffer and reads events back before commit (for atomic cross-outbox reposts). It must **fail loudly** when handed an op that can't buffer (a bare `sqlx::Transaction`) rather than silently yield nothing. Without this probe, `cursor()` had to take `&mut op` and register an empty hook just to detect support; with it, `cursor(&op) -> Result<…>` stays borrow-light:

```rust
if !op.supports_hooks() {
    return Err(CursorError::HooksUnsupported);
}
```

## Tests

`tests/hooks.rs::supports_hooks_reflects_op_capability` — asserts `true` for `DbOp` and its time wrappers, `false` for a bare `sqlx::Transaction`. Full `hooks` suite: 11 passed. `cargo fmt --check` clean; no new clippy warnings.

Additive and backwards-compatible (defaulted trait method). Unblocks the es-entity bump + `OpCursor` fail-loud behavior in obix (GaloyMoney/obix#79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive defaulted trait method with narrow capability reporting; no change to commit or hook execution paths.
> 
> **Overview**
> Adds **`AtomicOperation::supports_hooks(&self) -> bool`** so callers can tell whether an op can register commit hooks without using `&mut` or registering a dummy hook.
> 
> **`commit_hook`’s `None`** could mean “no hooks” or “nothing registered yet”; **`supports_hooks`** is unambiguous: **`DbOp`** (and time wrappers via delegation) return **`true`**, while the trait default and bare **`sqlx::Transaction`** return **`false`**.
> 
> A new integration test in **`tests/hooks.rs`** asserts that behavior for **`DbOp`**, **`DbOpWithTime`**, **`OpWithTime`**, and a raw transaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acde1d9affa33f5e037f0824dc9b83feccd00f6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->