### PR TITLE
feat: add JsonSchema support for Forgettable<T>

### DIFF
--- a/src/forgettable.rs
+++ b/src/forgettable.rs
@@ -24,6 +24,13 @@ use std::{fmt, hash, ops::Deref};
 /// - Real values are extracted via [`__extract_payload_value`] **before** serde runs,
 ///   and stored in the forgettable payloads table.
 ///
+/// # JSON Schema
+///
+/// With the `json-schema` feature enabled, `Forgettable<T>` implements
+/// `schemars::JsonSchema` by delegating to `Option<T>`, matching the
+/// value-or-null serialized shape — no field-level `#[schemars(with = ...)]`
+/// is needed on containing types.
+///
 /// # Repository Guard
 ///
 /// An event type with `Forgettable<T>` fields must be backed by a repository
@@ -134,6 +141,25 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Forgettable<T> {
             Some(v) => Ok(Forgettable(Some(v))),
             None => Ok(Forgettable(None)),
         }
+    }
+}
+
+#[cfg(feature = "json-schema")]
+impl<T: schemars::JsonSchema> schemars::JsonSchema for Forgettable<T> {
+    fn inline_schema() -> bool {
+        Option::<T>::inline_schema()
+    }
+
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        Option::<T>::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        Option::<T>::schema_id()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        Option::<T>::json_schema(generator)
     }
 }
 

--- a/tests/forgettable_json_schema.rs
+++ b/tests/forgettable_json_schema.rs
@@ -1,0 +1,55 @@
+#![cfg(feature = "json-schema")]
+//! Proof that types containing [`Forgettable<T>`] can derive
+//! [`schemars::JsonSchema`] without field-level `#[schemars(with = ...)]`
+//! workarounds, and that the field schema matches `Option<T>`.
+
+use schemars::{JsonSchema, schema_for};
+use serde::{Deserialize, Serialize};
+
+use es_entity::*;
+
+es_entity::entity_id! { UserId }
+
+#[derive(EsEvent, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "UserId")]
+pub enum UserEvent {
+    Initialized {
+        id: UserId,
+        name: Forgettable<String>,
+        email: String,
+    },
+}
+
+#[test]
+fn forgettable_schema_equals_option_schema() {
+    assert_eq!(
+        schema_for!(Forgettable<String>),
+        schema_for!(Option<String>)
+    );
+}
+
+#[test]
+fn event_with_forgettable_derives_json_schema() {
+    #[derive(JsonSchema)]
+    #[allow(dead_code)]
+    struct WithOption {
+        name: Option<String>,
+    }
+
+    let event_schema = serde_json::to_value(schema_for!(UserEvent)).unwrap();
+    let option_schema = serde_json::to_value(schema_for!(WithOption)).unwrap();
+
+    let initialized = &event_schema["oneOf"][0];
+    assert_eq!(
+        initialized["properties"]["name"],
+        option_schema["properties"]["name"]
+    );
+    // The field must be present in the serialized JSON (as null), so it is required.
+    assert!(
+        initialized["required"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("name"))
+    );
+}


### PR DESCRIPTION
## What

With the `json-schema` feature enabled, `Forgettable<T>` now implements `schemars::JsonSchema` by delegating to `Option<T>`, matching its value-or-null serialized shape.

## Why

Types deriving `JsonSchema` that contain `Forgettable<T>` fields currently need per-field workarounds like `#[schemars(with = "Option<T>")]`. The fix belongs in es-entity so every consumer gets it for free — once released, downstream annotations can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, feature-gated schema support with no runtime or serde behavior changes.
> 
> **Overview**
> With the **`json-schema`** feature enabled, **`Forgettable<T>`** now implements **`schemars::JsonSchema`** by forwarding to **`Option<T>`**, so generated schemas match the value-or-null wire shape and consumers can **`derive(JsonSchema)`** on events with forgettable fields without **`#[schemars(with = "Option<T>")]`** on each field.
> 
> Docs on **`Forgettable`** describe this behavior. New integration tests assert **`schema_for!(Forgettable<T>)`** equals **`schema_for!(Option<T>)`** and that an **`EsEvent`** with a **`Forgettable`** field produces the same property schema (and required **`name`**) as an equivalent **`Option`** field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b9f4eb3b1b4ee61bcec1a42c64734ddc095b503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->