### PR TITLE
feat(operation): preserve commit-hook registration order in execute_pre

### DIFF
--- a/src/operation/hooks.rs
+++ b/src/operation/hooks.rs
@@ -16,6 +16,26 @@
 //! 4. **Commit**: The underlying database transaction is committed
 //! 5. **Post-commit**: [`CommitHook::post_commit()`] executes after successful commit
 //!
+//! # Hook Ordering
+//!
+//! Hooks execute in **registration order** — per hook, not per type:
+//!
+//! 1. Hooks run in the order they were added to the operation, regardless of their
+//!    type. A hook that refuses to merge ([`CommitHook::merge()`] returns `false`)
+//!    executes at its own (later) registration position, even when an earlier hook
+//!    of the same type exists.
+//! 2. A hook that merges executes at the position of the hook it merged into (the
+//!    earlier one). For always-merging hook types this means the type's position is
+//!    anchored by its **first** registration in the operation; all later
+//!    registrations fold into that position.
+//! 3. [`CommitHook::post_commit()`] hooks run in the same order as their
+//!    [`CommitHook::pre_commit()`] counterparts (registration order).
+//! 4. The hook set is frozen when `commit()` starts (hooks cannot register further
+//!    hooks), so ordering is fully determined before the first `pre_commit` runs.
+//!
+//! Registration order is a determinism guarantee, not a priority mechanism — there
+//! is no way to reorder hooks independently of the order in which they were added.
+//!
 //! # Examples
 //!
 //! ## Hook with Database Operations and Channel-Based Publishing
@@ -143,7 +163,6 @@
 
 use std::{
     any::{Any, TypeId},
-    collections::HashMap,
     future::Future,
     pin::Pin,
 };
@@ -160,7 +179,9 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// Hooks execute in order: [`pre_commit()`](Self::pre_commit) → database commit → [`post_commit()`](Self::post_commit).
 /// Multiple hooks of the same type can be merged via [`merge()`](Self::merge).
 ///
-/// See module-level documentation for a complete example.
+/// Hooks registered on the same operation execute in registration order — see the
+/// [module-level documentation](self#hook-ordering) for the full ordering contract
+/// and a complete example.
 pub trait CommitHook: Send + 'static + Sized {
     /// Called before the transaction commits. Can perform database operations.
     ///
@@ -289,53 +310,54 @@ impl<H: CommitHook> DynHook for H {
     }
 }
 
+/// Hooks are stored in a single flat insertion-ordered vec so that
+/// [`execute_pre`](Self::execute_pre) runs them in registration order — per hook,
+/// not per type. See the [module-level documentation](self#hook-ordering) for the
+/// ordering contract.
 pub(crate) struct CommitHooks {
-    hooks: HashMap<TypeId, Vec<Box<dyn DynHook>>>,
+    hooks: Vec<(TypeId, Box<dyn DynHook>)>,
 }
 
 impl CommitHooks {
     pub fn new() -> Self {
-        Self {
-            hooks: HashMap::new(),
-        }
+        Self { hooks: Vec::new() }
     }
 
     pub(super) fn add<H: CommitHook>(&mut self, hook: H) {
         let type_id = TypeId::of::<H>();
-        let hooks_vec = self.hooks.entry(type_id).or_default();
 
         let mut new_hook: Box<dyn DynHook> = Box::new(hook);
 
-        if let Some(last) = hooks_vec.last_mut()
-            && last.try_merge(new_hook.as_mut())
+        // Merge with the most recently added hook of the same type, keeping the
+        // existing hook's original (earlier) position in the execution order.
+        if let Some((_, existing)) = self.hooks.iter_mut().rev().find(|(t, _)| *t == type_id)
+            && existing.try_merge(new_hook.as_mut())
         {
             return;
         }
 
-        hooks_vec.push(new_hook);
+        self.hooks.push((type_id, new_hook));
     }
 
     pub(super) fn get_last<H: CommitHook>(&self) -> Option<&H> {
         self.hooks
-            .get(&TypeId::of::<H>())?
-            .last()?
-            .as_any()
-            .downcast_ref::<H>()
+            .iter()
+            .rev()
+            .find(|(t, _)| *t == TypeId::of::<H>())
+            .and_then(|(_, hook)| hook.as_any().downcast_ref::<H>())
     }
 
     pub(super) async fn execute_pre(
-        mut self,
+        self,
         op: &mut impl AtomicOperation,
     ) -> Result<PostCommitHooks, sqlx::Error> {
         let mut op = HookOperation::new(op);
-        let mut post_hooks = Vec::new();
+        let mut post_hooks = Vec::with_capacity(self.hooks.len());
 
-        for (_, hooks_vec) in self.hooks.drain() {
-            for hook in hooks_vec {
-                let (new_op, hook) = hook.pre_commit_boxed(op).await?;
-                op = new_op;
-                post_hooks.push(hook);
-            }
+        for (_, hook) in self.hooks {
+            let (new_op, hook) = hook.pre_commit_boxed(op).await?;
+            op = new_op;
+            post_hooks.push(hook);
         }
 
         Ok(PostCommitHooks { hooks: post_hooks })

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -346,6 +346,210 @@ async fn commit_hook_not_visible_inside_pre_commit() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[derive(Debug)]
+struct OrderProbe<const N: usize> {
+    label: &'static str,
+    pre_order: Arc<Mutex<Vec<&'static str>>>,
+    post_order: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl<const N: usize> CommitHook for OrderProbe<N> {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.pre_order.lock().unwrap().push(self.label);
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.post_order.lock().unwrap().push(self.label);
+    }
+}
+
+#[derive(Debug)]
+struct MergingOrderProbe {
+    labels: Vec<&'static str>,
+    pre_order: Arc<Mutex<Vec<&'static str>>>,
+    post_order: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl CommitHook for MergingOrderProbe {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.pre_order.lock().unwrap().extend(&self.labels);
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.post_order.lock().unwrap().extend(&self.labels);
+    }
+
+    fn merge(&mut self, other: &mut Self) -> bool {
+        self.labels.append(&mut other.labels);
+        true
+    }
+}
+
+#[tokio::test]
+async fn hooks_execute_in_registration_order_across_types() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+
+    // Repeat to catch nondeterministic ordering: with the previous
+    // HashMap-backed storage, cross-type execution order differed between
+    // iterations; the registration-order contract must hold on every run.
+    for _ in 0..100 {
+        let pre_order = Arc::new(Mutex::new(Vec::new()));
+        let post_order = Arc::new(Mutex::new(Vec::new()));
+        let mut op = DbOp::init(&pool).await?;
+
+        macro_rules! probe {
+            ($n:literal, $label:literal) => {
+                op.add_commit_hook(OrderProbe::<$n> {
+                    label: $label,
+                    pre_order: pre_order.clone(),
+                    post_order: post_order.clone(),
+                })
+                .unwrap();
+            };
+        }
+        probe!(1, "one");
+        probe!(2, "two");
+        probe!(3, "three");
+        probe!(4, "four");
+        probe!(5, "five");
+
+        op.commit().await?;
+
+        let expected = vec!["one", "two", "three", "four", "five"];
+        assert_eq!(*pre_order.lock().unwrap(), expected);
+        assert_eq!(*post_order.lock().unwrap(), expected);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn merged_hook_executes_at_position_of_first_registration() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre_order = Arc::new(Mutex::new(Vec::new()));
+    let post_order = Arc::new(Mutex::new(Vec::new()));
+
+    // A, B, A′ where A′ merges into A: the merged hook keeps A's position.
+    op.add_commit_hook(MergingOrderProbe {
+        labels: vec!["a1"],
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+    op.add_commit_hook(OrderProbe::<10> {
+        label: "b",
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+    op.add_commit_hook(MergingOrderProbe {
+        labels: vec!["a2"],
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    let expected = vec!["a1", "a2", "b"];
+    assert_eq!(*pre_order.lock().unwrap(), expected);
+    assert_eq!(*post_order.lock().unwrap(), expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn non_merging_hook_executes_at_own_registration_position() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre_order = Arc::new(Mutex::new(Vec::new()));
+    let post_order = Arc::new(Mutex::new(Vec::new()));
+
+    // A, B, A″ where A″ refuses to merge (default merge() == false): A″ runs at
+    // its own later position instead of being grouped with A.
+    op.add_commit_hook(OrderProbe::<20> {
+        label: "a1",
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+    op.add_commit_hook(OrderProbe::<21> {
+        label: "b",
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+    op.add_commit_hook(OrderProbe::<20> {
+        label: "a2",
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    let expected = vec!["a1", "b", "a2"];
+    assert_eq!(*pre_order.lock().unwrap(), expected);
+    assert_eq!(*post_order.lock().unwrap(), expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn post_commit_order_mirrors_pre_commit_order() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre_order = Arc::new(Mutex::new(Vec::new()));
+    let post_order = Arc::new(Mutex::new(Vec::new()));
+
+    // Mixed merging and non-merging registrations.
+    op.add_commit_hook(OrderProbe::<30> {
+        label: "x",
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+    op.add_commit_hook(MergingOrderProbe {
+        labels: vec!["m1"],
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+    op.add_commit_hook(OrderProbe::<31> {
+        label: "y",
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+    op.add_commit_hook(MergingOrderProbe {
+        labels: vec!["m2"],
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    let pre = pre_order.lock().unwrap().clone();
+    let post = post_order.lock().unwrap().clone();
+    assert_eq!(pre, vec!["x", "m1", "m2", "y"]);
+    assert_eq!(post, pre);
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn supports_hooks_reflects_op_capability() -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;


### PR DESCRIPTION
## Summary

Implements the design in drua library space [`es-entity-dev/commit-hook-ordering-preservation.md`](https://github.com/GaloyMoney/drua-library/blob/main/spaces/es-entity-dev/commit-hook-ordering-preservation.md).

`CommitHooks::execute_pre` previously drained a `HashMap<TypeId, Vec<Box<dyn DynHook>>>` — cross-type hook execution order was arbitrary and could differ run to run, leaking nondeterminism into durable artifacts (outbox INSERTs / sequence assignment). This PR stores hooks in a single flat insertion-ordered `Vec<(TypeId, Box<dyn DynHook>)>` so hooks execute in **registration order**.

Scope is deliberately **preservation only** — this is a determinism guarantee, NOT a priority mechanism (explicitly rejected in the design for this iteration; priority layers on compatibly later if ever needed).

## Contract (now documented in module docs)

1. Hooks execute in registration order — per hook, not per type. A merge-refusing same-type hook registered later executes at its own later position.
2. A merged hook executes at the position of the hook it merged into (the earlier one) — always-merging types are anchored at their **first** registration in the op.
3. `post_commit` order mirrors `pre_commit` order.
4. The hook set is frozen at `commit()` (hooks cannot register hooks).

## Compatibility / semver

- **No API change** — behavioral tightening only. No code can correctly depend on today's cross-type order (it is nondeterministic).
- `AtomicOperation::commit_hook::<H>()` (0.10.41) semantics unchanged: still returns the most recently registered hook of a type (the merge target); only the internal lookup changed to a reverse scan.
- One observable nuance: merge-refusing (`merge() == false`) same-type hooks are no longer grouped with their type — they run at their own registered position. Their previous group position was undefined anyway.
- **Semver: minor** release. Release plan per design rollout: (1) this PR + minor bump, (2) audit direct `CommitHook` impls in obix / job / cala for the merge=false grouping nuance (expected: none affected — obix's `PersistEvents` / `PersistEphemeralEvents` always merge), (3) bump downstream lockfiles opportunistically.

## Downstream consumers

- **obix**: uses `commit_hook::<H>()` via `OpCursor`; `PersistEvents` hooks now get stable per-op cross-outbox ordering (anchored by first publish).
- **cala**: outbox implementation registers commit hooks — recompiles unchanged.
- **Unblocks**: lana-bank cala→lana outbox repost can now state a deterministic per-op stream contract (domain events before remapped ledger events for the standard entity-then-ledger pattern).

## Testing

- `hooks_execute_in_registration_order_across_types` — 5 distinct hook types, exact-order assertion looped 100×; flakes against the old HashMap storage and pins the new contract.
- `merged_hook_executes_at_position_of_first_registration` — A, B, A′(merge) → `[a1, a2, b]`.
- `non_merging_hook_executes_at_own_registration_position` — A, B, A″(no merge) → `[a1, b, a2]`.
- `post_commit_order_mirrors_pre_commit_order` — mixed merging/non-merging; post == pre.
- All existing tests (incl. the 7 `commit_hook` getter tests) pass unchanged.

Verification: `nix flake check` (fmt / clippy -D warnings / deny / audit) ✅, `nix run .#nextest` against live Postgres: **220/220 passed** ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral tightening on transaction commit hooks can change observable ordering of side effects (outbox/events) for code that implicitly relied on nondeterministic cross-type order; no public API changes.
> 
> **Overview**
> **Commit hooks now run in registration order** instead of an arbitrary `HashMap` bucket order, so cross-type `pre_commit` / `post_commit` sequencing is stable across runs (e.g. outbox INSERT order).
> 
> `CommitHooks` is a flat insertion-ordered `Vec<(TypeId, …)>`; `execute_pre` walks that vec. Same-type hooks still merge into the **most recently added** instance of that type, but execution stays at the **first** registration slot for that merged hook. Hooks with `merge() == false` run at their own later slot, not grouped with earlier same-type hooks.
> 
> Module docs spell out the ordering contract (registration order, merge anchoring, post mirrors pre, frozen at `commit()`). New tests cover cross-type order (100× loop), merge vs non-merge placement, and post/pre parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af8cb142136dc711c3efa3d5902d95d6f15a02c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->