### PR TITLE
docs: mention Forgettable payloads in README advanced features

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,26 @@ pub struct Orders {
 }
 ```
 
+### Forgettable payloads
+
+Events are immutable, but regulations like GDPR require deleting personal data.
+Wrap fields in `Forgettable<T>` to store their values outside the event stream,
+so they can be permanently deleted via `forget()` without rewriting event history:
+
+```rust
+#[derive(EsEvent, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "CustomerId")]
+pub enum CustomerEvent {
+    Initialized {
+        id: CustomerId,
+        name: Forgettable<String>,
+    },
+}
+```
+
+See the [Forgettable Data](https://galoymoney.github.io/es-entity/forgettable.html) chapter of the book for details.
+
 ## Testing
 
 The entity style is easily testable. Hydrate from events, mutate, assert.


### PR DESCRIPTION
## What

Adds a short **Forgettable payloads** subsection to the README's *Advanced features* section, alongside Transactions and Nested Entities.

## Why

`Forgettable<T>` is a distinguishing feature of es-entity (GDPR-style deletion of personal data without rewriting event history), but it was only documented in the book — the top-level README never mentioned it. This gives it a concise shoutout with a minimal example and links to the existing [Forgettable Data](https://galoymoney.github.io/es-entity/forgettable.html) book chapter for the full guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or API impact.
> 
> **Overview**
> Adds a **Forgettable payloads** subsection under README *Advanced features* (after Nested Entities), so `Forgettable<T>` is visible at the top level—not only in the book.
> 
> The new text explains GDPR-style deletion without rewriting events, shows a minimal `CustomerEvent` example with `Forgettable<String>`, and links to the existing [Forgettable Data](https://galoymoney.github.io/es-entity/forgettable.html) chapter for full guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff56568d510a6f6a818d8df7162ee1e81eeb09d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->