### PR TITLE
perf(macros): gate sargable multi-filter matrix behind opt-in

### DIFF
--- a/book/src/repo-list-for-filters.md
+++ b/book/src/repo-list-for-filters.md
@@ -74,6 +74,26 @@ SELECT id FROM user_documents
   ORDER BY id ASC LIMIT $3
 ```
 
+#### Compile-time cost — `sargable_filters` is opt-in
+
+The specialized matrix emits one `sqlx::query!` per filter combination × cursor state × direction. For an entity with N `list_for` columns that grows as 2^N (3^N with optional columns), and across many repos this can add thousands of compile-time-checked queries — a large release-codegen tax. The matrix is therefore **off by default** and the catch-all COALESCE query above is used for the multi-filter case.
+
+To opt in per repo (only for entities whose multi-filter list queries are hot paths that benefit from index usage), set `sargable_filters` on the `#[es_repo(...)]` attribute:
+
+```rust,ignore
+#[es_repo(
+    entity = "Transfer",
+    columns(
+        account_id(ty = "AccountId", list_for(by(created_at))),
+        status(ty = "String", list_for(by(created_at))),
+    ),
+    sargable_filters,
+)]
+pub struct Transfers { pool: PgPool }
+```
+
+Single-filter (`list_for_{col}_by_{sort}`) and no-filter (`list_by_{sort}`) queries are always sargable and cheap (O(N)), so they are generated regardless of this flag. Only the multi-filter combination matrix is gated.
+
 ### A Dispatch Function
 
 The `list_for_filters` function matches on the sort column and intelligently delegates to the most efficient underlying function:

--- a/es-entity-macros/src/repo/list_for_filters_fn.rs
+++ b/es-entity-macros/src/repo/list_for_filters_fn.rs
@@ -176,6 +176,7 @@ pub struct ListForFiltersFn<'a> {
     post_hydrate_error: Option<&'a syn::Type>,
     forgettable_table_name: Option<&'a str>,
     scope: Option<ScopeInfo<'a>>,
+    sargable_filters: bool,
     #[cfg(feature = "instrument")]
     repo_name_snake: String,
 }
@@ -203,6 +204,7 @@ impl<'a> ListForFiltersFn<'a> {
             post_hydrate_error: opts.post_hydrate_hook.as_ref().map(|h| &h.error),
             forgettable_table_name: opts.forgettable_table_name(),
             scope: ScopeInfo::from_opts(opts),
+            sargable_filters: opts.sargable_filters(),
             #[cfg(feature = "instrument")]
             repo_name_snake: opts.repo_name_snake_case(),
         }
@@ -346,6 +348,9 @@ impl<'a> ListForFiltersFn<'a> {
     /// everything else falls back to the catch-all COALESCE query
     /// (correctness preserved, just not sargable).
     fn is_specialized_combo(&self, combo: &[FilterState]) -> bool {
+        if !self.sargable_filters {
+            return false;
+        }
         let n = self.for_columns.len();
         if n <= 4 {
             return true;
@@ -1131,6 +1136,7 @@ mod tests {
             post_hydrate_error: None,
             forgettable_table_name: None,
             scope: None,
+            sargable_filters: true,
             #[cfg(feature = "instrument")]
             repo_name_snake: "test_repo".to_string(),
         };
@@ -1452,6 +1458,7 @@ mod tests {
             post_hydrate_error: None,
             forgettable_table_name: None,
             scope: None,
+            sargable_filters: true,
             #[cfg(feature = "instrument")]
             repo_name_snake: "test_repo".to_string(),
         };
@@ -1521,6 +1528,7 @@ mod tests {
             post_hydrate_error: None,
             forgettable_table_name: None,
             scope: None,
+            sargable_filters: true,
             #[cfg(feature = "instrument")]
             repo_name_snake: "test_repo".to_string(),
         };
@@ -1607,6 +1615,7 @@ mod tests {
             post_hydrate_error: None,
             forgettable_table_name: None,
             scope: None,
+            sargable_filters: true,
             #[cfg(feature = "instrument")]
             repo_name_snake: "test_repo".to_string(),
         };
@@ -1691,6 +1700,7 @@ mod tests {
             post_hydrate_error: None,
             forgettable_table_name: None,
             scope: None,
+            sargable_filters: true,
             #[cfg(feature = "instrument")]
             repo_name_snake: "test_repo".to_string(),
         };
@@ -1781,6 +1791,7 @@ mod tests {
             post_hydrate_error: None,
             forgettable_table_name: None,
             scope: None,
+            sargable_filters: true,
             #[cfg(feature = "instrument")]
             repo_name_snake: "test_repo".to_string(),
         };
@@ -1806,6 +1817,89 @@ mod tests {
         assert!(
             token_str.contains("COALESCE(a = $1, $1 IS NULL)"),
             "COALESCE fallback must remain for uncapped combinations"
+        );
+    }
+
+    /// With `sargable_filters` off (the default), the multi-filter cartesian
+    /// matrix is suppressed: only the catch-all COALESCE query is emitted,
+    /// regardless of filter-column count. This is what keeps downstream
+    /// compile times bounded (the fix for the lana-bank +2054-query regression).
+    #[test]
+    fn list_for_filters_sargable_off_emits_catch_all_only() {
+        let entity = Ident::new("Order", Span::call_site());
+        let query_error = syn::Ident::new("OrderQueryError", Span::call_site());
+        let id = syn::Ident::new("OrderId", proc_macro2::Span::call_site());
+        let cursor_mod = Ident::new("cursor_mod", Span::call_site());
+
+        let id_column = Column::for_id(syn::parse_str("OrderId").unwrap());
+        let id_ident = syn::Ident::new("id", proc_macro2::Span::call_site());
+        let customer_id_column = Column::new_list_for(
+            syn::Ident::new("customer_id", proc_macro2::Span::call_site()),
+            syn::parse_str("CustomerId").unwrap(),
+            vec![id_ident.clone()],
+        );
+        let status_column = Column::new_list_for(
+            syn::Ident::new("status", proc_macro2::Span::call_site()),
+            syn::parse_str("OrderStatus").unwrap(),
+            vec![id_ident],
+        );
+
+        let for_columns = vec![&customer_id_column, &status_column];
+        let by_columns = vec![&id_column];
+        let id_cursor = CursorStruct {
+            column: &id_column,
+            id: &id,
+            entity: &entity,
+            cursor_mod: &cursor_mod,
+        };
+        let combo_cursor = ComboCursor::new_test(&entity, vec![id_cursor]);
+
+        let build = |sargable: bool| -> String {
+            let fn_ = ListForFiltersFn {
+                filters_struct: FiltersStruct::new_test(&entity, for_columns.clone()),
+                entity: &entity,
+                query_error: query_error.clone(),
+                for_columns: for_columns.clone(),
+                by_columns: by_columns.clone(),
+                cursor: &combo_cursor,
+                delete: DeleteOption::No,
+                cursor_mod: cursor_mod.clone(),
+                table_name: "orders",
+                ignore_prefix: None,
+                id: &id,
+                any_nested: false,
+                post_hydrate_error: None,
+                forgettable_table_name: None,
+                scope: None,
+                sargable_filters: sargable,
+                #[cfg(feature = "instrument")]
+                repo_name_snake: "test_repo".to_string(),
+            };
+            let mut tokens = TokenStream::new();
+            fn_.to_tokens(&mut tokens);
+            tokens.to_string()
+        };
+
+        let off = build(false);
+        let on = build(true);
+
+        let count = |s: &str| s.matches("es_query").count();
+        let off_count = count(&off);
+        let on_count = count(&on);
+
+        // Opt-in specializes all 2^2 = 4 filter combos (no COALESCE);
+        // default-off collapses to a single catch-all COALESCE query.
+        assert!(
+            on_count > off_count,
+            "opt-in should emit more dedicated queries: on={on_count} off={off_count}"
+        );
+        assert!(
+            off.contains("COALESCE"),
+            "default-off must emit the catch-all COALESCE query"
+        );
+        assert!(
+            !on.contains("COALESCE"),
+            "opt-in (all combos specialized) should not need the COALESCE fallback"
         );
     }
 }

--- a/es-entity-macros/src/repo/options/mod.rs
+++ b/es-entity-macros/src/repo/options/mod.rs
@@ -241,6 +241,14 @@ pub struct RepositoryOptions {
     forgettable: bool,
     #[darling(default, rename = "forgettable_tbl")]
     forgettable_table_name: Option<String>,
+
+    /// Opt into the sargable per-state/per-combination SQL matrix for multi-filter
+    /// list queries. Defaults to `false`: only the catch-all `COALESCE` query is
+    /// emitted, keeping compile times low. Set `sargable_filters` to emit a
+    /// dedicated indexed query per filter combination (the #162 feature) for
+    /// repos whose multi-filter list queries are hot paths.
+    #[darling(default)]
+    sargable_filters: Option<bool>,
 }
 
 impl RepositoryOptions {
@@ -324,6 +332,10 @@ impl RepositoryOptions {
         self.events_table_name
             .as_ref()
             .expect("Events table name is not set")
+    }
+
+    pub fn sargable_filters(&self) -> bool {
+        self.sargable_filters.unwrap_or(false)
     }
 
     pub fn cursor_mod(&self) -> syn::Ident {

--- a/tests/sargable_list_queries.rs
+++ b/tests/sargable_list_queries.rs
@@ -18,7 +18,8 @@ use es_entity::*;
         status(ty = "String", list_for(by(created_at))),
         reference(ty = "Option<String>", list_for),
         score(ty = "Option<i32>", list_by)
-    )
+    ),
+    sargable_filters
 )]
 pub struct Transfers {
     pool: PgPool,


### PR DESCRIPTION
## Problem

The sargable per-state/per-combination SQL matrix added in #162 emits one `sqlx::query!` per **filter combination × cursor state × direction**. For an entity with N `list_for` columns that grows as 2^N (3^N with optional columns), and across many repos this exploded downstream compile times.

### Measured impact on lana-bank (the `build-rc-release` CI job)

`cc9f625fc` (the `es-entity` 0.11.8 → 0.11.9 bump) is the only code change between CI build 67 (last fast) and build 68 (first slow):

| builds | wall time |
|---|---|
| 49–67 (es-entity 0.11.8) | **34–45 min** (median ~37) |
| 68+ (es-entity 0.11.9) | **49–59 min** (median ~54) |

The bump is a pure dep bump + regenerated `.sqlx` cache (no `.rs` changes in lana-bank), and it took lana-bank's offline sqlx query cache from **1319 → 3373 descriptors (+2054, ×2.5)**. With the deps layer fetched from cache (apples-to-apples), the `lana-cli-release` release compile phase went **32m44s → 48–51 min**. Each new descriptor is a `sqlx::query!` that must be compile-time-checked and LLVM-optimized in release — that is the ~16 min.

## Fix

Make the **multi-filter** specialization matrix opt-in via a new `#[es_repo(..., sargable_filters)]` attribute (default off). With it off, `list_for_filters` emits only the existing catch-all `COALESCE` query (pre-#162 behavior).

Importantly, the cheap queries stay sargable regardless of the flag:
- **no-filter** (`list_by_{sort}`) — always sargable
- **single-filter** (`list_for_{col}_by_{sort}`) — always sargable, O(N)

Only the multi-filter combination matrix (the 2^N explosion) is gated. So repos opt in only when their multi-filter list queries are genuinely hot paths:

```rust
#[es_repo(
    entity = "Transfer",
    columns(
        account_id(ty = "AccountId", list_for(by(created_at))),
        status(ty = "String", list_for(by(created_at))),
    ),
    sargable_filters,
)]
pub struct Transfers { pool: PgPool }
```

## Changes

- `options/mod.rs`: add `sargable_filters: Option<bool>` (default false) + accessor
- `list_for_filters_fn.rs`: short-circuit `is_specialized_combo` when disabled
- existing specialization tests opt in (`sargable_filters: true`)
- new test proving default-off emits the catch-all only (fewer `es_query` calls, `COALESCE` present) while opt-in emits the full specialized matrix (no `COALESCE`)
- `book/src/repo-list-for-filters.md`: document the attribute + the compile-time tradeoff

## Verification

- 96 macro unit tests pass (`cargo test -p es-entity-macros --lib`)
- `cargo build -p es-entity --features event-context,tracing-context,instrument` clean
- Integration tests (`tests/sargable_list_queries.rs`) opt in to keep exercising the matrix

### Predicted downstream impact

A conservative classifier flags ≥1010 of the 3373 lana-bank descriptors as multi-predicate (definitely removed); in practice the gate removes the entire multi-filter matrix, bringing the descriptor count back toward the 1319 baseline and recovering most of the ~16 min. (The single-filter and no-filter queries that 0.11.9 added for new columns remain, so the count won't be exactly 1319.

## Notes

- This is a behavior change: consumers that relied on the matrix being on by default will silently fall back to the catch-all  for multi-filter queries. Correctness is preserved (same results); only index-sargability for multi-filter queries is lost unless they opt in. Given the compile-time tax, opt-in is the safer default.
- Versioning handled by the repo's release CI.
EOF
)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-off changes runtime SQL for multi-filter `list_for_filters` (COALESCE vs specialized plans)—correctness preserved but index usage may regress until consumers opt in. Macro/API default is a silent behavior shift for anyone who depended on the matrix without setting the flag.
> 
> **Overview**
> **Multi-filter `list_for_filters` codegen is now opt-in** via `sargable_filters` on `#[es_repo(...)]` (default **off**). Without it, only the catch-all `COALESCE` SQL is emitted for two-or-more active filters—same results as before #162’s per-combination matrix, but far fewer `sqlx::query!` descriptors at compile time.
> 
> **No-filter** (`list_by_*`) and **single-filter** (`list_for_*_by_*`) sargable queries are still generated unconditionally; only the exponential multi-filter combination matrix is gated.
> 
> Repos that need index-friendly multi-filter lists (e.g. hot UI table paths) set `sargable_filters` on the repo attribute; the book documents the compile-time tradeoff. Macro tests and `tests/sargable_list_queries` opt in so the full matrix stays covered in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d319dd0b63814386681cfefb2aed0c07e9ea61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->