### PR TITLE
feat(macros): per-column cursor = "catch_all" pagination mode for list_by columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Unreleased
+
+### Features
+
+- Per-column `cursor = "catch_all"` option for `list_by` columns: emits a
+  single catch-all COALESCE query per direction (identical result
+  semantics) instead of the sargable per-cursor-state matrix — 4-6 static
+  queries down to 2 per list fn — letting repos trade the index-friendly
+  cursor predicate for less generated code on cold list paths. Honored by
+  `list_by_*`, `list_for_*_by_*` and `list_for_filters` pagination.
+
 # [cala release v0.11.12](https://github.com/GaloyMoney/cala/releases/tag/0.11.12)
 
 

--- a/book/src/repo-list-by.md
+++ b/book/src/repo-list-by.md
@@ -121,3 +121,49 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 ```
+
+## Cursor pagination SQL modes
+
+By default every `list_by` sort column gets **sargable per-cursor-state
+SQL**: one static query per cursor state (page 1 / cursor on a value /
+cursor on NULL) per direction, so the cursor predicate is always a bare
+`(col, id)` row comparison that rides a composite index. The price is
+generated code — every one of those queries is a compile-time-checked
+`es_query!` that downstream builds must type-check, optimize and (under
+`lto = "fat"`) re-optimize:
+
+| column shape | sargable (default) | `cursor = "catch_all"` |
+|---|---|---|
+| non-nullable sort column | 2 states x 2 directions = 4 queries | 2 queries |
+| nullable (`Option<T>`) sort column | 3 states x 2 directions = 6 queries | 2 queries |
+
+(per `list_by_*` fn variant; `list_for_*_by_<column>` and
+`list_for_filters` pagination by the column follow the same mode, and
+scoped repos double both columns of the table.)
+
+For cold list paths you can trade the index-friendly predicate for less
+generated code with `cursor = "catch_all"`:
+
+```rust,ignore
+#[derive(EsRepo)]
+#[es_repo(
+    entity = "User",
+    columns(
+        name(ty = "String", list_by),
+        // one catch-all COALESCE query per direction instead of the
+        // per-state matrix — identical result semantics, non-sargable
+        // cursor predicate, fraction of the compile-time cost
+        nickname(ty = "Option<String>", list_by, cursor = "catch_all")
+    )
+)]
+pub struct Users {
+    pool: sqlx::PgPool
+}
+```
+
+The catch-all mode returns exactly the same rows in the same order — it
+uses the all-cases `COALESCE` predicate that handles page 1, cursors on
+values and cursors on NULL rows in one query per direction. Only the
+query plan changes: the `COALESCE(..., $ IS NULL)` fallback defeats
+composite-index extraction, so prefer the default sargable mode for hot
+paths and large tables.

--- a/es-entity-macros/src/repo/list_by_fn.rs
+++ b/es-entity-macros/src/repo/list_by_fn.rs
@@ -30,6 +30,18 @@ pub enum CursorState {
     AfterMaybeNull,
 }
 
+/// A cursor-query variant to generate for a sort column: one per
+/// [`CursorState`] in the default sargable mode, or a single catch-all
+/// variant when the column sets `cursor = "catch_all"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CursorVariant {
+    State(CursorState),
+    /// One query per direction using the all-cases COALESCE predicate —
+    /// same semantics as the per-state queries, non-sargable, but a
+    /// fraction of the generated code.
+    CatchAll,
+}
+
 /// Assemble a `SELECT ... [WHERE ...] ORDER BY ... LIMIT $n` query string
 /// from individual predicates.
 pub fn assemble_select(
@@ -159,6 +171,57 @@ impl CursorStruct<'_> {
                 "COALESCE(({0}, id) {comp} (${column_offset}, ${id_offset}), ${id_offset} IS NULL)",
                 self.column.name(),
             )
+        }
+    }
+
+    /// The cursor-query variants to generate for this sort column:
+    /// one per [`CursorState`] in sargable mode (default), or a single
+    /// [`CursorVariant::CatchAll`] when the column sets
+    /// `cursor = "catch_all"`.
+    pub fn cursor_variants(&self) -> Vec<CursorVariant> {
+        match self.column.cursor_pagination() {
+            CursorPagination::CatchAll => vec![CursorVariant::CatchAll],
+            CursorPagination::Sargable => self
+                .cursor_states()
+                .iter()
+                .map(|s| CursorVariant::State(*s))
+                .collect(),
+        }
+    }
+
+    /// The cursor predicate for a variant, or `None` when the variant
+    /// needs no predicate ([`CursorState::First`]). See
+    /// [`Self::condition_for_state`].
+    pub fn condition_for_variant(
+        &self,
+        variant: CursorVariant,
+        offset: u32,
+        ascending: bool,
+    ) -> Option<String> {
+        match variant {
+            CursorVariant::CatchAll => Some(self.condition(offset, ascending)),
+            CursorVariant::State(state) => self.condition_for_state(state, offset, ascending),
+        }
+    }
+
+    /// Cursor value bindings (without the `LIMIT` binding) for a variant.
+    pub fn cursor_arg_tokens_for_variant(&self, variant: CursorVariant) -> TokenStream {
+        match variant {
+            CursorVariant::CatchAll => self.cursor_arg_tokens(),
+            CursorVariant::State(state) => self.cursor_arg_tokens_for_state(state),
+        }
+    }
+
+    /// Pattern elements matching [`Self::state_scrutinee_elems`] for one
+    /// variant. The catch-all variant ignores the cursor-shape scrutinee.
+    pub fn variant_pattern_elems(&self, variant: CursorVariant) -> Vec<TokenStream> {
+        match variant {
+            CursorVariant::CatchAll => self
+                .state_scrutinee_elems()
+                .iter()
+                .map(|_| quote! { _ })
+                .collect(),
+            CursorVariant::State(state) => self.state_pattern_elems(state),
         }
     }
 
@@ -293,7 +356,7 @@ impl CursorStruct<'_> {
         }
     }
 
-    fn cursor_arg_tokens(&self) -> TokenStream {
+    pub fn cursor_arg_tokens(&self) -> TokenStream {
         let id = self.id;
 
         if self.column.is_id() {
@@ -607,14 +670,14 @@ impl ToTokens for ListByFn<'_> {
             let build_query_arms = |scope: Option<&ScopeInfo>| -> TokenStream {
                 let mut query_arms = TokenStream::new();
                 let offset = if scope.is_some() { 1 } else { 0 };
-                for state in cursor.cursor_states() {
+                for variant in cursor.cursor_variants() {
                     for ascending in [true, false] {
                         let mut conditions: Vec<String> = Vec::new();
                         if let Some(scope) = scope {
                             conditions.push(scope.predicate(1));
                         }
                         if let Some(condition) =
-                            cursor.condition_for_state(*state, offset, ascending)
+                            cursor.condition_for_variant(variant, offset, ascending)
                         {
                             conditions.push(format!("({condition})"));
                         }
@@ -630,7 +693,7 @@ impl ToTokens for ListByFn<'_> {
                             &cursor.order_by(ascending),
                             offset + 1,
                         );
-                        let cursor_args = cursor.cursor_arg_tokens_for_state(*state);
+                        let cursor_args = cursor.cursor_arg_tokens_for_variant(variant);
                         let scope_args = scope.map(|s| s.arg_tokens()).unwrap_or_default();
                         let args = quote! {
                             #scope_args
@@ -643,7 +706,7 @@ impl ToTokens for ListByFn<'_> {
                         } else {
                             quote! { es_entity::ListDirection::Descending }
                         };
-                        let state_pattern = cursor.state_pattern_elems(*state);
+                        let state_pattern = cursor.variant_pattern_elems(variant);
                         query_arms.append_all(quote! {
                             (#direction_pattern, #(#state_pattern),*) => {
                                 #es_query_call.fetch_n(op, first).await?
@@ -1389,5 +1452,115 @@ mod tests {
         };
 
         assert_eq!(tokens.to_string(), expected.to_string());
+    }
+}
+
+#[cfg(test)]
+mod catch_all_tests {
+    use super::*;
+    use darling::FromMeta;
+    use proc_macro2::Span;
+    use syn::Ident;
+
+    fn catch_all_optional_column() -> Column {
+        let input: syn::Meta =
+            syn::parse_quote!(score(ty = "Option<i32>", list_by, cursor = "catch_all"));
+        Column::from_nested_meta(&darling::ast::NestedMeta::Meta(input))
+            .expect("Failed to parse Column")
+    }
+
+    #[test]
+    fn catch_all_column_has_single_variant() {
+        let id_type = Ident::new("EntityId", Span::call_site());
+        let entity = Ident::new("Entity", Span::call_site());
+        let column = catch_all_optional_column();
+        let cursor_mod = Ident::new("cursor_mod", Span::call_site());
+
+        let cursor = CursorStruct {
+            column: &column,
+            id: &id_type,
+            entity: &entity,
+            cursor_mod: &cursor_mod,
+        };
+
+        assert_eq!(cursor.cursor_variants(), vec![CursorVariant::CatchAll]);
+        // The catch-all variant reuses the all-cases COALESCE predicate
+        assert_eq!(
+            cursor.condition_for_variant(CursorVariant::CatchAll, 0, true),
+            Some(cursor.condition(0, true))
+        );
+        // ... and ignores the cursor-shape scrutinee (nullable optional
+        // column -> 2 scrutinee elems -> 2 wildcards)
+        let patterns = cursor.variant_pattern_elems(CursorVariant::CatchAll);
+        assert_eq!(patterns.len(), 2);
+        for pattern in patterns {
+            assert_eq!(pattern.to_string(), "_");
+        }
+    }
+
+    #[test]
+    fn sargable_column_has_per_state_variants() {
+        let id_type = Ident::new("EntityId", Span::call_site());
+        let entity = Ident::new("Entity", Span::call_site());
+        let input: syn::Meta = syn::parse_quote!(score(ty = "Option<i32>", list_by));
+        let column = Column::from_nested_meta(&darling::ast::NestedMeta::Meta(input))
+            .expect("Failed to parse Column");
+        let cursor_mod = Ident::new("cursor_mod", Span::call_site());
+
+        let cursor = CursorStruct {
+            column: &column,
+            id: &id_type,
+            entity: &entity,
+            cursor_mod: &cursor_mod,
+        };
+
+        assert_eq!(
+            cursor.cursor_variants(),
+            vec![
+                CursorVariant::State(CursorState::First),
+                CursorVariant::State(CursorState::After),
+                CursorVariant::State(CursorState::AfterNull),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_by_fn_catch_all_emits_one_query_per_direction() {
+        let id_type = Ident::new("EntityId", Span::call_site());
+        let entity = Ident::new("Entity", Span::call_site());
+        let query_error = syn::Ident::new("EntityQueryError", Span::call_site());
+        let column = catch_all_optional_column();
+        let cursor_mod = Ident::new("cursor_mod", Span::call_site());
+
+        let persist_fn = ListByFn {
+            ignore_prefix: None,
+            column: &column,
+            id: &id_type,
+            entity: &entity,
+            table_name: "entities",
+            query_error,
+            delete: DeleteOption::SoftWithoutQueries,
+            cursor_mod,
+            any_nested: false,
+            post_hydrate_error: None,
+            forgettable_table_name: None,
+            scope: None,
+            #[cfg(feature = "instrument")]
+            repo_name_snake: "test_repo".to_string(),
+        };
+
+        let mut tokens = TokenStream::new();
+        persist_fn.to_tokens(&mut tokens);
+        let generated = tokens.to_string();
+
+        // 1 catch-all variant x 2 directions = 2 static queries (vs 3
+        // states x 2 = 6 in sargable mode)
+        // (token-stream stringification puts a space before `!`)
+        assert_eq!(generated.matches("es_query !").count(), 2);
+        // catch-all COALESCE predicate for the nullable column (ASC form)
+        assert!(generated.contains("COALESCE(id > $2, true)"));
+        // NULLS FIRST/LAST ordering is preserved
+        assert!(generated.contains("NULLS FIRST"));
+        assert!(generated.contains("NULLS LAST"));
     }
 }

--- a/es-entity-macros/src/repo/list_for_filters_fn.rs
+++ b/es-entity-macros/src/repo/list_for_filters_fn.rs
@@ -669,10 +669,11 @@ impl<'a> ListForFiltersFn<'a> {
                         }
                     }
 
-                    for cursor_state in cursor_struct.cursor_states() {
-                        let cursor_patterns = cursor_struct.state_pattern_elems(*cursor_state);
+                    for cursor_variant in cursor_struct.cursor_variants() {
+                        let cursor_patterns = cursor_struct.variant_pattern_elems(cursor_variant);
                         let pattern = quote! { (#(#filter_patterns,)* #(#cursor_patterns,)*) };
-                        let cursor_args = cursor_struct.cursor_arg_tokens_for_state(*cursor_state);
+                        let cursor_args =
+                            cursor_struct.cursor_arg_tokens_for_variant(cursor_variant);
                         let args = quote! {
                             #filter_args
                             (first + 1) as i64,
@@ -681,8 +682,8 @@ impl<'a> ListForFiltersFn<'a> {
 
                         for ascending in [true, false] {
                             let mut conditions = filter_conditions.clone();
-                            if let Some(condition) = cursor_struct.condition_for_state(
-                                *cursor_state,
+                            if let Some(condition) = cursor_struct.condition_for_variant(
+                                cursor_variant,
                                 param_idx - 1,
                                 ascending,
                             ) {

--- a/es-entity-macros/src/repo/list_for_fn.rs
+++ b/es-entity-macros/src/repo/list_for_fn.rs
@@ -213,7 +213,7 @@ impl ToTokens for ListForFn<'_> {
             let build_query_arms = |scope: Option<&ScopeInfo>| -> TokenStream {
                 let mut query_arms = TokenStream::new();
                 let offset = if scope.is_some() { 2 } else { 1 };
-                for state in cursor.cursor_states() {
+                for variant in cursor.cursor_variants() {
                     for ascending in [true, false] {
                         let mut conditions: Vec<String> =
                             vec![format!("({for_column_name} {filter_op} $1)")];
@@ -221,7 +221,7 @@ impl ToTokens for ListForFn<'_> {
                             conditions.push(scope.predicate(2));
                         }
                         if let Some(condition) =
-                            cursor.condition_for_state(*state, offset, ascending)
+                            cursor.condition_for_variant(variant, offset, ascending)
                         {
                             conditions.push(format!("({condition})"));
                         }
@@ -237,7 +237,7 @@ impl ToTokens for ListForFn<'_> {
                             &cursor.order_by(ascending),
                             offset + 1,
                         );
-                        let cursor_args = cursor.cursor_arg_tokens_for_state(*state);
+                        let cursor_args = cursor.cursor_arg_tokens_for_variant(variant);
                         let scope_args = scope.map(|s| s.arg_tokens()).unwrap_or_default();
                         let args = quote! {
                             #filter_arg_name as &#for_column_type,
@@ -251,7 +251,7 @@ impl ToTokens for ListForFn<'_> {
                         } else {
                             quote! { es_entity::ListDirection::Descending }
                         };
-                        let state_pattern = cursor.state_pattern_elems(*state);
+                        let state_pattern = cursor.variant_pattern_elems(variant);
                         query_arms.append_all(quote! {
                             (#direction_pattern, #(#state_pattern),*) => {
                                 #es_query_call.fetch_n(op, first).await?

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -30,6 +30,7 @@ use options::RepositoryOptions;
 pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream> {
     let opts = RepositoryOptions::from_derive_input(&ast)?;
     opts.columns.validate_list_for_by_columns()?;
+    opts.columns.validate_cursor_pagination()?;
     opts.columns.validate_scope()?;
     opts.validate_forgettable()?;
     let repo = EsRepo::from(&opts);

--- a/es-entity-macros/src/repo/options/columns.rs
+++ b/es-entity-macros/src/repo/options/columns.rs
@@ -93,6 +93,25 @@ impl Columns {
             .find(|c| c.name() == name && c.opts.list_by())
     }
 
+    /// Validates the `cursor = "..."` column option: it is only meaningful
+    /// on `list_by` columns (it steers the cursor-pagination SQL of the
+    /// `list_by_*` / `list_for_*_by_*` / filter list fns).
+    pub fn validate_cursor_pagination(&self) -> darling::Result<()> {
+        let mut errors = darling::Error::accumulator();
+        for col in self
+            .all
+            .iter()
+            .filter(|c| c.opts.cursor.is_some() && !c.opts.list_by())
+        {
+            errors.push(darling::Error::custom(format!(
+                "column '{}' sets `cursor` but is not a list_by column — \
+                 cursor pagination is only generated for list_by columns",
+                col.name(),
+            )));
+        }
+        errors.finish()
+    }
+
     pub fn validate_list_for_by_columns(&self) -> darling::Result<()> {
         let mut errors = darling::Error::accumulator();
         for col in self.all.iter().filter(|c| c.opts.list_for()) {
@@ -512,6 +531,7 @@ impl Column {
                 forgettable: false,
                 scope: false,
                 list_by: Some(true),
+                cursor: None,
                 find_by: Some(true),
                 nullable: None,
                 list_for_opts: None,
@@ -540,6 +560,7 @@ impl Column {
                 forgettable: false,
                 scope: false,
                 list_by: Some(true),
+                cursor: None,
                 find_by: Some(false),
                 nullable: None,
                 list_for_opts: None,
@@ -603,6 +624,12 @@ impl Column {
     /// cursor `WHERE` clause in [`Self::condition`].
     pub fn is_nullable_column(&self) -> bool {
         self.is_optional() || self.opts.nullable()
+    }
+
+    /// How much static SQL the cursor-pagination fns generate for this sort
+    /// column. Defaults to [`CursorPagination::Sargable`].
+    pub fn cursor_pagination(&self) -> CursorPagination {
+        self.opts.cursor.unwrap_or_default()
     }
 
     pub fn name(&self) -> &syn::Ident {
@@ -751,6 +778,34 @@ fn option_inner(ty: &syn::Type) -> Option<syn::Type> {
     None
 }
 
+/// Cursor-pagination SQL mode for a `list_by` column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CursorPagination {
+    /// One static, sargable query per cursor state x direction (default):
+    /// page 1 and each cursor shape get their own index-friendly SQL text.
+    #[default]
+    Sargable,
+    /// A single catch-all COALESCE query per direction: same result
+    /// semantics as the per-state queries (it is the predicate the
+    /// `AfterMaybeNull` state and pre-0.11.9 versions use everywhere), but
+    /// non-sargable — the cursor predicate defeats composite-index
+    /// extraction. Halves-to-thirds the generated query surface (and thus
+    /// compile time) for the column.
+    CatchAll,
+}
+
+impl FromMeta for CursorPagination {
+    fn from_string(value: &str) -> darling::Result<Self> {
+        match value {
+            "sargable" => Ok(Self::Sargable),
+            "catch_all" => Ok(Self::CatchAll),
+            other => Err(darling::Error::custom(format!(
+                "unknown cursor pagination mode '{other}'; expected \"sargable\" or \"catch_all\""
+            ))),
+        }
+    }
+}
+
 #[derive(PartialEq, FromMeta)]
 struct ColumnOpts {
     ty: syn::Type,
@@ -770,6 +825,14 @@ struct ColumnOpts {
     find_by: Option<bool>,
     #[darling(default)]
     list_by: Option<bool>,
+    /// Cursor-pagination SQL mode for this sort column: `cursor =
+    /// "sargable"` (default) emits one static, index-friendly query per
+    /// cursor state x direction; `cursor = "catch_all"` emits a single
+    /// catch-all COALESCE query per direction — identical result semantics
+    /// with a fraction of the generated code (compile time), at the cost of
+    /// a non-sargable cursor predicate. Use for cold list paths.
+    #[darling(default)]
+    cursor: Option<CursorPagination>,
     /// Opt-in flag for columns whose Rust type is not syntactically `Option<T>`
     /// but whose underlying SQL column is nullable. When set, the macro emits
     /// the same nullable-aware cursor SQL (`IS NOT DISTINCT FROM`, `NULLS
@@ -801,6 +864,7 @@ impl ColumnOpts {
             scope: false,
             find_by: None,
             list_by: None,
+            cursor: None,
             nullable: None,
             list_for_opts: None,
             parent_opts: None,
@@ -1135,5 +1199,59 @@ mod tests {
             .expect("Failed to parse Column");
         assert_eq!(column.name().to_string(), "job_type");
         assert_eq!(column.custom_constraint(), Some("idx_unique_job_type"));
+    }
+
+    #[test]
+    fn cursor_pagination_defaults_to_sargable() {
+        let input: syn::Meta = parse_quote!(thing(ty = "String", list_by));
+        let values = ColumnOpts::from_meta(&input).expect("Failed to parse Field");
+        assert!(values.list_by());
+        assert!(values.cursor.is_none());
+
+        let column = Column::new(parse_quote!(thing), syn::parse_str("String").unwrap());
+        assert_eq!(column.cursor_pagination(), CursorPagination::Sargable);
+    }
+
+    #[test]
+    fn cursor_pagination_catch_all_parses() {
+        let input: syn::Meta = parse_quote!(thing(ty = "String", list_by, cursor = "catch_all"));
+        let values = ColumnOpts::from_meta(&input).expect("Failed to parse Field");
+        assert_eq!(values.cursor, Some(CursorPagination::CatchAll));
+
+        let input: syn::Meta = parse_quote!(thing(ty = "String", list_by, cursor = "sargable"));
+        let values = ColumnOpts::from_meta(&input).expect("Failed to parse Field");
+        assert!(values.cursor == Some(CursorPagination::Sargable));
+    }
+
+    #[test]
+    fn cursor_pagination_rejects_unknown_mode() {
+        let input: syn::Meta = parse_quote!(thing(ty = "String", list_by, cursor = "bogus"));
+        let err = match ColumnOpts::from_meta(&input) {
+            Ok(_) => panic!("expected parse error for unknown cursor mode"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains("bogus"),
+            "error should mention the mode: {err}"
+        );
+    }
+
+    #[test]
+    fn cursor_pagination_requires_list_by() {
+        let id_ident: syn::Ident = parse_quote!(TestId);
+        let input: syn::Meta = parse_quote!(thing(ty = "String", cursor = "catch_all"));
+        let opts = ColumnOpts::from_meta(&input).expect("Failed to parse Field");
+        let col = Column {
+            name: parse_quote!(thing),
+            opts,
+        };
+        let columns = Columns::new(&id_ident, vec![col]);
+        let result = columns.validate_cursor_pagination();
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("list_by"),
+            "error should mention list_by: {err}"
+        );
     }
 }

--- a/tests/catch_all_cursor_pagination.rs
+++ b/tests/catch_all_cursor_pagination.rs
@@ -1,0 +1,194 @@
+mod entities;
+mod helpers;
+
+use sqlx::PgPool;
+
+use entities::transfer::*;
+use es_entity::*;
+
+/// Same entity/table as the sargable list tests, but the nullable `score`
+/// sort column opts out of the per-cursor-state SQL matrix via
+/// `cursor = "catch_all"`: a single catch-all COALESCE query per direction.
+/// Result semantics must be identical to the sargable per-state queries.
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "Transfer",
+    columns(
+        account_id(ty = "AccountId", list_for(by(score))),
+        status(ty = "String"),
+        reference(ty = "Option<String>"),
+        score(ty = "Option<i32>", list_by, cursor = "catch_all")
+    )
+)]
+pub struct TransfersCatchAll {
+    pool: PgPool,
+}
+
+impl TransfersCatchAll {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+async fn seed(
+    repo: &TransfersCatchAll,
+    account_id: uuid::Uuid,
+    scores: &[Option<i32>],
+) -> anyhow::Result<()> {
+    for score in scores {
+        let new = NewTransfer::builder()
+            .id(TransferId::new())
+            .account_id(AccountId::from(account_id))
+            .status("catch_all_test")
+            .score(*score)
+            .build()
+            .unwrap();
+        repo.create(new).await?;
+    }
+    Ok(())
+}
+
+async fn rows_for_account(
+    pool: &PgPool,
+    account_id: uuid::Uuid,
+) -> anyhow::Result<Vec<(uuid::Uuid, Option<i32>)>> {
+    let rows = sqlx::query_as::<_, (uuid::Uuid, Option<i32>)>(
+        "SELECT id, score FROM transfers WHERE account_id = $1",
+    )
+    .bind(account_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// ASC: NULLs first (id asc), then values by (score, id) asc.
+/// DESC: values by (score, id) desc, then NULLs (id desc).
+fn reference_order(
+    rows: &[(uuid::Uuid, Option<i32>)],
+    direction: ListDirection,
+) -> Vec<uuid::Uuid> {
+    let mut null_rows: Vec<_> = rows.iter().filter(|r| r.1.is_none()).collect();
+    let mut value_rows: Vec<_> = rows.iter().filter(|r| r.1.is_some()).collect();
+    null_rows.sort_by_key(|r| r.0);
+    value_rows.sort_by_key(|r| (r.1, r.0));
+    match direction {
+        ListDirection::Ascending => null_rows
+            .into_iter()
+            .chain(value_rows)
+            .map(|r| r.0)
+            .collect(),
+        ListDirection::Descending => value_rows
+            .into_iter()
+            .rev()
+            .chain(null_rows.into_iter().rev())
+            .map(|r| r.0)
+            .collect(),
+    }
+}
+
+/// `list_by_score` with `cursor = "catch_all"` must paginate through NULL
+/// and non-NULL cursor values in both directions with the exact same
+/// semantics as the sargable per-state queries.
+#[tokio::test]
+async fn list_by_score_catch_all_paginates_through_nulls() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let transfers = TransfersCatchAll::new(pool.clone());
+
+    let account_id = uuid::Uuid::from(AccountId::new());
+    let scores = [
+        None,
+        Some(5),
+        None,
+        Some(3),
+        Some(7),
+        None,
+        Some(1),
+        Some(3),
+    ];
+    seed(&transfers, account_id, &scores).await?;
+    let truth = rows_for_account(&pool, account_id).await?;
+    // `list_by_score` is unfiltered over a shared table — retain only this
+    // test's rows from the (totally ordered) returned stream.
+    let truth_ids: std::collections::HashSet<_> = truth.iter().map(|r| r.0).collect();
+
+    for direction in [ListDirection::Ascending, ListDirection::Descending] {
+        let expected = reference_order(&truth, direction);
+
+        // A page size smaller than the 8 seeded rows forces pagination even
+        // on a pristine database: ASC crosses the NULL → value boundary and
+        // DESC the value → NULL boundary, so the catch-all query paginates
+        // from both NULL and non-NULL cursor values in each direction.
+        let mut actual = Vec::new();
+        let mut after: Option<transfer_cursor::TransferByScoreCursor> = None;
+        let mut pages = 0;
+        loop {
+            let ret = transfers
+                .list_by_score(PaginatedQueryArgs { first: 3, after }, direction)
+                .await?;
+            pages += 1;
+            actual.extend(ret.entities.iter().map(|t| uuid::Uuid::from(t.id)));
+            if !ret.has_next_page {
+                break;
+            }
+            after = ret.end_cursor;
+            assert!(after.is_some(), "has_next_page without end_cursor");
+        }
+        actual.retain(|id| truth_ids.contains(id));
+
+        assert!(
+            pages >= 3,
+            "pagination must span multiple pages to exercise the cursor \
+             transitions, got {pages} page(s) for direction={direction:?}"
+        );
+        assert_eq!(actual, expected, "mismatch for direction={direction:?}");
+    }
+
+    Ok(())
+}
+
+/// `list_for_account_id_by_score` must honor the by-column's catch-all mode
+/// with the same semantics: filter + paginate through NULLs, both
+/// directions.
+#[tokio::test]
+async fn list_for_account_id_by_score_catch_all_paginates() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let transfers = TransfersCatchAll::new(pool.clone());
+
+    let account_id = uuid::Uuid::from(AccountId::new());
+    let scores = [None, Some(5), None, Some(3), Some(7), None, Some(1)];
+    seed(&transfers, account_id, &scores).await?;
+    let truth = rows_for_account(&pool, account_id).await?;
+
+    for direction in [ListDirection::Ascending, ListDirection::Descending] {
+        let expected = reference_order(&truth, direction);
+
+        let mut actual = Vec::new();
+        let mut after: Option<transfer_cursor::TransferByScoreCursor> = None;
+        let mut pages = 0;
+        loop {
+            let ret = transfers
+                .list_for_account_id_by_score(
+                    AccountId::from(account_id),
+                    PaginatedQueryArgs { first: 2, after },
+                    direction,
+                )
+                .await?;
+            pages += 1;
+            actual.extend(ret.entities.iter().map(|t| uuid::Uuid::from(t.id)));
+            if !ret.has_next_page {
+                break;
+            }
+            after = ret.end_cursor;
+            assert!(after.is_some(), "has_next_page without end_cursor");
+        }
+
+        assert!(
+            pages >= 3,
+            "pagination must span multiple pages, got {pages} page(s) for \
+             direction={direction:?}"
+        );
+        assert_eq!(actual, expected, "mismatch for direction={direction:?}");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Since 0.11.9 (sargable per-state SQL), every `list_by` sort column emits one static `es_query!` per cursor state × direction — 4 queries for non-nullable columns, 6 for nullable (`Option<T>`) ones, per list fn variant, doubled for scoped repos. In downstream workspaces with many repos this multiplies the compile-time-checked query surface fast. Measured in lana-bank (~50 `EsRepo`s):

| es-entity | `.sqlx` entries | `build-rc-release` on CI |
|---|---|---|
| 0.11.8 | 1319 | ~36 min |
| 0.11.9 | 3373 | ~53 min |
| 0.11.12 (HEAD) | 2653 | ~46 min |

The dominant cost is not macro expansion but the generated code volume: with `lto = "fat"`, every generated query (describe metadata, row decoders, executor glue) is IR that the final, mostly-serial whole-program LTO pass on the binary must re-optimize (~79% of the release build is that one unit). See GaloyMoney/lana-bank#7824 for the full investigation.

## What this PR does

Adds a **per-column opt-out**: `cursor = "catch_all"` on a `list_by` column emits a single catch-all `COALESCE` query per direction — the exact all-cases predicate the `AfterMaybeNull` state (and pre-0.11.9 versions) already use — instead of the per-state matrix:

| column shape | sargable (default) | `cursor = "catch_all"` |
|---|---|---|
| non-nullable sort column | 2 states × 2 dirs = 4 queries | 2 queries |
| nullable (`Option<T>`) sort column | 3 states × 2 dirs = 6 queries | 2 queries |

- Honored by `list_by_*`, `list_for_*_by_<column>`, and `list_for_filters` pagination by the column.
- **Semantics are identical** — same rows, same order, NULL-cursor handling included (covered by new integration tests paginating through NULLs in both directions and comparing against a reference implementation).
- Only the query plan changes: the `COALESCE(..., $ IS NULL)` fallback is not sargable, so hot paths should keep the default. Default is unchanged — fully backward compatible.
- Usage: `score(ty = "Option<i32>", list_by, cursor = "catch_all")`. Setting `cursor` on a non-`list_by` column is a compile error; unknown modes are rejected at macro-expansion time.

Implementation: a `CursorVariant` abstraction on `CursorStruct` (`State(CursorState)` / `CatchAll`) so all three codegen sites (`list_by_fn`, `list_for_fn`, `list_for_filters_fn`) iterate variants uniformly. The refactor is output-identical for default columns — verified by the existing strict token-stream unit tests (117 pass unmodified).

## Explicitly not pursued

- **Dropping the `AfterNull` state**: required for correctness when a cursor sits on a NULL row of a nullable sort column. (But a catch-all column no longer needs it — the catch-all predicate covers that case.)
- **Runtime `QueryBuilder` for cold paths**: loses compile-time SQL checking and `.sqlx` coverage; `catch_all` achieves the same codegen reduction while keeping every query statically checked.

## Tests

- Unit: parsing (`cursor = "catch_all"` / `"sargable"` / unknown mode / validation on non-`list_by`), variant planning, codegen shape (2 queries per direction, catch-all predicate, NULLS FIRST/LAST preserved).
- Integration (`tests/catch_all_cursor_pagination.rs`): `list_by_score` and `list_for_account_id_by_score` with a catch-all nullable column, paginating through NULL/non-NULL cursor values in both directions against a Rust reference implementation (mirrors `sargable_list_queries.rs`).
- Full suite: 148 passed. `cargo fmt --check` / `clippy` clean. Book chapter + CHANGELOG updated.

## Follow-up

Release + bump in lana-bank, opting cold `list_by`/`list_for` columns into `catch_all` (biggest targets: `core_pending_credit_facilities` 351 queries, `core_disbursals` 214, `core_customers` 115), enforced going forward by the `.sqlx` budget lint from GaloyMoney/lana-bank#7824.
