### PR TITLE
feat: add exponential backoff to retry_on_concurrent_modification

### DIFF
--- a/es-entity-macros/src/lib.rs
+++ b/es-entity-macros/src/lib.rs
@@ -21,6 +21,19 @@ pub fn es_event_derive(input: TokenStream) -> TokenStream {
     }
 }
 
+/// Retries the annotated async function when it fails with a concurrent
+/// modification error (or with any error when `any_error = true`).
+///
+/// Attempts are spaced with exponential backoff (25ms, 50ms, 100ms, ...
+/// capped at 1s) so a contended entity is not hammered in a hot loop while
+/// the conflicting writer finishes its transaction.
+///
+/// # Arguments
+///
+/// - `max_retries = N` — maximum attempts (default: 3)
+/// - `any_error = true|false` — retry on any error, not just concurrent
+///   modifications (default: false). Only enable this when the annotated
+///   function is fully idempotent.
 #[proc_macro_attribute]
 pub fn retry_on_concurrent_modification(args: TokenStream, input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as syn::ItemFn);

--- a/es-entity-macros/src/retry_on_concurrent_modification.rs
+++ b/es-entity-macros/src/retry_on_concurrent_modification.rs
@@ -43,15 +43,29 @@ pub fn make(
 
     let any_error = args.any_error.unwrap_or(false);
 
+    // Exponential backoff between attempts: 25ms, 50ms, 100ms, ... capped at 1s.
+    // Sleeping before the retry avoids hammering the database in a hot loop
+    // while the conflicting writer is still finishing its transaction.
+    let compute_backoff = quote::quote! {
+        let backoff = std::time::Duration::from_millis(25u64 << (n - 1).min(6))
+            .min(std::time::Duration::from_secs(1));
+    };
+    let sleep_backoff = quote::quote! {
+        es_entity::prelude::tokio::time::sleep(backoff).await;
+    };
+
     #[cfg(feature = "instrument")]
     let err_match = if any_error {
         quote::quote! {
             if result.is_err() {
+                #compute_backoff
                 tracing::warn!(
                     attempt = n,
                     max_retries = max_retries,
+                    backoff_ms = backoff.as_millis() as u64,
                     "Error detected, retrying"
                 );
+                #sleep_backoff
                 continue;
             }
         }
@@ -59,11 +73,14 @@ pub fn make(
         quote::quote! {
             if let Err(e) = result.as_ref() {
                 if e.was_concurrent_modification() {
+                    #compute_backoff
                     tracing::warn!(
                         attempt = n,
                         max_retries = max_retries,
+                        backoff_ms = backoff.as_millis() as u64,
                         "Concurrent modification detected, retrying"
                     );
+                    #sleep_backoff
                     continue;
                 }
             }
@@ -74,6 +91,8 @@ pub fn make(
     let err_match = if any_error {
         quote::quote! {
             if result.is_err() {
+                #compute_backoff
+                #sleep_backoff
                 continue;
             }
         }
@@ -81,6 +100,8 @@ pub fn make(
         quote::quote! {
             if let Err(e) = result.as_ref() {
                 if e.was_concurrent_modification() {
+                    #compute_backoff
+                    #sleep_backoff
                     continue;
                 }
             }
@@ -197,6 +218,9 @@ pub fn make(
 //                     }
 //                     if let Err(e) = result.as_ref() {
 //                         if e.was_concurrent_modification() {
+//                             let backoff = std::time::Duration::from_millis(25u64 << (n - 1).min(6))
+//                                 .min(std::time::Duration::from_secs(1));
+//                             es_entity::prelude::tokio::time::sleep(backoff).await;
 //                             continue;
 //                         }
 //                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod prelude {
     pub use serde;
     pub use serde_json;
     pub use sqlx;
+    pub use tokio;
     pub use uuid;
 
     #[cfg(feature = "json-schema")]


### PR DESCRIPTION
## Summary
`#[retry_on_concurrent_modification]` retried immediately in a hot loop (default 3 attempts). Under contention this amplifies database load precisely when the entity row is already contended.

Attempts are now spaced with **exponential backoff: 25ms, 50ms, 100ms, ... capped at 1s**, slept via `tokio::time::sleep`.

## Implementation notes
- `tokio` is re-exported as `es_entity::prelude::tokio` so the generated code does not impose a new dependency requirement on consumers (tokio was already a non-optional dependency of `es-entity`).
- With the `instrument` feature, the scheduled backoff is logged on the retry warning (`backoff_ms` field).
- The macro's rustdoc now documents the backoff behavior and arguments (including the caveat that `any_error = true` requires full idempotency).

## Test plan
- [x] `cargo test -p es-entity-macros --lib`, `cargo test --lib`, `cargo clippy`, `cargo fmt --check` pass
- [x] Verified the generated code compiles in a scratch consumer crate, with and without the `instrument` feature
- [x] Runtime check: 3 failing attempts take ~78ms (25ms + 50ms backoff), previously ~0ms
- [ ] CI (integration tests against Postgres)