### PR TITLE
ci: retry release git puts

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -11,6 +11,18 @@
 #@   "nix_task_image_config",
 #@ )
 
+#@ def retry_task():
+task: wait-and-retry
+config:
+  platform: linux
+  image_resource: #@ release_task_image_config()
+  run:
+    path: sh
+    args:
+    - "-c"
+    - "sleep 5"
+#@ end
+
 groups:
 - name: es-entity
   jobs:
@@ -122,18 +134,22 @@ jobs:
       run:
         path: pipeline-tasks/ci/tasks/publish-to-crates.sh
   - put: repo
+    attempts: 3
     params:
       tag: artifacts/gh-release-tag
       repository: repo
       merge: true
+    on_failure: #@ retry_task()
   - put: gh-release
     params:
       name: artifacts/gh-release-name
       tag: artifacts/gh-release-tag
       body: artifacts/gh-release-notes.md
   - put: version
+    attempts: 3
     params:
       file: version/version
+    on_failure: #@ retry_task()
 
 - name: set-dev-version
   plan:


### PR DESCRIPTION
## Summary
- retry the Git-backed repo and semver version release puts up to three times
- add the same wait-and-retry failure hook used by Lana Bank
- leave gh-release unretried because release creation is side-effecting

## Context
Concourse release build 27 published version 0.10.41 and created its GitHub release, then failed at the final version put with exit status 128:
https://ci.galoy.io/teams/dev/pipelines/es-entity/jobs/release/builds/27

## Validation
- ytt render passes strict Concourse pipeline validation
- git diff --check passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI pipeline YAML only; no application or release artifact logic changes.
> 
> **Overview**
> Adds **resilience to the release job** when Concourse Git/version resource puts fail transiently (e.g. exit 128 after a successful publish).
> 
> Introduces a ytt **`retry_task()`** helper that runs a 5s `wait-and-retry` sleep on failure, matching the Lana Bank pattern. The **`put: repo`** (tag/merge) and **`put: version`** steps now use **`attempts: 3`** and **`on_failure: retry_task()`**. **`put: gh-release`** is unchanged—no retries because creating the GitHub release is side-effecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc4bf770f8969d94056b0efd5be35412e21c68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->