### PR TITLE
chore(deps): bump rustls-webpki 0.103.9 -> 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

`cargo audit` reports 4 vulnerabilities in `rustls-webpki 0.103.9`, all fixed in `>=0.103.13`:

- [RUSTSEC-2026-0049](https://rustsec.org/advisories/RUSTSEC-2026-0049)
- [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098)
- [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099)
- [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104)

These advisories post-date the advisory DB snapshot used by recent CI runs, so the `security_audit` job will start failing once CI picks up a newer DB. Lockfile-only change (`cargo update -p rustls-webpki`).

## Verification

- `cargo audit` exits clean (only pre-existing allowed informational warnings)
- `cargo check --workspace` passes