### PR TITLE
perf(context): lazy event-context seeding — skip stack work on untouched polls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +34,18 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -221,6 +242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +274,58 @@ dependencies = [
  "serde",
  "windows-link",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "concurrent-queue"
@@ -303,6 +382,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +450,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -507,6 +647,7 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
+ "criterion",
  "derive_builder",
  "es-entity-macros",
  "futures",
@@ -745,6 +886,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -994,6 +1146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1395,16 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1336,6 +1513,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pluralizer"
@@ -1480,6 +1685,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1634,6 +1859,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schemars"
@@ -2156,6 +2390,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +2663,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,6 +2782,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +2828,37 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,11 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 tracing-subscriber = { workspace = true }
+criterion = { version = "0.8", features = ["html_reports", "async_tokio"] }
+
+[[bench]]
+name = "context"
+harness = false
 
 [workspace]
 resolver = "2"

--- a/benches/context.rs
+++ b/benches/context.rs
@@ -1,0 +1,232 @@
+//! Micro-benchmarks for the event-context machinery.
+//!
+//! Structured after cala's `cala-perf` criterion setup. These benches only use
+//! public API that exists both before and after PR #163 (`im::HashMap` vs
+//! copy-on-write `Arc<Vec>` inside `ContextData`), so the identical bench
+//! commit can be cherry-picked onto either implementation for an A/B run.
+//!
+//! # Running
+//!
+//! ```text
+//! cargo bench --bench context                              # core paths
+//! cargo bench --bench context --features tracing-context   # + per-persist tracing insert
+//! ```
+//!
+//! # A/B protocol against the `im`-based implementation
+//!
+//! ```text
+//! git switch perf/event-context-benches-im    # parent of PR #163 + this bench commit
+//! cargo bench --bench context -- --save-baseline im
+//! git switch perf/event-context-benches       # PR #163 + this bench commit
+//! cargo bench --bench context -- --baseline im
+//! ```
+//!
+//! # What each group isolates
+//!
+//! 1. `per_poll_overhead` — the PR's headline claim. A future that returns
+//!    `Pending` N times is driven to completion by a raw no-op-waker loop,
+//!    bare vs wrapped in `with_event_context`. (wrapped - bare) / (N + 1)
+//!    is the per-poll cost of the wrapper (seed + inner poll + write-back +
+//!    drop).
+//! 2. `tokio_yield` — same comparison on a real tokio runtime, so the wrapper
+//!    cost can be read as a fraction of realistic scheduler overhead.
+//! 3. `context_data_clone` — the clone that `EventContextFuture::poll` pays
+//!    on every poll (`im` map clone vs `Arc` refcount bump).
+//! 4. `context_lifecycle` — `seed`+`drop` (TLS push/pop + `Rc` alloc, a cost
+//!    the PR does NOT remove) and `seed`+`insert`+`drop` (the copy-on-write /
+//!    HAMT path-copy mutation cost).
+//! 5. `persist_path` — `EntityEvents::push` on an `event_context` event
+//!    (the real `data_for_storing()` call, one per persisted event; with
+//!    `tracing-context` enabled this includes the `"tracing"` insert) and
+//!    `serde_json::to_value` (the sqlx `Encode` serialization shape).
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use serde::{Deserialize, Serialize};
+
+use std::{
+    future::Future,
+    hint::black_box,
+    pin::{Pin, pin},
+    task::{Context, Poll, Waker},
+    time::Duration,
+};
+
+use es_entity::{ContextData, EntityEvents, EventContext, WithEventContext, *};
+
+es_entity::entity_id! { BenchEntityId }
+
+#[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "BenchEntityId", event_context)]
+enum BenchEvent {
+    Happened { value: u64 },
+}
+
+const KEYS: [&str; 8] = [
+    "key_0", "key_1", "key_2", "key_3", "key_4", "key_5", "key_6", "key_7",
+];
+
+/// Realistic context payloads: what `#[es_event_context]` inserts at request
+/// setup (ids / small strings).
+fn context_data(entries: usize) -> ContextData {
+    let mut ctx = EventContext::fork();
+    for key in KEYS.iter().take(entries) {
+        ctx.insert(key, &"01996a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b")
+            .unwrap();
+    }
+    ctx.data()
+}
+
+/// Number of `Poll::Pending` returns before completion; a request that
+/// suspends 64 times pays the wrapper 65 polls.
+const POLLS: u32 = 64;
+
+struct YieldN(u32);
+
+impl Future for YieldN {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+        if self.0 == 0 {
+            Poll::Ready(())
+        } else {
+            self.0 -= 1;
+            Poll::Pending
+        }
+    }
+}
+
+/// Drive a future to completion with a no-op waker — isolates poll cost from
+/// any scheduler.
+fn drive<F: Future>(fut: F) -> F::Output {
+    let mut fut = pin!(fut);
+    let mut cx = Context::from_waker(Waker::noop());
+    loop {
+        if let Poll::Ready(out) = fut.as_mut().poll(&mut cx) {
+            return out;
+        }
+    }
+}
+
+fn per_poll_overhead(c: &mut Criterion) {
+    let mut g = c.benchmark_group("1. per_poll_overhead");
+    g.throughput(Throughput::Elements(POLLS as u64 + 1));
+
+    g.bench_function("bare_future", |b| {
+        b.iter(|| drive(black_box(YieldN(POLLS))))
+    });
+
+    for entries in [0usize, 3] {
+        let data = context_data(entries);
+        g.bench_function(
+            BenchmarkId::new("with_event_context", format!("{entries}_entries")),
+            |b| b.iter(|| drive(black_box(YieldN(POLLS)).with_event_context(data.clone()))),
+        );
+    }
+    g.finish();
+}
+
+async fn yield_many() {
+    for _ in 0..POLLS {
+        tokio::task::yield_now().await;
+    }
+}
+
+fn tokio_yield(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let mut g = c.benchmark_group("2. tokio_yield");
+    g.throughput(Throughput::Elements(POLLS as u64 + 1));
+
+    g.bench_function("bare_future", |b| b.to_async(&rt).iter(yield_many));
+
+    let data = context_data(3);
+    g.bench_function("with_event_context/3_entries", |b| {
+        b.to_async(&rt)
+            .iter(|| yield_many().with_event_context(data.clone()))
+    });
+    g.finish();
+}
+
+fn context_data_clone(c: &mut Criterion) {
+    let mut g = c.benchmark_group("3. context_data_clone");
+    for entries in [0usize, 3, 8] {
+        let data = context_data(entries);
+        g.bench_function(
+            BenchmarkId::from_parameter(format!("{entries}_entries")),
+            |b| b.iter(|| black_box(data.clone())),
+        );
+    }
+    g.finish();
+}
+
+fn context_lifecycle(c: &mut Criterion) {
+    let mut g = c.benchmark_group("4. context_lifecycle");
+
+    // TLS push + Rc alloc + reverse-scan removal — per-poll cost the PR keeps.
+    let data = context_data(3);
+    g.bench_function("seed_drop/3_entries", |b| {
+        b.iter(|| {
+            let ctx = EventContext::seed(black_box(data.clone()));
+            drop(ctx);
+        })
+    });
+
+    // Adds one insert into shared data: Arc::make_mut copy-on-write on the PR
+    // branch, HAMT path-copy (chunk clone) on the im branch.
+    g.bench_function("seed_insert_drop/3_entries", |b| {
+        b.iter(|| {
+            let mut ctx = EventContext::seed(black_box(data.clone()));
+            ctx.insert("inserted_key", &"inserted-value").unwrap();
+            drop(ctx);
+        })
+    });
+    g.finish();
+}
+
+fn persist_path(c: &mut Criterion) {
+    let mut g = c.benchmark_group("5. persist_path");
+
+    // Keep an ambient context (as a request handler would) alive across the
+    // whole group so `data_for_storing()` clones realistic data.
+    let mut ambient = EventContext::current();
+    for key in KEYS.iter().take(3) {
+        ambient
+            .insert(key, &"01996a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b")
+            .unwrap();
+    }
+
+    // One `data_for_storing()` per pushed event — ~10M calls in the stress run.
+    g.bench_function("entity_events_push/3_ambient_entries", |b| {
+        b.iter_batched(
+            || EntityEvents::<BenchEvent>::init(BenchEntityId::new(), std::iter::empty()),
+            |mut events| {
+                events.push(BenchEvent::Happened { value: 42 });
+                events
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    // The serialization the sqlx `Encode` path performs per stored context.
+    let data = context_data(3);
+    g.bench_function("serde_to_value/3_entries", |b| {
+        b.iter(|| serde_json::to_value(black_box(&data)).unwrap())
+    });
+    g.finish();
+
+    drop(ambient);
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(2));
+    targets = per_poll_overhead, tokio_yield, context_data_clone, context_lifecycle, persist_path
+);
+criterion_main!(benches);

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -131,93 +131,6 @@ thread_local! {
     static CONTEXT_STACK: RefCell<Vec<StackEntry>> = const { RefCell::new(Vec::new()) };
 }
 
-/// A context seed deferred by [`EventContextFuture`]: the wrapper's
-/// [`ContextData`] is parked here on poll entry instead of eagerly becoming a
-/// [`CONTEXT_STACK`] entry. A real entry is only materialized — see
-/// [`materialize_pending_seeds`] — if the inner future actually observes the
-/// context during that poll. Most polls of a request/job future never do, so
-/// the common case skips the entry allocation, the push/pop, and the clone
-/// entirely.
-struct PendingSeed {
-    /// `Some` until materialized; then moved into the stack entry.
-    data: Option<ContextData>,
-    /// Handle to the materialized entry, if any. Dropping it removes the
-    /// entry via the normal [`EventContext`] drop logic.
-    ctx: Option<EventContext>,
-}
-
-thread_local! {
-    static PENDING_SEEDS: RefCell<Vec<PendingSeed>> = const { RefCell::new(Vec::new()) };
-}
-
-/// Materializes every pending seed into a real [`CONTEXT_STACK`] entry, in
-/// push order.
-///
-/// Called before any operation that observes or pushes onto the stack
-/// ([`EventContext::current`] / [`EventContext::seed`]). This preserves the
-/// invariant that pending seeds always sit logically *above* every stack
-/// entry that existed when they were parked: any new entry is pushed after
-/// the seeds have been materialized beneath it.
-fn materialize_pending_seeds() {
-    PENDING_SEEDS.with(|p| {
-        let mut pending = p.borrow_mut();
-        for seed in pending.iter_mut() {
-            if seed.ctx.is_none() {
-                let data = seed.data.take().expect("unmaterialized seed retains data");
-                seed.ctx = Some(EventContext::push_entry(data));
-            }
-        }
-    })
-}
-
-/// RAII token for one [`EventContextFuture`] poll invocation.
-///
-/// [`enter`](Self::enter) parks the wrapper's data as a pending seed;
-/// [`finish`](Self::finish) (normal exit) pops it and returns the data to
-/// store back into the wrapper — either untouched (fast path: the poll never
-/// observed the context) or harvested from the materialized entry. If the
-/// inner poll panics, `Drop` pops the record and discards any materialized
-/// handle so the thread-local stacks stay balanced.
-#[must_use]
-pub(crate) struct SeedGuard(());
-
-impl SeedGuard {
-    pub(crate) fn enter(data: ContextData) -> Self {
-        PENDING_SEEDS.with(|p| {
-            p.borrow_mut().push(PendingSeed {
-                data: Some(data),
-                ctx: None,
-            })
-        });
-        SeedGuard(())
-    }
-
-    pub(crate) fn finish(self) -> ContextData {
-        let seed = PENDING_SEEDS
-            .with(|p| p.borrow_mut().pop())
-            .expect("SeedGuard::finish: pending-seed stack is empty");
-        std::mem::forget(self);
-        match seed {
-            // Materialized: harvest the (possibly mutated) data. Dropping the
-            // handle removes the entry unless the inner future kept its own
-            // handle across the poll — same lifecycle as an eager seed.
-            PendingSeed { ctx: Some(ctx), .. } => ctx.data(),
-            // Fast path: the poll never observed the context; hand the data
-            // back unchanged without ever having touched CONTEXT_STACK.
-            PendingSeed { data, .. } => data.expect("unmaterialized seed retains data"),
-        }
-    }
-}
-
-impl Drop for SeedGuard {
-    fn drop(&mut self) {
-        // Unwind path: the wrapped poll panicked. Pop the record; dropping a
-        // materialized handle removes its stack entry via EventContext::drop.
-        // Write-back is skipped, matching the eager-seeding behavior.
-        let _ = PENDING_SEEDS.with(|p| p.borrow_mut().pop());
-    }
-}
-
 /// Thread-local event context for tracking metadata throughout event sourcing operations.
 ///
 /// `EventContext` provides a way to attach contextual information (like request IDs, audit info,
@@ -290,7 +203,7 @@ impl EventContext {
     /// // Context is now available for the current thread
     /// ```
     pub fn current() -> Self {
-        materialize_pending_seeds();
+        with_event_context::materialize_pending_seeds();
         CONTEXT_STACK.with(|c| {
             let mut stack = c.borrow_mut();
             if let Some(last) = stack.last() {
@@ -330,13 +243,13 @@ impl EventContext {
     /// // new_ctx now has its own independent context stack
     /// ```
     pub fn seed(data: ContextData) -> Self {
-        materialize_pending_seeds();
+        with_event_context::materialize_pending_seeds();
         Self::push_entry(data)
     }
 
     /// Pushes a new stack entry without materializing pending seeds first.
     /// Only [`seed`](Self::seed) (after materializing) and
-    /// [`materialize_pending_seeds`] itself may call this.
+    /// `with_event_context::materialize_pending_seeds` itself may call this.
     fn push_entry(data: ContextData) -> Self {
         CONTEXT_STACK.with(|c| {
             let mut stack = c.borrow_mut();
@@ -668,7 +581,7 @@ mod tests {
     }
 
     fn pending_depth() -> usize {
-        PENDING_SEEDS.with(|p| p.borrow().len())
+        with_event_context::pending_seed_depth()
     }
 
     #[tokio::test]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -131,6 +131,93 @@ thread_local! {
     static CONTEXT_STACK: RefCell<Vec<StackEntry>> = const { RefCell::new(Vec::new()) };
 }
 
+/// A context seed deferred by [`EventContextFuture`]: the wrapper's
+/// [`ContextData`] is parked here on poll entry instead of eagerly becoming a
+/// [`CONTEXT_STACK`] entry. A real entry is only materialized — see
+/// [`materialize_pending_seeds`] — if the inner future actually observes the
+/// context during that poll. Most polls of a request/job future never do, so
+/// the common case skips the entry allocation, the push/pop, and the clone
+/// entirely.
+struct PendingSeed {
+    /// `Some` until materialized; then moved into the stack entry.
+    data: Option<ContextData>,
+    /// Handle to the materialized entry, if any. Dropping it removes the
+    /// entry via the normal [`EventContext`] drop logic.
+    ctx: Option<EventContext>,
+}
+
+thread_local! {
+    static PENDING_SEEDS: RefCell<Vec<PendingSeed>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Materializes every pending seed into a real [`CONTEXT_STACK`] entry, in
+/// push order.
+///
+/// Called before any operation that observes or pushes onto the stack
+/// ([`EventContext::current`] / [`EventContext::seed`]). This preserves the
+/// invariant that pending seeds always sit logically *above* every stack
+/// entry that existed when they were parked: any new entry is pushed after
+/// the seeds have been materialized beneath it.
+fn materialize_pending_seeds() {
+    PENDING_SEEDS.with(|p| {
+        let mut pending = p.borrow_mut();
+        for seed in pending.iter_mut() {
+            if seed.ctx.is_none() {
+                let data = seed.data.take().expect("unmaterialized seed retains data");
+                seed.ctx = Some(EventContext::push_entry(data));
+            }
+        }
+    })
+}
+
+/// RAII token for one [`EventContextFuture`] poll invocation.
+///
+/// [`enter`](Self::enter) parks the wrapper's data as a pending seed;
+/// [`finish`](Self::finish) (normal exit) pops it and returns the data to
+/// store back into the wrapper — either untouched (fast path: the poll never
+/// observed the context) or harvested from the materialized entry. If the
+/// inner poll panics, `Drop` pops the record and discards any materialized
+/// handle so the thread-local stacks stay balanced.
+#[must_use]
+pub(crate) struct SeedGuard(());
+
+impl SeedGuard {
+    pub(crate) fn enter(data: ContextData) -> Self {
+        PENDING_SEEDS.with(|p| {
+            p.borrow_mut().push(PendingSeed {
+                data: Some(data),
+                ctx: None,
+            })
+        });
+        SeedGuard(())
+    }
+
+    pub(crate) fn finish(self) -> ContextData {
+        let seed = PENDING_SEEDS
+            .with(|p| p.borrow_mut().pop())
+            .expect("SeedGuard::finish: pending-seed stack is empty");
+        std::mem::forget(self);
+        match seed {
+            // Materialized: harvest the (possibly mutated) data. Dropping the
+            // handle removes the entry unless the inner future kept its own
+            // handle across the poll — same lifecycle as an eager seed.
+            PendingSeed { ctx: Some(ctx), .. } => ctx.data(),
+            // Fast path: the poll never observed the context; hand the data
+            // back unchanged without ever having touched CONTEXT_STACK.
+            PendingSeed { data, .. } => data.expect("unmaterialized seed retains data"),
+        }
+    }
+}
+
+impl Drop for SeedGuard {
+    fn drop(&mut self) {
+        // Unwind path: the wrapped poll panicked. Pop the record; dropping a
+        // materialized handle removes its stack entry via EventContext::drop.
+        // Write-back is skipped, matching the eager-seeding behavior.
+        let _ = PENDING_SEEDS.with(|p| p.borrow_mut().pop());
+    }
+}
+
 /// Thread-local event context for tracking metadata throughout event sourcing operations.
 ///
 /// `EventContext` provides a way to attach contextual information (like request IDs, audit info,
@@ -203,6 +290,7 @@ impl EventContext {
     /// // Context is now available for the current thread
     /// ```
     pub fn current() -> Self {
+        materialize_pending_seeds();
         CONTEXT_STACK.with(|c| {
             let mut stack = c.borrow_mut();
             if let Some(last) = stack.last() {
@@ -242,6 +330,14 @@ impl EventContext {
     /// // new_ctx now has its own independent context stack
     /// ```
     pub fn seed(data: ContextData) -> Self {
+        materialize_pending_seeds();
+        Self::push_entry(data)
+    }
+
+    /// Pushes a new stack entry without materializing pending seeds first.
+    /// Only [`seed`](Self::seed) (after materializing) and
+    /// [`materialize_pending_seeds`] itself may call this.
+    fn push_entry(data: ContextData) -> Self {
         CONTEXT_STACK.with(|c| {
             let mut stack = c.borrow_mut();
             let id = Rc::new(());
@@ -503,11 +599,16 @@ mod tests {
 
         let handle = tokio::spawn(
             async {
-                assert_eq!(stack_depth(), 2);
+                // Seeding is lazy: only the outer test context exists until
+                // the wrapped future observes the context.
+                assert_eq!(stack_depth(), 1);
 
                 EventContext::current()
                     .insert("spawned", &serde_json::json!("value"))
                     .unwrap();
+
+                // Observing the context materialized the wrapper's entry.
+                assert_eq!(stack_depth(), 2);
 
                 assert_eq!(
                     current_json(),
@@ -535,11 +636,16 @@ mod tests {
 
         let handle = tokio::spawn(
             async {
-                assert_eq!(stack_depth(), 1);
+                // Seeding is lazy: the worker thread's stack stays empty
+                // until the wrapped future observes the context.
+                assert_eq!(stack_depth(), 0);
 
                 EventContext::current()
                     .insert("spawned", &serde_json::json!("value"))
                     .unwrap();
+
+                // Observing the context materialized the wrapper's entry.
+                assert_eq!(stack_depth(), 1);
 
                 assert_eq!(
                     current_json(),
@@ -559,5 +665,78 @@ mod tests {
         );
 
         assert_eq!(current_json(), serde_json::json!({ "parent": "context" }));
+    }
+
+    fn pending_depth() -> usize {
+        PENDING_SEEDS.with(|p| p.borrow().len())
+    }
+
+    #[tokio::test]
+    async fn with_event_context_untouched_poll_leaves_stacks_alone() {
+        let mut ctx = EventContext::current();
+        ctx.insert("parent", &serde_json::json!("context")).unwrap();
+        let before = current_json();
+
+        async {
+            // The wrapper parked a pending seed but no stack entry exists.
+            assert_eq!(stack_depth(), 1);
+            assert_eq!(pending_depth(), 1);
+            tokio::task::yield_now().await;
+            assert_eq!(stack_depth(), 1);
+        }
+        .with_event_context(ctx.data())
+        .await;
+
+        assert_eq!(current_json(), before);
+        assert_eq!(stack_depth(), 1);
+        assert_eq!(pending_depth(), 0);
+    }
+
+    #[tokio::test]
+    async fn with_event_context_fork_materializes_wrapper_seed() {
+        let mut ctx = EventContext::current();
+        ctx.insert("parent", &serde_json::json!("context")).unwrap();
+
+        async {
+            // fork() = current() + seed(): materializes the wrapper's entry
+            // and pushes the fork above it.
+            let mut forked = EventContext::fork();
+            forked.insert("forked", &serde_json::json!("data")).unwrap();
+            assert_eq!(stack_depth(), 3);
+            assert_eq!(
+                current_json(),
+                serde_json::json!({ "parent": "context", "forked": "data" })
+            );
+            drop(forked);
+            assert_eq!(stack_depth(), 2);
+            // Fork isolation: the wrapper's entry never saw "forked".
+            assert_eq!(current_json(), serde_json::json!({ "parent": "context" }));
+        }
+        .with_event_context(ctx.data())
+        .await;
+
+        assert_eq!(current_json(), serde_json::json!({ "parent": "context" }));
+    }
+
+    #[tokio::test]
+    async fn with_event_context_panic_leaves_stacks_balanced() {
+        let ctx = EventContext::current();
+        let data = ctx.data();
+
+        let res = tokio::spawn(
+            async {
+                // Materialize the wrapper's entry, then panic mid-poll.
+                let _ = EventContext::current();
+                panic!("boom");
+            }
+            .with_event_context(data),
+        )
+        .await;
+
+        assert!(res.is_err());
+        // The guard's unwind path removed both the pending seed and the
+        // materialized entry (current-thread runtime: same thread).
+        assert_eq!(stack_depth(), 1);
+        assert_eq!(pending_depth(), 0);
     }
 }

--- a/src/context/with_event_context.rs
+++ b/src/context/with_event_context.rs
@@ -1,12 +1,13 @@
 use pin_project::pin_project;
 
 use std::{
+    cell::RefCell,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
-use super::{ContextData, SeedGuard};
+use super::{ContextData, EventContext};
 
 /// Extension trait for propagating event context across async boundaries.
 ///
@@ -104,4 +105,97 @@ impl<F: Future> Future for EventContextFuture<F> {
         *this.context_data = Some(guard.finish());
         res
     }
+}
+
+/// A context seed deferred by [`EventContextFuture`]: the wrapper's
+/// [`ContextData`] is parked here on poll entry instead of eagerly becoming
+/// a context-stack entry. A real entry is only materialized — see
+/// [`materialize_pending_seeds`] — if the inner future actually observes the
+/// context during that poll. Most polls of a request/job future never do, so
+/// the common case skips the entry allocation, the push/pop, and the clone
+/// entirely.
+struct PendingSeed {
+    /// `Some` until materialized; then moved into the stack entry.
+    data: Option<ContextData>,
+    /// Handle to the materialized entry, if any. Dropping it removes the
+    /// entry via the normal [`EventContext`] drop logic.
+    ctx: Option<EventContext>,
+}
+
+thread_local! {
+    static PENDING_SEEDS: RefCell<Vec<PendingSeed>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Materializes every pending seed into a real context-stack entry, in push
+/// order.
+///
+/// [`EventContext`] calls this before any operation that observes or pushes
+/// onto the stack ([`EventContext::current`] / [`EventContext::seed`]). This
+/// preserves the invariant that pending seeds always sit logically *above*
+/// every stack entry that existed when they were parked: any new entry is
+/// pushed after the seeds have been materialized beneath it.
+pub(super) fn materialize_pending_seeds() {
+    PENDING_SEEDS.with(|p| {
+        let mut pending = p.borrow_mut();
+        for seed in pending.iter_mut() {
+            if seed.ctx.is_none() {
+                let data = seed.data.take().expect("unmaterialized seed retains data");
+                seed.ctx = Some(EventContext::push_entry(data));
+            }
+        }
+    })
+}
+
+/// RAII token for one [`EventContextFuture`] poll invocation.
+///
+/// [`enter`](Self::enter) parks the wrapper's data as a pending seed;
+/// [`finish`](Self::finish) (normal exit) pops it and returns the data to
+/// store back into the wrapper — either untouched (fast path: the poll never
+/// observed the context) or harvested from the materialized entry. If the
+/// inner poll panics, `Drop` pops the record and discards any materialized
+/// handle so the thread-local stacks stay balanced.
+#[must_use]
+struct SeedGuard(());
+
+impl SeedGuard {
+    fn enter(data: ContextData) -> Self {
+        PENDING_SEEDS.with(|p| {
+            p.borrow_mut().push(PendingSeed {
+                data: Some(data),
+                ctx: None,
+            })
+        });
+        SeedGuard(())
+    }
+
+    fn finish(self) -> ContextData {
+        let seed = PENDING_SEEDS
+            .with(|p| p.borrow_mut().pop())
+            .expect("SeedGuard::finish: pending-seed stack is empty");
+        std::mem::forget(self);
+        match seed {
+            // Materialized: harvest the (possibly mutated) data. Dropping the
+            // handle removes the entry unless the inner future kept its own
+            // handle across the poll — same lifecycle as an eager seed.
+            PendingSeed { ctx: Some(ctx), .. } => ctx.data(),
+            // Fast path: the poll never observed the context; hand the data
+            // back unchanged without ever having touched the context stack.
+            PendingSeed { data, .. } => data.expect("unmaterialized seed retains data"),
+        }
+    }
+}
+
+impl Drop for SeedGuard {
+    fn drop(&mut self) {
+        // Unwind path: the wrapped poll panicked. Pop the record; dropping a
+        // materialized handle removes its stack entry via EventContext::drop.
+        // Write-back is skipped, matching the eager-seeding behavior.
+        let _ = PENDING_SEEDS.with(|p| p.borrow_mut().pop());
+    }
+}
+
+/// Test-only visibility into the pending-seed stack for the context tests.
+#[cfg(test)]
+pub(super) fn pending_seed_depth() -> usize {
+    PENDING_SEEDS.with(|p| p.borrow().len())
 }

--- a/src/context/with_event_context.rs
+++ b/src/context/with_event_context.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use super::{ContextData, EventContext};
+use super::{ContextData, SeedGuard};
 
 /// Extension trait for propagating event context across async boundaries.
 ///
@@ -54,7 +54,7 @@ pub trait WithEventContext: Future {
     {
         EventContextFuture {
             future: self,
-            context_data,
+            context_data: Some(context_data),
         }
     }
 }
@@ -70,11 +70,24 @@ impl<F: Future> WithEventContext for F {}
 /// The future maintains context isolation - the context is only active
 /// during the polling of the wrapped future and does not leak to other
 /// concurrent operations.
+///
+/// Seeding is lazy: on each poll the context data is parked on a
+/// thread-local pending-seed stack, and a real [`EventContext`] entry is
+/// only materialized if the inner future actually observes the context
+/// (via [`EventContext::current`] or [`EventContext::seed`]) during that
+/// poll. Polls that never touch the context — the overwhelming majority —
+/// pay neither an allocation nor a clone.
+///
+/// [`EventContext`]: super::EventContext
+/// [`EventContext::current`]: super::EventContext::current
+/// [`EventContext::seed`]: super::EventContext::seed
 #[pin_project]
 pub struct EventContextFuture<F> {
     #[pin]
     future: F,
-    context_data: ContextData,
+    /// `Some` between polls; taken for the duration of each poll while the
+    /// data is parked on the pending-seed stack.
+    context_data: Option<ContextData>,
 }
 
 impl<F: Future> Future for EventContextFuture<F> {
@@ -82,9 +95,13 @@ impl<F: Future> Future for EventContextFuture<F> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let ctx = EventContext::seed(this.context_data.clone());
+        let data = this
+            .context_data
+            .take()
+            .expect("EventContextFuture must not be polled after a panic");
+        let guard = SeedGuard::enter(data);
         let res = this.future.poll(cx);
-        *this.context_data = ctx.data();
+        *this.context_data = Some(guard.finish());
         res
     }
 }


### PR DESCRIPTION
## Motivation

Follow-up to the review discussion on #163. Benchmarking that PR's two changes in isolation (criterion suite included here; A/B protocol below) showed:

- an `im::HashMap` clone is a flat **~3.4 ns regardless of size** — clone cost was never the problem, structural sharing already makes it O(1)
- of the wrapper's **~21 ns/poll** cost, **~18 ns is the seed/drop machinery itself** — 3 thread-local accesses, a per-poll `Rc::new(())` heap allocation, and a stack push/pop — which is independent of the container and survives #163 unchanged (#163 lands at ~18.6 ns/poll)

So this PR keeps `im` and instead removes the machinery cost for the polls that don't need it — which is almost all of them: `EventContext` is observed once at request setup (the `#[es_event_context]` macro's inserts) and once per event persist, while the wrapper's `poll` runs at *every* `.await` resumption.

## Design

`EventContextFuture::poll` no longer eagerly creates a context-stack entry. Instead it parks its `ContextData` on a thread-local **pending-seed stack** (a move — no clone, no allocation) and pops it on exit:

- **Untouched poll (fast path):** the data is taken back unchanged. Zero heap allocations, zero clones, zero `CONTEXT_STACK` traffic — just two thread-local `Vec` push/pops.
- **Observed poll:** `EventContext::current()` / `seed()` first **materialize** all pending seeds (in push order) into real stack entries, then proceed exactly as before. On poll exit the wrapper harvests `ctx.data()` from the materialized entry — identical write-back semantics, including the entry surviving if the inner future kept a handle across the poll.

Ordering invariant: pending seeds always sit logically *above* every entry that existed when they were parked; since every push path (`current`/`seed`/`fork`) materializes first, nested wrappers, forks, and direct seeds interleave identically to eager seeding.

Panic safety: a guard pops the pending record on unwind and drops any materialized handle through the normal `EventContext` drop path — write-back skipped, matching eager behavior. (Re-polling an `EventContextFuture` after a panicked poll now panics with an explicit message; futures are contractually dead after a panic.)

## Measured effect

Criterion, Apple Silicon, `--baseline im` = current `main` (reproduce: `cargo bench --bench context -- --save-baseline im` on `main` + the bench commit, then `-- --baseline im` here):

| | `main` (im, eager) | #163 (`Arc<Vec>`) | this PR (im, lazy) |
|---|---|---|---|
| wrapper cost per poll (raw driver) | 21.4 ns | 18.6 ns (−13%) | **12.6 ns (−41%)** |
| wrapped 65-yield tokio task | 1.91 µs | 1.72 µs (−9%) | **0.89 µs (−54%)** — ~5.8 ns/poll added |
| heap allocs per untouched poll | 1 (`Rc::new`) | 1 (`Rc::new`) | **0** |
| clones per untouched poll | 2 | 1 | **0** |
| `EntityEvents::push` persist path | 177 ns | 123 ns | 179 ns (unchanged, p > 0.05) |
| explicit `EventContext::seed()` | 17.8 ns | 16.7 ns | 19.7 ns (+10%, materialize check) |

Trade-offs, honestly: direct `seed()` and first-observation polls pay a ~2 ns materialize check; the persist path is unchanged (this PR deliberately doesn't touch `ContextData` — container/serialization changes can be argued separately on hygiene grounds).

Scale disclaimer (why this is framed as hygiene, not throughput): even at 1M poll resumptions/sec the eager machinery costs ~2% of one core. What this PR does eliminate at any rate is the per-poll allocation and clone traffic — the `malloc/free` and `LocalKey::try_with` signals visible in the lana-bank stress-run profile.

## Testing

- New unit tests: untouched-poll fast path (stacks provably untouched), fork-under-wrapper materialization ordering, panic-unwind balance; existing spawned-context tests updated for the lazy depth semantics (entries appear on first observation).
- `nix run .#nextest` green (full DB-backed integration suite against live process-compose Postgres); all 37 lib tests + doctests pass; `cargo clippy --workspace --all-features` clean; `cargo fmt --check` clean.
- The criterion bench suite (`benches/context.rs`, structured after cala-perf) is included so the numbers are reproducible on any branch — it only uses public API, so it cherry-picks onto `main` and #163 alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async context propagation semantics (lazy vs eager stack depth) across spawned tasks and panics; behavior is heavily tested but ordering bugs could affect event context on persist.
> 
> **Overview**
> **`with_event_context` no longer eagerly seeds the context stack on every poll.** Each poll parks `ContextData` on a thread-local pending-seed stack; a real stack entry is created only when the inner future calls `EventContext::current()` or `seed()` (via `materialize_pending_seeds`). Untouched polls avoid `Rc` allocation, `ContextData` clone, and `CONTEXT_STACK` push/pop.
> 
> `EventContext::seed` / `current` materialize pending seeds before proceeding; stack pushes go through a new private `push_entry`. `SeedGuard` handles normal write-back and panic unwind so stacks stay balanced.
> 
> Adds **`benches/context`** (Criterion) for per-poll overhead, tokio yield, clone, lifecycle, and persist paths, plus tests for lazy depth, untouched polls, fork ordering, and panic cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03274dfedf88cc1ca584fb7d34f379aa18da9604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->