### PR TITLE
fix: remove panic paths from event persistence and last_persisted

### DIFF
--- a/es-entity-macros/src/repo/persist_events_batch_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_batch_fn.rs
@@ -149,6 +149,10 @@ impl ToTokens for PersistEventsBatchFn<'_> {
                     n_events_map.insert(id.clone(), n_events);
                 }
 
+                if all_ids.is_empty() {
+                    return Ok(n_events_map);
+                }
+
                 let rows = sqlx::query(#query)
                         .bind(now)
                         .bind(&all_ids)
@@ -161,7 +165,10 @@ impl ToTokens for PersistEventsBatchFn<'_> {
 
                 #forgettable_insert
 
-                let recorded_at = rows[0].try_get("recorded_at").expect("no recorded at");
+                let recorded_at = rows
+                    .first()
+                    .ok_or(sqlx::Error::RowNotFound)?
+                    .try_get("recorded_at")?;
 
                 for item in all_events.iter_mut() {
                     let events: &mut es_entity::EntityEvents<#event_type> = item.borrow_mut();
@@ -232,6 +239,10 @@ mod tests {
                     n_events_map.insert(id.clone(), n_events);
                 }
 
+                if all_ids.is_empty() {
+                    return Ok(n_events_map);
+                }
+
                 let rows = sqlx::query("INSERT INTO entity_events (id, recorded_at, sequence, event_type, event, context) SELECT unnested.id, COALESCE($1, NOW()), unnested.sequence, unnested.event_type, unnested.event, unnested.context FROM UNNEST($2, $3::INT[], $4::TEXT[], $5::JSONB[], $6::JSONB[]) AS unnested(id, sequence, event_type, event, context) RETURNING recorded_at")
                         .bind(now)
                         .bind(&all_ids)
@@ -246,7 +257,10 @@ mod tests {
                         .fetch_all(op.as_executor())
                         .await?;
 
-                let recorded_at = rows[0].try_get("recorded_at").expect("no recorded at");
+                let recorded_at = rows
+                    .first()
+                    .ok_or(sqlx::Error::RowNotFound)?
+                    .try_get("recorded_at")?;
 
                 for item in all_events.iter_mut() {
                     let events: &mut es_entity::EntityEvents<EntityEvent> = item.borrow_mut();
@@ -309,6 +323,10 @@ mod tests {
                     n_events_map.insert(id.clone(), n_events);
                 }
 
+                if all_ids.is_empty() {
+                    return Ok(n_events_map);
+                }
+
                 let rows = sqlx::query("INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, COALESCE($1, NOW()), unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($2, $3::INT[], $4::TEXT[], $5::JSONB[]) AS unnested(id, sequence, event_type, event) RETURNING recorded_at")
                         .bind(now)
                         .bind(&all_ids)
@@ -318,7 +336,10 @@ mod tests {
                         .fetch_all(op.as_executor())
                         .await?;
 
-                let recorded_at = rows[0].try_get("recorded_at").expect("no recorded at");
+                let recorded_at = rows
+                    .first()
+                    .ok_or(sqlx::Error::RowNotFound)?
+                    .try_get("recorded_at")?;
 
                 for item in all_events.iter_mut() {
                     let events: &mut es_entity::EntityEvents<EntityEvent> = item.borrow_mut();

--- a/es-entity-macros/src/repo/persist_events_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_fn.rs
@@ -107,6 +107,9 @@ impl ToTokens for PersistEventsFn<'_> {
                 OP: es_entity::AtomicOperation,
             {
                 let id = events.id();
+                if !events.any_new() {
+                    return Ok(0);
+                }
                 let offset = events.len_persisted();
                 let events_types = events.new_event_types();
                 let serialized_events = events.serialize_new_events();
@@ -124,7 +127,10 @@ impl ToTokens for PersistEventsFn<'_> {
                         #ctx_arg
                     ).fetch_all(op.as_executor()).await?;
 
-                let recorded_at = rows[0].recorded_at;
+                let recorded_at = rows
+                    .first()
+                    .map(|row| row.recorded_at)
+                    .ok_or(sqlx::Error::RowNotFound)?;
                 let n_events = events.mark_new_events_persisted_at(recorded_at);
 
                 Ok(n_events)
@@ -175,6 +181,9 @@ mod tests {
                 OP: es_entity::AtomicOperation,
             {
                 let id = events.id();
+                if !events.any_new() {
+                    return Ok(0);
+                }
                 let offset = events.len_persisted();
                 let events_types = events.new_event_types();
                 let serialized_events = events.serialize_new_events();
@@ -191,7 +200,10 @@ mod tests {
                         contexts.as_deref() as Option<&[es_entity::ContextData]>,
                     ).fetch_all(op.as_executor()).await?;
 
-                let recorded_at = rows[0].recorded_at;
+                let recorded_at = rows
+                    .first()
+                    .map(|row| row.recorded_at)
+                    .ok_or(sqlx::Error::RowNotFound)?;
                 let n_events = events.mark_new_events_persisted_at(recorded_at);
 
                 Ok(n_events)
@@ -239,6 +251,9 @@ mod tests {
                 OP: es_entity::AtomicOperation,
             {
                 let id = events.id();
+                if !events.any_new() {
+                    return Ok(0);
+                }
                 let offset = events.len_persisted();
                 let events_types = events.new_event_types();
                 let serialized_events = events.serialize_new_events();
@@ -253,7 +268,10 @@ mod tests {
                         &serialized_events,
                     ).fetch_all(op.as_executor()).await?;
 
-                let recorded_at = rows[0].recorded_at;
+                let recorded_at = rows
+                    .first()
+                    .map(|row| row.recorded_at)
+                    .ok_or(sqlx::Error::RowNotFound)?;
                 let n_events = events.mark_new_events_persisted_at(recorded_at);
 
                 Ok(n_events)

--- a/src/events.rs
+++ b/src/events.rs
@@ -169,8 +169,11 @@ where
     }
 
     /// Returns an iterator over the last `n` persisted events
+    ///
+    /// If fewer than `n` events have been persisted, all persisted events are
+    /// returned instead of panicking.
     pub fn last_persisted(&self, n: usize) -> LastPersisted<'_, T> {
-        let start = self.persisted_events.len() - n;
+        let start = self.persisted_events.len().saturating_sub(n);
         self.persisted_events[start..].iter()
     }
 
@@ -465,5 +468,29 @@ mod tests {
             EntityEvents::load_n(generic_events, 2).expect("Could not load");
         assert!(!more);
         assert_eq!(entity.len(), 2);
+    }
+
+    #[test]
+    fn last_persisted_does_not_panic_when_n_exceeds_len() {
+        let generic_events = vec![GenericEvent {
+            entity_id: Uuid::parse_str("00000000-0000-0000-0000-000000000004").unwrap(),
+            sequence: 1,
+            event: serde_json::to_value(DummyEntityEvent::Created("dummy".to_owned()))
+                .expect("Could not serialize"),
+            context: None,
+            recorded_at: chrono::Utc::now(),
+            forgettable_payload: None,
+        }];
+        let entity: DummyEntity = EntityEvents::load_first(generic_events)
+            .expect("Could not load")
+            .expect("No entity found");
+        let events = entity.events();
+
+        // n == len works
+        assert_eq!(events.last_persisted(1).count(), 1);
+        // n > len clamps to all persisted events instead of underflowing
+        assert_eq!(events.last_persisted(10).count(), 1);
+        // n == 0 yields nothing
+        assert_eq!(events.last_persisted(0).count(), 0);
     }
 }


### PR DESCRIPTION
## Summary
Removes reachable panics from public API surfaces (availability hardening):

- **`EntityEvents::last_persisted(n)`** panicked via subtraction underflow when `n > persisted_events.len()`. Now clamps with `saturating_sub` and returns all persisted events.
- **`persist_events`** panicked on `rows[0]` when called with zero new events (the `INSERT ... FROM UNNEST(...)` returns zero rows). Now returns `Ok(0)` early; the first-row access is additionally made fallible (`sqlx::Error::RowNotFound`) as defense in depth.
- **`persist_events_batch`** same `rows[0]` panic when no entity in the batch had new events — the INSERT is now skipped entirely; `try_get(...).expect("no recorded at")` is replaced with `?` propagation.

The generated `update`/`update_all`/`forget` callers already guarded these paths with `any_new()`, but the trait methods are public and could be driven into a panic (process crash) by direct callers.

## Test plan
- [x] New unit test: `last_persisted_does_not_panic_when_n_exceeds_len`
- [x] Macro token-stream tests updated for both persist fns (`cargo test -p es-entity-macros --lib`)
- [x] `cargo test --lib`, `cargo fmt --check` pass
- [ ] CI (integration tests against Postgres)