### PR TITLE
feat(macros): repo.scoped(scope) bound view for scoped repositories

### DIFF
--- a/book/src/scoped-repositories.md
+++ b/book/src/scoped-repositories.md
@@ -71,6 +71,29 @@ a missing row: `find_by_*` returns `NotFound`, `maybe_find_by_*` returns
 `None`, `find_all` silently omits the id, and lists never contain the row.
 **Missing and not-yours look identical.**
 
+## The bound view: `repo.scoped(scope)`
+
+When a request performs several reads under one subject, threading the scope
+into every call gets repetitive. Scoped repos additionally generate a
+**bound view** — `Scoped{Repo}` — that captures the scope once:
+
+```rust,ignore
+let customers = self.customers.scoped(sub.scope());   // ScopedCustomers<'_>
+
+customers.find_by_id(id).await?;                      // no per-call scope arg
+customers.maybe_find_by_email(email).await?;
+customers.list_by_created_at(args, direction).await?;
+customers.find_by_id_in_op(&mut op, id).await?;       // _in_op variants too
+customers.scope();                                    // the bound CustomerScope
+```
+
+Every view method simply delegates to the corresponding scope-argument fn
+with the bound scope — no new SQL, identical semantics. The view **borrows**
+the repository (`ScopedCustomers<'a>` holds `&'a Customers`), so it is
+naturally request-scoped: it cannot be stored beyond the repo borrow, which
+keeps a bound all-access or tenant view from quietly outliving the request
+that justified it.
+
 ## Writes are custody-guarded
 
 `create`, `create_all`, `update`, `update_all` and `delete` keep their

--- a/es-entity-macros/src/repo/find_all_fn.rs
+++ b/es-entity-macros/src/repo/find_all_fn.rs
@@ -36,6 +36,48 @@ impl<'a> From<&'a RepositoryOptions> for FindAllFn<'a> {
     }
 }
 
+impl FindAllFn<'_> {
+    /// Delegating methods for the generated `Scoped{Repo}` bound view.
+    /// Empty for unscoped repos.
+    pub fn scoped_delegates(&self) -> TokenStream {
+        if self.scope.is_none() {
+            return TokenStream::new();
+        }
+        let id = self.id;
+        let entity = self.entity;
+        let query_error = &self.query_error;
+        let query_fn_op_traits = RepositoryOptions::query_fn_op_traits(self.any_nested);
+
+        let generics = if self.any_nested {
+            quote! { <Out: From<#entity>> }
+        } else {
+            quote! { <'a, Out: From<#entity>> }
+        };
+        let op_param = if self.any_nested {
+            quote! { op: &mut impl #query_fn_op_traits }
+        } else {
+            quote! { op: impl #query_fn_op_traits }
+        };
+
+        quote! {
+            pub async fn find_all<Out: From<#entity>>(
+                &self,
+                ids: &[#id]
+            ) -> Result<std::collections::HashMap<#id, Out>, #query_error> {
+                self.repo.find_all(self.scope, ids).await
+            }
+
+            pub async fn find_all_in_op #generics(
+                &self,
+                #op_param,
+                ids: &[#id]
+            ) -> Result<std::collections::HashMap<#id, Out>, #query_error> {
+                self.repo.find_all_in_op(op, self.scope, ids).await
+            }
+        }
+    }
+}
+
 impl ToTokens for FindAllFn<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let id = self.id;

--- a/es-entity-macros/src/repo/find_by_fn.rs
+++ b/es-entity-macros/src/repo/find_by_fn.rs
@@ -41,6 +41,80 @@ impl<'a> FindByFn<'a> {
             repo_name_snake: opts.repo_name_snake_case(),
         }
     }
+
+    /// Delegating methods for the generated `Scoped{Repo}` bound view: the
+    /// same fns without the `scope` argument, forwarding `self.scope`.
+    /// Empty for unscoped repos.
+    pub fn scoped_delegates(&self) -> TokenStream {
+        let mut tokens = TokenStream::new();
+        if self.scope.is_none() {
+            return tokens;
+        }
+        let entity = self.entity;
+        let column_name = &self.column.name();
+        let (_column_type, impl_expr, _access_expr) = &self.column.ty_for_find_by();
+        let query_fn_generics = RepositoryOptions::query_fn_generics(self.any_nested);
+        let query_fn_op_arg = RepositoryOptions::query_fn_op_arg(self.any_nested);
+        let query_fn_op_traits = RepositoryOptions::query_fn_op_traits(self.any_nested);
+
+        for maybe in ["", "maybe_"] {
+            let error = if maybe.is_empty() {
+                &self.find_error
+            } else {
+                &self.query_error
+            };
+            let result_type = if maybe.is_empty() {
+                quote! { #entity }
+            } else {
+                quote! { Option<#entity> }
+            };
+            for delete in [DeleteOption::No, DeleteOption::Soft] {
+                let fn_name = syn::Ident::new(
+                    &format!(
+                        "{}find_by_{}{}",
+                        maybe,
+                        column_name,
+                        delete.include_deletion_fn_postfix()
+                    ),
+                    Span::call_site(),
+                );
+                let fn_in_op = syn::Ident::new(
+                    &format!(
+                        "{}find_by_{}{}_in_op",
+                        maybe,
+                        column_name,
+                        delete.include_deletion_fn_postfix()
+                    ),
+                    Span::call_site(),
+                );
+
+                tokens.append_all(quote! {
+                    pub async fn #fn_name(
+                        &self,
+                        #column_name: #impl_expr
+                    ) -> Result<#result_type, #error> {
+                        self.repo.#fn_name(self.scope, #column_name).await
+                    }
+
+                    pub async fn #fn_in_op #query_fn_generics(
+                        &self,
+                        #query_fn_op_arg,
+                        #column_name: #impl_expr
+                    ) -> Result<#result_type, #error>
+                        where
+                            OP: #query_fn_op_traits
+                    {
+                        self.repo.#fn_in_op(op, self.scope, #column_name).await
+                    }
+                });
+
+                if delete == self.delete || self.delete == DeleteOption::SoftWithoutQueries {
+                    break;
+                }
+            }
+        }
+        tokens
+    }
 }
 
 impl ToTokens for FindByFn<'_> {

--- a/es-entity-macros/src/repo/list_by_fn.rs
+++ b/es-entity-macros/src/repo/list_by_fn.rs
@@ -476,6 +476,70 @@ impl<'a> ListByFn<'a> {
             cursor_mod: &self.cursor_mod,
         }
     }
+
+    /// Delegating methods for the generated `Scoped{Repo}` bound view.
+    /// Empty for unscoped repos.
+    pub fn scoped_delegates(&'a self) -> TokenStream {
+        let mut tokens = TokenStream::new();
+        if self.scope.is_none() {
+            return tokens;
+        }
+        let entity = self.entity;
+        let column_name = self.column.name();
+        let cursor = self.cursor();
+        let cursor_ident = cursor.ident();
+        let cursor_mod = cursor.cursor_mod();
+        let query_error = &self.query_error;
+        let query_fn_generics = RepositoryOptions::query_fn_generics(self.any_nested);
+        let query_fn_op_arg = RepositoryOptions::query_fn_op_arg(self.any_nested);
+        let query_fn_op_traits = RepositoryOptions::query_fn_op_traits(self.any_nested);
+
+        for delete in [DeleteOption::No, DeleteOption::Soft] {
+            let fn_name = syn::Ident::new(
+                &format!(
+                    "list_by_{}{}",
+                    column_name,
+                    delete.include_deletion_fn_postfix()
+                ),
+                Span::call_site(),
+            );
+            let fn_in_op = syn::Ident::new(
+                &format!(
+                    "list_by_{}{}_in_op",
+                    column_name,
+                    delete.include_deletion_fn_postfix()
+                ),
+                Span::call_site(),
+            );
+
+            tokens.append_all(quote! {
+                pub async fn #fn_name(
+                    &self,
+                    cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                    direction: es_entity::ListDirection,
+                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #query_error> {
+                    self.repo.#fn_name(self.scope, cursor, direction).await
+                }
+
+                pub async fn #fn_in_op #query_fn_generics(
+                    &self,
+                    #query_fn_op_arg,
+                    cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                    direction: es_entity::ListDirection,
+                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #query_error>
+                   where
+                       OP: #query_fn_op_traits
+                {
+                    self.repo.#fn_in_op(op, self.scope, cursor, direction).await
+                }
+            });
+
+            if delete == self.delete || self.delete == DeleteOption::SoftWithoutQueries {
+                break;
+            }
+        }
+        tokens
+    }
 }
 
 impl ToTokens for ListByFn<'_> {

--- a/es-entity-macros/src/repo/list_for_filters_fn.rs
+++ b/es-entity-macros/src/repo/list_for_filters_fn.rs
@@ -208,6 +208,94 @@ impl<'a> ListForFiltersFn<'a> {
         }
     }
 
+    /// Delegating methods for the generated `Scoped{Repo}` bound view.
+    /// Empty for unscoped repos.
+    pub fn scoped_delegates(&self) -> TokenStream {
+        let mut tokens = TokenStream::new();
+        if self.scope.is_none() {
+            return tokens;
+        }
+        let entity = self.entity;
+        let error = &self.query_error;
+        let cursor_mod = &self.cursor_mod;
+        let filters_ident = self.filters_struct.ident();
+        let sort_by_name = self.cursor.sort_by_name();
+        let combo_cursor_ident = self.cursor.ident();
+        let query_fn_generics = RepositoryOptions::query_fn_generics(self.any_nested);
+        let query_fn_op_arg = RepositoryOptions::query_fn_op_arg(self.any_nested);
+        let query_fn_op_traits = RepositoryOptions::query_fn_op_traits(self.any_nested);
+
+        for delete in [DeleteOption::No, DeleteOption::Soft] {
+            let delete_postfix = delete.include_deletion_fn_postfix();
+
+            for by_column in &self.by_columns {
+                let cursor_struct = CursorStruct {
+                    column: by_column,
+                    id: self.id,
+                    entity: self.entity,
+                    cursor_mod: &self.cursor_mod,
+                };
+                let cursor_ident = cursor_struct.ident();
+                let fn_name = syn::Ident::new(
+                    &format!("list_for_filters_by_{}{}", by_column.name(), delete_postfix),
+                    Span::call_site(),
+                );
+                let fn_in_op = syn::Ident::new(
+                    &format!(
+                        "list_for_filters_by_{}{}_in_op",
+                        by_column.name(),
+                        delete_postfix
+                    ),
+                    Span::call_site(),
+                );
+
+                tokens.append_all(quote! {
+                    pub async fn #fn_name(
+                        &self,
+                        filters: #filters_ident,
+                        cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                        direction: es_entity::ListDirection,
+                    ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> {
+                        self.repo.#fn_name(self.scope, filters, cursor, direction).await
+                    }
+
+                    pub async fn #fn_in_op #query_fn_generics(
+                        &self,
+                        #query_fn_op_arg,
+                        filters: #filters_ident,
+                        cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                        direction: es_entity::ListDirection,
+                    ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error>
+                        where
+                            OP: #query_fn_op_traits
+                    {
+                        self.repo.#fn_in_op(op, self.scope, filters, cursor, direction).await
+                    }
+                });
+            }
+
+            let dispatch_fn = syn::Ident::new(
+                &format!("list_for_filters{}", delete_postfix),
+                Span::call_site(),
+            );
+            tokens.append_all(quote! {
+                pub async fn #dispatch_fn(
+                    &self,
+                    filters: #filters_ident,
+                    sort: es_entity::Sort<#sort_by_name>,
+                    cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#combo_cursor_ident>,
+                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#combo_cursor_ident>, #error> {
+                    self.repo.#dispatch_fn(self.scope, filters, sort, cursor).await
+                }
+            });
+
+            if delete == self.delete || self.delete == DeleteOption::SoftWithoutQueries {
+                break;
+            }
+        }
+        tokens
+    }
+
     /// Scrutinee elements (bools over the destructured filter locals)
     /// identifying each filter's [`FilterState`] at runtime: one bool per
     /// non-optional column (`is_some`), two per optional column (`apply`,

--- a/es-entity-macros/src/repo/list_for_fn.rs
+++ b/es-entity-macros/src/repo/list_for_fn.rs
@@ -55,6 +55,81 @@ impl<'a> ListForFn<'a> {
             cursor_mod: &self.cursor_mod,
         }
     }
+
+    /// Delegating methods for the generated `Scoped{Repo}` bound view.
+    /// Empty for unscoped repos.
+    pub fn scoped_delegates(&'a self) -> TokenStream {
+        let mut tokens = TokenStream::new();
+        if self.scope.is_none() {
+            return tokens;
+        }
+        let entity = self.entity;
+        let cursor = self.cursor();
+        let cursor_ident = cursor.ident();
+        let cursor_mod = cursor.cursor_mod();
+        let error = &self.query_error;
+        let query_fn_generics = RepositoryOptions::query_fn_generics(self.any_nested);
+        let query_fn_op_arg = RepositoryOptions::query_fn_op_arg(self.any_nested);
+        let query_fn_op_traits = RepositoryOptions::query_fn_op_traits(self.any_nested);
+
+        let by_column_name = self.by_column.name();
+        let for_column_name = self.for_column.name();
+        let filter_arg_name = syn::Ident::new(
+            &format!("filter_{}", self.for_column.name()),
+            Span::call_site(),
+        );
+        let (_for_column_type, for_impl_expr, _for_access_expr) = self.for_column.ty_for_find_by();
+
+        for delete in [DeleteOption::No, DeleteOption::Soft] {
+            let fn_name = syn::Ident::new(
+                &format!(
+                    "list_for_{}_by_{}{}",
+                    for_column_name,
+                    by_column_name,
+                    delete.include_deletion_fn_postfix()
+                ),
+                Span::call_site(),
+            );
+            let fn_in_op = syn::Ident::new(
+                &format!(
+                    "list_for_{}_by_{}{}_in_op",
+                    for_column_name,
+                    by_column_name,
+                    delete.include_deletion_fn_postfix()
+                ),
+                Span::call_site(),
+            );
+
+            tokens.append_all(quote! {
+                pub async fn #fn_name(
+                    &self,
+                    #filter_arg_name: #for_impl_expr,
+                    cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                    direction: es_entity::ListDirection,
+                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> {
+                    self.repo.#fn_name(self.scope, #filter_arg_name, cursor, direction).await
+                }
+
+                pub async fn #fn_in_op #query_fn_generics(
+                    &self,
+                    #query_fn_op_arg,
+                    #filter_arg_name: #for_impl_expr,
+                    cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                    direction: es_entity::ListDirection,
+                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error>
+                    where
+                        OP: #query_fn_op_traits
+                {
+                    self.repo.#fn_in_op(op, self.scope, #filter_arg_name, cursor, direction).await
+                }
+            });
+
+            if delete == self.delete || self.delete == DeleteOption::SoftWithoutQueries {
+                break;
+            }
+        }
+        tokens
+    }
 }
 
 impl ToTokens for ListForFn<'_> {

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -213,6 +213,73 @@ impl ToTokens for EsRepo<'_> {
 
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
+        // The `repo.scoped(scope)` bound view: a borrowed view of the repo
+        // with the scope captured once, exposing every read fn without the
+        // per-call scope argument (each method delegates to the scope-arg
+        // fn). Only generated for scoped repos.
+        let (scoped_fn, scoped_view) = if let Some(info) = scope::ScopeInfo::from_opts(self.opts) {
+            let scoped_ident = self.opts.scoped_view_ident();
+            let scope_ty = &info.scope_ty;
+            let repo_ident = self.repo;
+
+            let mut scoped_generics = self.generics.clone();
+            scoped_generics
+                .params
+                .insert(0, syn::parse_quote!('scoped_repo));
+            let scoped_struct_where = scoped_generics.where_clause.clone();
+            let (scoped_impl_generics, scoped_ty_generics, scoped_where) =
+                scoped_generics.split_for_impl();
+
+            let find_by_delegates = self.find_by_fns.iter().map(|f| f.scoped_delegates());
+            let find_all_delegates = self.find_all_fn.scoped_delegates();
+            let list_by_delegates = self.list_by_fns.iter().map(|f| f.scoped_delegates());
+            let list_for_delegates = self.list_for_fns.iter().map(|f| f.scoped_delegates());
+            let list_for_filters_delegates = list_for_filters.scoped_delegates();
+
+            let scoped_doc = format!(
+                "Bound view of [`{repo_ident}`] with a [`{scope_ty}`] captured once: every \
+                 read method delegates to the corresponding scope-argument fn with the bound \
+                 scope. Obtained via [`{repo_ident}::scoped`]. Borrows the repo, so it is \
+                 naturally request-scoped."
+            );
+
+            (
+                quote! {
+                    pub fn scoped<'scoped_repo>(
+                        &'scoped_repo self,
+                        scope: impl Into<#scope_ty>,
+                    ) -> #scoped_ident #scoped_ty_generics {
+                        #scoped_ident {
+                            repo: self,
+                            scope: scope.into(),
+                        }
+                    }
+                },
+                quote! {
+                    #[doc = #scoped_doc]
+                    pub struct #scoped_ident #scoped_generics #scoped_struct_where {
+                        repo: &'scoped_repo #repo_ident #ty_generics,
+                        scope: #scope_ty,
+                    }
+
+                    impl #scoped_impl_generics #scoped_ident #scoped_ty_generics #scoped_where {
+                        #[inline(always)]
+                        pub fn scope(&self) -> #scope_ty {
+                            self.scope
+                        }
+
+                        #(#find_by_delegates)*
+                        #find_all_delegates
+                        #(#list_by_delegates)*
+                        #(#list_for_delegates)*
+                        #list_for_filters_delegates
+                    }
+                },
+            )
+        } else {
+            (quote! {}, quote! {})
+        };
+
         // If the event type has Forgettable fields, the repo must enable
         // `forgettable` — otherwise the payload machinery is never generated
         // and forgettable values would be lost. The repo cannot see the
@@ -264,6 +331,8 @@ impl ToTokens for EsRepo<'_> {
 
             #scope_type
 
+            #scoped_view
+
             #list_for_filters_struct
             #sort_by
 
@@ -272,6 +341,8 @@ impl ToTokens for EsRepo<'_> {
                 pub fn pool(&self) -> &es_entity::db::Pool {
                     &self.#pool_field
                 }
+
+                #scoped_fn
 
                 #map_constraint_fn
                 #begin
@@ -413,6 +484,62 @@ mod tests {
         // writes stay unscoped (custody principle)
         assert!(tokens.contains("fn create_in_op < OP > (& self , op : & mut OP , new_entity"));
         assert!(tokens.contains("fn update_in_op < OP > (& self , op : & mut OP , entity"));
+    }
+
+    #[test]
+    fn scoped_repo_generates_bound_view() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[es_repo(
+                entity = "User",
+                columns(partner_id(ty = "PartnerId", scope), name(ty = "String"))
+            )]
+            struct Users {
+                pool: sqlx::PgPool,
+            }
+        };
+        let tokens = derive(input)
+            .expect("scoped repo should derive")
+            .to_string();
+        // the bound view type + constructor
+        assert!(tokens.contains("pub struct ScopedUsers"));
+        assert!(tokens.contains("pub fn scoped <"));
+        // view methods take no scope argument and forward the bound scope
+        assert!(tokens.contains("self . repo . find_by_id (self . scope"));
+        assert!(tokens.contains("self . repo . maybe_find_by_id_in_op (op , self . scope"));
+        assert!(tokens.contains("self . repo . find_all (self . scope"));
+        assert!(tokens.contains("self . repo . list_by_created_at (self . scope"));
+        assert!(tokens.contains("self . repo . list_for_filters (self . scope"));
+    }
+
+    #[test]
+    fn unscoped_repo_has_no_bound_view() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[es_repo(entity = "User", columns(name(ty = "String")))]
+            struct Users {
+                pool: sqlx::PgPool,
+            }
+        };
+        let tokens = derive(input).unwrap().to_string();
+        assert!(!tokens.contains("ScopedUsers"));
+        assert!(!tokens.contains("pub fn scoped <"));
+    }
+
+    #[test]
+    fn scoped_repo_with_generics_generates_bound_view() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[es_repo(
+                entity = "User",
+                columns(partner_id(ty = "PartnerId", scope))
+            )]
+            struct Users<E> {
+                pool: sqlx::PgPool,
+                _phantom: std::marker::PhantomData<E>,
+            }
+        };
+        let tokens = derive(input)
+            .expect("generic scoped repo should derive")
+            .to_string();
+        assert!(tokens.contains("pub struct ScopedUsers < 'scoped_repo , E >"));
     }
 
     #[test]

--- a/es-entity-macros/src/repo/options/mod.rs
+++ b/es-entity-macros/src/repo/options/mod.rs
@@ -472,6 +472,12 @@ impl RepositoryOptions {
         syn::Ident::new(&format!("{}Scope", self.entity_ident), Span::call_site())
     }
 
+    /// The generated bound-view ident (`Scoped{Repo}`), repo-named because it
+    /// is a view of the repository itself (returned by `repo.scoped(scope)`).
+    pub fn scoped_view_ident(&self) -> syn::Ident {
+        syn::Ident::new(&format!("Scoped{}", self.ident), Span::call_site())
+    }
+
     pub fn query_fn_get_op(nested: bool) -> proc_macro2::TokenStream {
         if nested {
             quote! {

--- a/tests/scoped_repo.rs
+++ b/tests/scoped_repo.rs
@@ -370,3 +370,99 @@ async fn scoped_list_query_plan_uses_composite_index() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// The `repo.scoped(scope)` bound view captures the scope once and exposes
+/// every read fn without the per-call scope argument, delegating to the
+/// scope-argument fns.
+#[tokio::test]
+async fn scoped_view_delegates() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let contacts = Contacts::new(pool);
+
+    let partner_a = PartnerId::new();
+    let partner_b = PartnerId::new();
+    let ids_a = seed_contacts(
+        &contacts,
+        partner_a,
+        &[("v1", "active"), ("v2", "inactive")],
+    )
+    .await?;
+    let ids_b = seed_contacts(&contacts, partner_b, &[("v3", "active")]).await?;
+
+    let view = contacts.scoped(partner_a);
+    assert!(matches!(view.scope(), ContactScope::Only(p) if p == partner_a));
+
+    // point reads — no scope argument at the call sites
+    let contact = view.find_by_id(ids_a[0]).await?;
+    assert_eq!(contact.partner_id, partner_a);
+    view.find_by_email(&contact.email).await?;
+    assert!(view.maybe_find_by_id(ids_b[0]).await?.is_none());
+    assert!(matches!(
+        view.find_by_id(ids_b[0]).await,
+        Err(ContactFindError::NotFound { .. })
+    ));
+
+    // batch + lists
+    let all_ids: Vec<ContactId> = ids_a.iter().chain(ids_b.iter()).copied().collect();
+    let found = view.find_all::<Contact>(&all_ids).await?;
+    assert_eq!(found.len(), 2);
+
+    let page = view
+        .list_by_created_at(
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert_eq!(page.entities.len(), 2);
+    assert!(page.entities.iter().all(|c| c.partner_id == partner_a));
+
+    let ret = view
+        .list_for_status_by_created_at(
+            "active",
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert_eq!(ret.entities.len(), 1);
+
+    let ret = view
+        .list_for_filters(
+            ContactFilters {
+                status: Some("inactive".to_string()),
+            },
+            Sort {
+                by: ContactSortBy::CreatedAt,
+                direction: ListDirection::Descending,
+            },
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+        )
+        .await?;
+    assert_eq!(ret.entities.len(), 1);
+    assert_eq!(ret.entities[0].partner_id, partner_a);
+
+    // `_in_op` variants through the view
+    let mut op = contacts.begin_op().await?;
+    view.find_by_id_in_op(&mut op, ids_a[0]).await?;
+    assert!(
+        view.maybe_find_by_id_in_op(&mut op, ids_b[0])
+            .await?
+            .is_none()
+    );
+    op.commit().await?;
+
+    // an All-bound view reads across scopes
+    let all_view = contacts.scoped(ContactScope::All);
+    all_view.find_by_id(ids_b[0]).await?;
+    assert_eq!(all_view.find_all::<Contact>(&all_ids).await?.len(), 3);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fast-follow to #166, completing the ratified scoped-repositories design (drua `es-entity-dev/scoped-repositories-decisions.md`, item Q8/G1): scoped repos now also generate a **bound view** so read-heavy call sites capture the scope once instead of threading it into every call.

```rust
let customers = self.customers.scoped(sub.scope());   // ScopedCustomers<'_>

customers.find_by_id(id).await?;                      // no per-call scope arg
customers.maybe_find_by_email(email).await?;
customers.list_by_created_at(args, direction).await?;
customers.find_by_id_in_op(&mut op, id).await?;       // _in_op variants too
customers.scope();                                    // the bound CustomerScope
```

## What changed

- **Generated view type**: `pub struct Scoped{Repo}<'scoped_repo, ..repo generics..>` holding `&'scoped_repo Repo` + the bound `{Entity}Scope`; constructed via a generated `repo.scoped(impl Into<{Entity}Scope>)`. Repo-named (it is a view of the repository), scope enum stays entity-named per #166.
- **Complete read surface**: every scope-argument fn from #166 gets a delegating method without the scope argument — `find_by_*`/`maybe_find_by_*`, `find_all`, `list_by_*`, `list_for_*`, `list_for_filters_by_*`, `list_for_filters`, including all `_in_op` and `_include_deleted` variants. **Zero new SQL** — each delegate forwards `self.scope` (Copy) to the corresponding scope-arg fn, so semantics are identical by construction.
- **Naturally request-scoped**: the view *borrows* the repo, so a bound all-access or tenant view cannot be stored beyond the repo borrow — the friction the decision record wanted against views quietly outliving their request. No `Clone`/`Copy` on the view.
- **Unscoped repos unaffected**: no view, no `scoped()` fn, byte-identical output (all pre-existing fixtures pass unchanged).
- Implementation: each read emitter gains a `scoped_delegates()` generator mirroring its fn-naming loops; `repo/mod.rs` assembles the struct + impl (repo generics handled via a prepended `'scoped_repo` lifetime — generic repos covered by test).

## Verification

- 107 macro unit tests: view smoke test (delegates forward `self.scope`, no scope arg on view methods), generic-repo view generation, and no-view-on-unscoped-repo guard
- 141 integration tests green on live PG — new `scoped_view_delegates` exercises every delegate family (point reads own/foreign, `find_all` foreign-id dropping, `list_by`, `list_for`, `list_for_filters`, `_in_op` through the view, `scope()` getter, and an `All`-bound view)
- `cargo clippy --workspace --all-features -- -D warnings` clean; `nix flake check` passes
- Book: new "The bound view" section in the Scoped Repositories chapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Macro-only delegation to existing scoped reads with no SQL or write-path changes; unscoped repos unchanged.
> 
> **Overview**
> Scoped repositories now generate a **bound view** via `repo.scoped(scope)` so multi-read request handlers can capture tenant scope once instead of passing it on every read.
> 
> The macro emits `Scoped{Repo}` (repo-named) holding a borrow of the repo plus the bound `{Entity}Scope`, with delegating methods for the full scoped read surface—`find_by_*`, `find_all`, `list_by_*`, `list_for_*`, `list_for_filters*`, including `_in_op` and soft-delete variants—each forwarding `self.scope` to the existing scope-argument APIs. **No new SQL**; semantics match the per-call scope fns by construction.
> 
> Unscoped repos get no `scoped()` or view type. The book adds a **The bound view** section; integration coverage exercises delegates end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc1c34aef41fa9b0863784d1dc7b92b6c608a136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->