### PR TITLE
perf(context): eliminate per-poll context clone overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,15 +182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,7 +503,6 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "im",
  "opentelemetry",
  "opentelemetry_sdk",
  "parking_lot",
@@ -964,21 +954,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "serde",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1474,15 +1449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1784,16 +1750,6 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ serde =  { workspace = true }
 serde_json =  { workspace = true }
 derive_builder = { workspace = true }
 uuid = { workspace = true }
-im = { workspace = true }
 pin-project = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true }
@@ -83,7 +82,6 @@ sqlx = { version = "0.8", default-features = false, features = ["macros", "runti
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "time"] }
 thiserror = "2.0"
 uuid = { version = "1.23", features = ["serde", "v7"] }
-im = { version = "15.1", features = ["serde"] }
 pin-project = "1.1"
 tracing = { version = "0.1.41", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -74,7 +74,7 @@ mod with_event_context;
 
 use serde::{Deserialize, Serialize};
 
-use std::{borrow::Cow, cell::RefCell, rc::Rc};
+use std::{borrow::Cow, cell::RefCell, rc::Rc, sync::Arc};
 
 pub use tracing::*;
 pub use with_event_context::*;
@@ -82,23 +82,41 @@ pub use with_event_context::*;
 /// Immutable context data that can be safely shared across thread boundaries.
 ///
 /// This struct holds key-value pairs of context information that gets attached
-/// to events when they are persisted. It uses an immutable HashMap internally
-/// for efficient cloning and thread-safe sharing of data snapshots.
+/// to events when they are persisted. It uses a copy-on-write entry vector
+/// internally: cloning is a single atomic refcount bump, and mutation only
+/// clones the (tiny) entry vector when the data is currently shared. Context
+/// maps hold a handful of entries in practice, so a linear-scan vector is
+/// cheaper than a hashed or persistent map on every operation that matters
+/// (clone, insert, lookup).
 ///
 /// `ContextData` is `Send` and can be passed between threads, unlike [`EventContext`]
 /// which is thread-local. This makes it suitable for transferring context across
 /// async boundaries via the [`WithEventContext`] trait.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct ContextData(im::HashMap<Cow<'static, str>, serde_json::Value>);
+#[derive(Debug, Clone)]
+pub struct ContextData(Arc<Vec<(Cow<'static, str>, serde_json::Value)>>);
 
 impl ContextData {
     fn new() -> Self {
-        Self(im::HashMap::new())
+        Self(Arc::new(Vec::new()))
     }
 
     fn insert(&mut self, key: &'static str, value: serde_json::Value) {
-        self.0 = self.0.update(Cow::Borrowed(key), value);
+        let entries = Arc::make_mut(&mut self.0);
+        if let Some((_, existing)) = entries.iter_mut().find(|(k, _)| *k == key) {
+            *existing = value;
+        } else {
+            entries.push((Cow::Borrowed(key), value));
+        }
+    }
+
+    /// Number of key-value pairs stored in this context.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the context holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     #[cfg(feature = "tracing-context")]
@@ -115,16 +133,63 @@ impl ContextData {
         &self,
         key: &'static str,
     ) -> Result<Option<T>, serde_json::Error> {
-        let Some(val) = self.0.get(key) else {
+        let Some((_, val)) = self.0.iter().find(|(k, _)| *k == key) else {
             return Ok(None);
         };
         serde_json::from_value(val.clone()).map(Some)
     }
 }
 
+impl Serialize for ContextData {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for (key, value) in self.0.iter() {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for ContextData {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ContextDataVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for ContextDataVisitor {
+            type Value = ContextData;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a map of context keys to JSON values")
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut access: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut entries = Vec::with_capacity(access.size_hint().unwrap_or(0));
+                while let Some((key, value)) =
+                    access.next_entry::<Cow<'static, str>, serde_json::Value>()?
+                {
+                    if let Some((_, existing)) = entries.iter_mut().find(|(k, _)| *k == key) {
+                        *existing = value;
+                    } else {
+                        entries.push((key, value));
+                    }
+                }
+                Ok(ContextData(Arc::new(entries)))
+            }
+        }
+
+        deserializer.deserialize_map(ContextDataVisitor)
+    }
+}
+
 struct StackEntry {
     id: Rc<()>,
     data: ContextData,
+    /// Set by [`EventContext::insert`]. Lets [`EventContext::data_if_dirty`]
+    /// skip the write-back clone when a poll left the context untouched.
+    dirty: bool,
 }
 
 thread_local! {
@@ -216,6 +281,7 @@ impl EventContext {
             stack.push(StackEntry {
                 id: id.clone(),
                 data,
+                dirty: false,
             });
 
             EventContext { id }
@@ -248,6 +314,7 @@ impl EventContext {
             stack.push(StackEntry {
                 id: id.clone(),
                 data,
+                dirty: false,
             });
 
             EventContext { id }
@@ -318,6 +385,7 @@ impl EventContext {
             for entry in stack.iter_mut().rev() {
                 if Rc::ptr_eq(&entry.id, &self.id) {
                     entry.data.insert(key, json_value);
+                    entry.dirty = true;
                     return;
                 }
             }
@@ -353,6 +421,28 @@ impl EventContext {
                 }
             }
             panic!("EventContext missing on CONTEXT_STACK")
+        })
+    }
+
+    /// Returns a snapshot of the context data only if it was mutated since
+    /// the context was created (or since the last `data_if_dirty` call),
+    /// clearing the dirty flag. Returns `None` when untouched, letting
+    /// callers skip the clone entirely on the (overwhelmingly common)
+    /// read-only path.
+    pub(crate) fn data_if_dirty(&self) -> Option<ContextData> {
+        CONTEXT_STACK.with(|c| {
+            let mut stack = c.borrow_mut();
+            for entry in stack.iter_mut().rev() {
+                if Rc::ptr_eq(&entry.id, &self.id) {
+                    return if entry.dirty {
+                        entry.dirty = false;
+                        Some(entry.data.clone())
+                    } else {
+                        None
+                    };
+                }
+            }
+            None
         })
     }
 
@@ -421,6 +511,69 @@ mod tests {
             current_json(),
             serde_json::json!({ "data": new_value, "new_data": value})
         );
+    }
+
+    #[test]
+    fn context_data_serializes_as_json_object_and_round_trips() {
+        let mut ctx = EventContext::current();
+        ctx.insert("request_id", &"req-123").unwrap();
+        ctx.insert("nested", &serde_json::json!({ "a": 1 }))
+            .unwrap();
+
+        let data = ctx.data();
+        assert_eq!(data.len(), 2);
+        assert!(!data.is_empty());
+
+        let json = serde_json::to_value(&data).unwrap();
+        assert!(json.is_object());
+        assert_eq!(
+            json,
+            serde_json::json!({ "request_id": "req-123", "nested": { "a": 1 } })
+        );
+
+        let round_tripped: ContextData = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            round_tripped.lookup::<String>("request_id").unwrap(),
+            Some("req-123".to_string())
+        );
+        assert_eq!(
+            round_tripped.lookup::<serde_json::Value>("nested").unwrap(),
+            Some(serde_json::json!({ "a": 1 }))
+        );
+        assert_eq!(round_tripped.lookup::<String>("missing").unwrap(), None);
+    }
+
+    #[test]
+    fn context_data_insert_replaces_existing_key() {
+        let mut ctx = EventContext::current();
+        ctx.insert("key", &"first").unwrap();
+        ctx.insert("key", &"second").unwrap();
+        let data = ctx.data();
+        assert_eq!(data.len(), 1);
+        assert_eq!(
+            data.lookup::<String>("key").unwrap(),
+            Some("second".to_string())
+        );
+    }
+
+    #[test]
+    fn data_if_dirty_only_returns_data_after_mutation() {
+        let mut ctx = EventContext::current();
+        ctx.insert("data", &"value").unwrap();
+
+        let seeded = EventContext::seed(ctx.data());
+        assert!(seeded.data_if_dirty().is_none());
+
+        let mut inner = EventContext::current();
+        inner.insert("inner", &"mutation").unwrap();
+
+        let dirty_data = seeded.data_if_dirty().expect("insert must mark dirty");
+        assert_eq!(
+            dirty_data.lookup::<String>("inner").unwrap(),
+            Some("mutation".to_string())
+        );
+        // Flag is cleared by the read
+        assert!(seeded.data_if_dirty().is_none());
     }
 
     #[test]

--- a/src/context/with_event_context.rs
+++ b/src/context/with_event_context.rs
@@ -84,7 +84,12 @@ impl<F: Future> Future for EventContextFuture<F> {
         let this = self.project();
         let ctx = EventContext::seed(this.context_data.clone());
         let res = this.future.poll(cx);
-        *this.context_data = ctx.data();
+        // Only write the context back when the poll actually mutated it —
+        // almost all polls are read-only, and the write-back costs a clone
+        // plus a stack walk.
+        if let Some(data) = ctx.data_if_dirty() {
+            *this.context_data = data;
+        }
         res
     }
 }


### PR DESCRIPTION
## Motivation

This came out of a 5-hour DB-bottleneck stress test of lana-bank
(sandbox `sb-str3lps`, `stress-testing` preset at a 3 loans/sec target,
lana-bank @ `314fbd8`, es-entity pinned at 0.11.7). The headline numbers
from that run:

- The server was **CPU-bound, not DB-bound**: 5.2 cores average / 6.6
  max (Honeycomb kubelet stats) the entire run, while the database sat
  largely idle behind advisory-lock waits.
- Achieved throughput plateaued at ~2.1-2.4 loans/sec (~75% of target).
  The direct cap is cala's per-balance `pg_advisory_xact_lock` (mean
  wait ~700ms), but the lock holds are *stretched app-side*: holders
  sit `idle in transaction` between statements because the app has no
  spare CPU. Framework CPU overhead therefore converts directly into
  lock queueing and lost throughput — every percent of wasted app CPU
  is a percent of pipeline throughput.

The 60s `/debug/pprof` CPU capture showed no single hot function; the
burn is framework-level per-operation overhead, and es-entity's event
context is a measurable part of it:

- `<EventContextFuture as Future>::poll` is an ancestor of **51% of
  all samples** (it wraps every request/job root future).
- `std::thread::local::LocalKey::try_with` is on the stack of **63%**
  of samples.
- `sized_chunks::Chunk::clone` (the `im` persistent-map internals
  behind `ContextData::clone`) shows up as its own profile row.
- Flat self-time leaders are allocator traffic (`malloc/free` ~15%)
  and atomic refcount ops (~2%) — exactly the cost shape of the
  clone-heavy context machinery.

## The problem, mechanically

`EventContextFuture::poll` runs on every poll of every request/job
future — futures are re-polled at *every* `.await` resumption, so a
request that suspends 50 times pays this 50 times. Each poll did:

1. `context_data.clone()` — `ContextData` was
   `im::HashMap<Cow<'static, str>, serde_json::Value>`. Cloning an
   `im` map walks the persistent chunk tree bumping `Arc` refcounts.
2. `EventContext::seed(clone)` — TLS push + `Rc` allocation.
3. `ctx.data()` — a second TLS walk and a **second full clone**,
   unconditionally written back into the wrapper.

Plus `EventContext::drop`: third TLS access, reverse stack scan, and
a `Vec::remove`. All of this to support a write-back that is only
meaningful when the inner future *mutated* the context — which in
practice happens once at request setup (the `#[es_event_context]`
macro's inserts), i.e. in a vanishing fraction of polls.

Separately, every event persist calls `data_for_storing()`, which also
pays the `im` clone — the stress run wrote on the order of 10M event
rows.

## The fix

Two contained changes, no public API or behavior change:

1. **`ContextData` is now copy-on-write `Arc<Vec<(Cow, Value)>>`.**
   Clone = one atomic refcount bump. Mutation clones the entry vector
   only when shared (`Arc::make_mut`). Context maps hold 0-3 entries
   in practice, so a linear-scan vector beats both hashing and a
   persistent tree on every operation this type actually performs.
   Custom `Serialize`/`Deserialize` impls preserve the exact stored
   JSON shape (a plain object — what `#[serde(transparent)]` over the
   map produced), so existing `context` columns and event payloads
   round-trip identically. This also makes `data()`, `fork()` and
   `data_for_storing()` cheap everywhere, not just in the poll path.
2. **Write-back is skipped unless the poll mutated the context.**
   `StackEntry` gains a `dirty` flag set by `EventContext::insert`;
   the wrapper only clones data back out (new crate-private
   `data_if_dirty()`) when an insert actually happened during that
   poll. Semantics are unchanged: unchanged context propagates
   unchanged.

Drops the `im` dependency (it was used nowhere else).

**Preserved invariants:** the per-poll re-seed itself stays — on
tokio's multi-thread scheduler a task's polls hop worker threads and
TLS doesn't travel with the task, so seeding at each poll is what
guarantees `EventContext::current()` inside the future resolves
correctly. Only the redundant clones around it are gone.

## Expected effect

Direct profile attribution for this machinery is ~2-5% of app CPU
(chunk-tree clones, Rc traffic, TLS walks, plus the per-persist clone
across ~10M event writes) — modest in isolation, but on this workload
it sits directly upstream of the throughput-capping lock holds, and it
compounds with the other allocation-rate reducers (tracing span
volume, allocator swap) rather than overlapping them.

## Validation plan

- [ ] Re-run the same `stress-testing` sandbox at 3 loans/sec with a
  lana-bank build on this es-entity version; compare Honeycomb
  `container.cpu.usage` AVG, cala `find_for_update` mean advisory-lock
  wait, and achieved loans/sec against the baseline from the stress
  run (5.2 cores avg / ~700ms lock wait / ~2.2 loans/s).

## Testing

- 3 new unit tests: serde JSON-object shape + round-trip, insert key
  replacement, dirty-flag write-back behavior.
- All 37 lib tests + 10 context doctests pass;
  `cargo clippy --workspace --all-features` and `cargo fmt --check`
  are clean.
- DB-backed integration tests were not run locally (no postgres in
  this environment); the change touches no SQL, and `ContextData`'s
  sqlx `Encode`/`Decode` go through the preserved serde shape.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread-local context propagation on every async poll and persisted event context JSON shape; behavior is intended to be unchanged but regressions would affect audit metadata and cross-task context.
> 
> **Overview**
> Reduces hot-path CPU and allocation cost in event context propagation by changing how **`ContextData`** is stored and when async wrappers write context back after each poll.
> 
> **`ContextData`** no longer uses **`im::HashMap`** (and the **`im`** crate is removed). It is now **`Arc<Vec<(Cow, Value)>>`** with copy-on-write on insert, so **`clone()`** is a cheap refcount bump instead of walking persistent map chunks. Custom **`Serialize`/`Deserialize`** keep the stored JSON as a plain object for DB/event payloads. **`len`** / **`is_empty`** are added on **`ContextData`**.
> 
> **`EventContextFuture::poll`** still re-seeds TLS each poll, but write-back uses new **`data_if_dirty()`** instead of unconditional **`ctx.data()`**. **`StackEntry`** tracks a **`dirty`** flag set on **`insert`**, so read-only polls skip cloning context back into the wrapper.
> 
> Unit tests cover serde round-trip, key replacement, and dirty write-back behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81527d2ae1b5704b14f66fa2e6783234b0f089f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->