### PR TITLE
docs: warn about PII/user-enumeration risk of ConstraintViolation values

### DIFF
--- a/book/src/repo-errors.md
+++ b/book/src/repo-errors.md
@@ -33,6 +33,8 @@ pub enum UserCreateError {
 
 When a `create` or `create_all` operation violates a unique constraint, the error is returned as `ConstraintViolation` rather than a raw `Sqlx` error. The `column` field identifies which column caused the violation and the `value` field contains the conflicting value extracted from the PostgreSQL error detail.
 
+> **Security note:** `value` (and the `duplicate_value()` helper) contains attacker-influenced input that was rejected by a unique constraint and is frequently PII (e.g. an email address). Do not propagate it to untrusted API clients — a caller can probe which values already exist (user enumeration) — and be aware it may end up in logs via the error's `Display`/`Debug` output. At trust boundaries, prefer the boolean helpers `was_duplicate()` / `was_duplicate_by(column)` and map the error to a neutral client-facing message.
+
 ```rust,ignore
 let result = users.create(new_user).await;
 match result {

--- a/es-entity-macros/src/repo/error_types.rs
+++ b/es-entity-macros/src/repo/error_types.rs
@@ -377,6 +377,11 @@ impl<'a> ErrorTypes<'a> {
             #[derive(Debug)]
             pub enum #create_error {
                 Sqlx(sqlx::Error),
+                /// **Security note:** `value` is extracted from the PostgreSQL error
+                /// detail and may contain PII (e.g. an email address). Exposing it to
+                /// untrusted API clients enables user enumeration and may place PII in
+                /// logs — prefer the `was_duplicate` / `was_duplicate_by` helpers at
+                /// trust boundaries.
                 ConstraintViolation { column: Option<#column_enum>, value: Option<String>, inner: sqlx::Error },
                 ConcurrentModification,
                 HydrationError(es_entity::EntityHydrationError),
@@ -448,6 +453,10 @@ impl<'a> ErrorTypes<'a> {
                     matches!(self, Self::ConstraintViolation { column: Some(c), .. } if *c == column)
                 }
 
+                /// Returns the conflicting value extracted from the database error.
+                ///
+                /// **Security note:** may contain PII and enables user enumeration if
+                /// returned to untrusted clients. Handle with care.
                 pub fn duplicate_value(&self) -> Option<&str> {
                     match self {
                         Self::ConstraintViolation { value: Some(v), .. } => Some(v.as_str()),
@@ -628,6 +637,11 @@ impl<'a> ErrorTypes<'a> {
             #[derive(Debug)]
             pub enum #modify_error {
                 Sqlx(sqlx::Error),
+                /// **Security note:** `value` is extracted from the PostgreSQL error
+                /// detail and may contain PII (e.g. an email address). Exposing it to
+                /// untrusted API clients enables user enumeration and may place PII in
+                /// logs — prefer the `was_duplicate` / `was_duplicate_by` helpers at
+                /// trust boundaries.
                 ConstraintViolation { column: Option<#column_enum>, value: Option<String>, inner: sqlx::Error },
                 ConcurrentModification,
                 #pp_variant
@@ -687,6 +701,10 @@ impl<'a> ErrorTypes<'a> {
                     matches!(self, Self::ConstraintViolation { column: Some(c), .. } if *c == column)
                 }
 
+                /// Returns the conflicting value extracted from the database error.
+                ///
+                /// **Security note:** may contain PII and enables user enumeration if
+                /// returned to untrusted clients. Handle with care.
                 pub fn duplicate_value(&self) -> Option<&str> {
                     match self {
                         Self::ConstraintViolation { value: Some(v), .. } => Some(v.as_str()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,11 @@ impl From<(&'static str, &'static str)> for CursorDestructureError {
 /// `Key (column)=(value) already exists.`
 ///
 /// Returns `None` if the detail is missing or doesn't match the expected format.
+///
+/// **Security note:** the extracted value is attacker-influenced input that
+/// was rejected by a unique constraint and may be PII (e.g. an email
+/// address). Returning it to untrusted API clients enables user
+/// enumeration; logging it may place PII in log pipelines.
 pub fn parse_constraint_detail_value(detail: Option<&str>) -> Option<String> {
     let detail = detail?;
     let start = detail.find("=(")? + 2;
@@ -44,6 +49,9 @@ pub fn parse_constraint_detail_value(detail: Option<&str>) -> Option<String> {
 ///
 /// Downcasts to [`sqlx::postgres::PgDatabaseError`], reads its `detail()`,
 /// and parses the conflicting value.
+///
+/// **Security note:** see [`parse_constraint_detail_value`] — the returned
+/// value may be PII and must not be exposed to untrusted clients.
 pub fn extract_constraint_value(db_err: &dyn sqlx::error::DatabaseError) -> Option<String> {
     let pg_err = db_err.try_downcast_ref::<sqlx::postgres::PgDatabaseError>()?;
     parse_constraint_detail_value(pg_err.detail())


### PR DESCRIPTION
## Summary
The generated `CreateError`/`ModifyError` `ConstraintViolation { column, value, inner }` variant carries the conflicting value parsed from PostgreSQL's `Key (col)=(value) already exists.` detail, exposed via `duplicate_value()`.

That value is attacker-influenced input rejected by a unique constraint and is frequently PII (e.g. an email address):
- **User enumeration** — if an app propagates this error to an API client, callers can probe which emails/usernames already exist.
- **PII in logs** — the value appears in the error's `Display`/`Debug` output.

## Changes (documentation only, no behavior change)
- Doc warnings on the generated `ConstraintViolation` variants (create + modify errors) and `duplicate_value()` helpers
- Doc warnings on `parse_constraint_detail_value` / `extract_constraint_value` in `src/error.rs`
- Security note in the `repo-errors` book chapter recommending the boolean `was_duplicate()` / `was_duplicate_by(column)` helpers at trust boundaries

Removing/gating the value extraction would be a breaking change to the generated public error enums; this PR documents the risk so consumers can handle it correctly. Happy to follow up with an opt-out macro option if maintainers want one.

## Test plan
- [x] `cargo test -p es-entity-macros --lib`, `cargo test --lib`, `cargo fmt --check` pass