### PR TITLE
feat!: add global toggle for SQL trace-context annotation (default off)

### DIFF
--- a/src/sql_commenter.rs
+++ b/src/sql_commenter.rs
@@ -26,22 +26,23 @@
 //! sampled flag keeps full prepared-statement reuse for all un-sampled
 //! traffic.
 //!
-//! Annotation requires the `tracing-context` feature and an initialized
-//! OpenTelemetry tracing layer. Otherwise [`annotate_sql`] is a zero-cost
-//! pass-through.
+//! Annotation requires the `tracing-context` feature, an initialized
+//! OpenTelemetry tracing layer, and must be switched on via
+//! [`set_annotation_enabled`] (it is disabled by default). Otherwise
+//! [`annotate_sql`] is a zero-cost pass-through.
 
 use std::borrow::Cow;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-static ANNOTATION_ENABLED: AtomicBool = AtomicBool::new(true);
+static ANNOTATION_ENABLED: AtomicBool = AtomicBool::new(false);
 
-/// Globally enables or disables SQL trace-context annotation (enabled by
+/// Globally enables or disables SQL trace-context annotation (disabled by
 /// default).
 ///
-/// When disabled, [`annotate_sql`] is a pass-through and executors delegate
-/// statements untouched — restoring prepared-statement reuse for all traffic
-/// at the cost of losing statement-level trace correlation. Intended to be
-/// set once at process startup from application configuration.
+/// While disabled, [`annotate_sql`] is a pass-through and executors delegate
+/// statements untouched — prepared-statement reuse for all traffic at the
+/// cost of losing statement-level trace correlation. Intended to be set once
+/// at process startup from application configuration.
 pub fn set_annotation_enabled(enabled: bool) {
     ANNOTATION_ENABLED.store(enabled, Ordering::Relaxed);
 }
@@ -121,6 +122,7 @@ mod tests {
     #[test]
     fn annotates_within_sampled_span() {
         let _lock = ANNOTATION_LOCK.lock().unwrap();
+        set_annotation_enabled(true);
         let _subscriber = subscriber_with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn);
 
         let span = tracing::info_span!("test_span");
@@ -138,6 +140,8 @@ mod tests {
             annotate_sql("SELECT 1"),
             format!("SELECT 1 /*traceparent='{tp}'*/")
         );
+
+        set_annotation_enabled(false);
     }
 
     #[test]
@@ -152,19 +156,18 @@ mod tests {
     }
 
     #[test]
-    fn disabled_annotation_is_pass_through() {
+    fn annotation_disabled_by_default_and_toggleable() {
         let _lock = ANNOTATION_LOCK.lock().unwrap();
         let _subscriber = subscriber_with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn);
 
         let span = tracing::info_span!("test_span");
         let _guard = span.enter();
 
-        set_annotation_enabled(false);
-        let disabled = annotate_sql("SELECT 1");
-        set_annotation_enabled(true);
+        // Disabled by default: pass-through even within a sampled span.
+        assert_eq!(annotate_sql("SELECT 1"), "SELECT 1");
 
-        assert_eq!(disabled, "SELECT 1");
-        // Re-enabled annotation still applies within a sampled span.
+        set_annotation_enabled(true);
         assert!(annotate_sql("SELECT 1").contains("/*traceparent='"));
+        set_annotation_enabled(false);
     }
 }

--- a/src/sql_commenter.rs
+++ b/src/sql_commenter.rs
@@ -101,6 +101,29 @@ mod tests {
     /// Serializes tests that are sensitive to the global annotation toggle.
     static ANNOTATION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// Locks the toggle, tolerating poisoning from a previously panicked test.
+    fn annotation_lock() -> std::sync::MutexGuard<'static, ()> {
+        ANNOTATION_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Enables annotation for the duration of a test, restoring the default
+    /// (disabled) on drop — including when the test panics.
+    struct AnnotationEnabled(std::sync::MutexGuard<'static, ()>);
+
+    impl AnnotationEnabled {
+        fn for_test() -> Self {
+            let guard = annotation_lock();
+            set_annotation_enabled(true);
+            Self(guard)
+        }
+    }
+
+    impl Drop for AnnotationEnabled {
+        fn drop(&mut self) {
+            set_annotation_enabled(false);
+        }
+    }
+
     fn subscriber_with_sampler(
         sampler: opentelemetry_sdk::trace::Sampler,
     ) -> tracing::subscriber::DefaultGuard {
@@ -121,8 +144,7 @@ mod tests {
 
     #[test]
     fn annotates_within_sampled_span() {
-        let _lock = ANNOTATION_LOCK.lock().unwrap();
-        set_annotation_enabled(true);
+        let _enabled = AnnotationEnabled::for_test();
         let _subscriber = subscriber_with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn);
 
         let span = tracing::info_span!("test_span");
@@ -140,17 +162,14 @@ mod tests {
             annotate_sql("SELECT 1"),
             format!("SELECT 1 /*traceparent='{tp}'*/")
         );
-
-        set_annotation_enabled(false);
     }
 
     #[test]
     fn unsampled_span_is_not_annotated() {
-        let _lock = ANNOTATION_LOCK.lock().unwrap();
         // Even with annotation enabled, an un-sampled span must not be
         // annotated: its trace is never exported, so the comment could not
         // be correlated with anything.
-        set_annotation_enabled(true);
+        let _enabled = AnnotationEnabled::for_test();
         let _subscriber = subscriber_with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOff);
 
         let span = tracing::info_span!("test_span");
@@ -158,13 +177,11 @@ mod tests {
 
         assert!(current_traceparent().is_none());
         assert_eq!(annotate_sql("SELECT 1"), "SELECT 1");
-
-        set_annotation_enabled(false);
     }
 
     #[test]
     fn annotation_disabled_by_default_and_toggleable() {
-        let _lock = ANNOTATION_LOCK.lock().unwrap();
+        let _lock = annotation_lock();
         let _subscriber = subscriber_with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn);
 
         let span = tracing::info_span!("test_span");

--- a/src/sql_commenter.rs
+++ b/src/sql_commenter.rs
@@ -31,6 +31,25 @@
 //! pass-through.
 
 use std::borrow::Cow;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static ANNOTATION_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Globally enables or disables SQL trace-context annotation (enabled by
+/// default).
+///
+/// When disabled, [`annotate_sql`] is a pass-through and executors delegate
+/// statements untouched — restoring prepared-statement reuse for all traffic
+/// at the cost of losing statement-level trace correlation. Intended to be
+/// set once at process startup from application configuration.
+pub fn set_annotation_enabled(enabled: bool) {
+    ANNOTATION_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether SQL trace-context annotation is currently enabled.
+pub fn annotation_enabled() -> bool {
+    ANNOTATION_ENABLED.load(Ordering::Relaxed)
+}
 
 /// The W3C `trace-flags` sampled bit.
 #[cfg(feature = "tracing-context")]
@@ -62,6 +81,9 @@ pub fn current_traceparent() -> Option<String> {
 /// Returns [`Cow::Borrowed`] (no allocation) when there is no sampled span
 /// context; callers can use this to skip any annotation-dependent work.
 pub fn annotate_sql(sql: &str) -> Cow<'_, str> {
+    if !annotation_enabled() {
+        return Cow::Borrowed(sql);
+    }
     match current_traceparent() {
         Some(traceparent) => Cow::Owned(format!("{sql} /*traceparent='{traceparent}'*/")),
         None => Cow::Borrowed(sql),
@@ -74,6 +96,9 @@ mod tests {
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     use super::*;
+
+    /// Serializes tests that are sensitive to the global annotation toggle.
+    static ANNOTATION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn subscriber_with_sampler(
         sampler: opentelemetry_sdk::trace::Sampler,
@@ -95,6 +120,7 @@ mod tests {
 
     #[test]
     fn annotates_within_sampled_span() {
+        let _lock = ANNOTATION_LOCK.lock().unwrap();
         let _subscriber = subscriber_with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn);
 
         let span = tracing::info_span!("test_span");
@@ -123,5 +149,22 @@ mod tests {
 
         assert!(current_traceparent().is_none());
         assert_eq!(annotate_sql("SELECT 1"), "SELECT 1");
+    }
+
+    #[test]
+    fn disabled_annotation_is_pass_through() {
+        let _lock = ANNOTATION_LOCK.lock().unwrap();
+        let _subscriber = subscriber_with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn);
+
+        let span = tracing::info_span!("test_span");
+        let _guard = span.enter();
+
+        set_annotation_enabled(false);
+        let disabled = annotate_sql("SELECT 1");
+        set_annotation_enabled(true);
+
+        assert_eq!(disabled, "SELECT 1");
+        // Re-enabled annotation still applies within a sampled span.
+        assert!(annotate_sql("SELECT 1").contains("/*traceparent='"));
     }
 }

--- a/src/sql_commenter.rs
+++ b/src/sql_commenter.rs
@@ -146,6 +146,11 @@ mod tests {
 
     #[test]
     fn unsampled_span_is_not_annotated() {
+        let _lock = ANNOTATION_LOCK.lock().unwrap();
+        // Even with annotation enabled, an un-sampled span must not be
+        // annotated: its trace is never exported, so the comment could not
+        // be correlated with anything.
+        set_annotation_enabled(true);
         let _subscriber = subscriber_with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOff);
 
         let span = tracing::info_span!("test_span");
@@ -153,6 +158,8 @@ mod tests {
 
         assert!(current_traceparent().is_none());
         assert_eq!(annotate_sql("SELECT 1"), "SELECT 1");
+
+        set_annotation_enabled(false);
     }
 
     #[test]

--- a/tests/trace_annotation.rs
+++ b/tests/trace_annotation.rs
@@ -21,6 +21,9 @@ async fn trace_context_reaches_postgres() -> anyhow::Result<()> {
         .with(tracing_opentelemetry::layer().with_tracer(tracer))
         .try_init();
 
+    // Annotation is disabled by default; this test exercises the opt-in path.
+    sql_commenter::set_annotation_enabled(true);
+
     let pool = init_pool().await?;
 
     let span = tracing::info_span!("trace_annotation_test");


### PR DESCRIPTION
Adds `sql_commenter::set_annotation_enabled(bool)` — **disabled by default** (opt-in).

While disabled (the default), `annotate_sql` is a zero-cost pass-through, so `OneTimeExecutor` delegates statements untouched: full sqlx prepared-statement reuse for all traffic. Calling `set_annotation_enabled(true)` once at process startup restores the traceparent annotation introduced in #154.

Motivation: annotated statements are executed `persistent(false)` — a server-side parse + plan per execution. Under stress-test load (obix outbox checkpoint churn ≈ 250 `UPDATE job_executions`/s) that cost is significant; this makes annotation an explicit choice and gives operators a config lever to reclaim the cost without recompiling.

lana-bank wires it to `tracing.annotate_sql_statements` in lana.yml (GaloyMoney/lana-bank#7452).

Tests: `annotation_disabled_by_default_and_toggleable` covers the default and the toggle; a mutex serializes toggle-sensitive tests since the flag is global. The `trace_annotation` integration test opts in explicitly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking default: annotation is off unless configured, changing observability and DB execution characteristics for existing deployments that relied on implicit annotation.
> 
> **Overview**
> **SQL `traceparent` comments are now opt-in** via `sql_commenter::set_annotation_enabled` / `annotation_enabled`, backed by a process-wide atomic flag that defaults to **disabled**.
> 
> When the toggle is off, `annotate_sql` returns the original SQL immediately (`Cow::Borrowed`), so executors keep full prepared-statement reuse and avoid per-execution parse/plan cost. Enabling it at startup restores sampled-span annotation behavior from the prior feature.
> 
> Tests gain a mutex-serialized `AnnotationEnabled` helper for the global flag, a case for default-off plus toggle, and the Postgres integration test explicitly calls `set_annotation_enabled(true)` before exercising the end-to-end path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e724cdf9c1eef39d3ffd3ea0d15658645d5d4e82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->