### PR TITLE
chore(deps): bump event-listener to 5.4.2 to patch RUSTSEC-2026-0221

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,15 +328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,11 +687,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
## Summary
`cargo audit` flagged an unsoundness advisory in a transitive dep (via sqlx):

- **event-listener 5.4.1 → 5.4.2**
  - RUSTSEC-2026-0221 — unsound `!Send` tags crossing thread boundaries via `StackSlot`

The rustls-webpki advisories (RUSTSEC-2026-0104 / -0098 / -0099 / -0049) were already resolved on main by #176.

`cargo audit` reports no vulnerabilities after this change.

## Test plan
- [x] `cargo audit` clean
- [x] `cargo test -p es-entity-macros --lib` / `cargo test --lib` pass
- [ ] CI (integration tests against Postgres)