### PR TITLE
feat(macros): unified cursor query emission (reverts per-state matrix)

### DIFF
--- a/es-entity-macros/src/query/mod.rs
+++ b/es-entity-macros/src/query/mod.rs
@@ -74,8 +74,13 @@ impl ToTokens for EsQuery {
                 )
             };
 
+        // `entity_id!` forces the non-null assertion: `i.id` is a primary-key
+        // join key so it is always non-null, but sqlx cannot infer that through
+        // a `UNION ALL` CTE (the unified cursor queries) and would otherwise
+        // decode it as `Option<Repo__Id>`, breaking `Repo__DbEvent`. The
+        // override is a safe no-op for the non-union queries.
         let query = format!(
-            "WITH entities AS ({}) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN {} THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, {} FROM entities i JOIN {} e ON i.id = e.id{} ORDER BY {} e.sequence",
+            "WITH entities AS ({}) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN {} THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, {} FROM entities i JOIN {} e ON i.id = e.id{} ORDER BY {} e.sequence",
             self.input.sql, context_arg, payload_column, events_table, forgettable_join, order_by
         );
 
@@ -154,7 +159,7 @@ mod tests {
                 es_entity::EsQuery::<Self, <Self as es_entity::EsRepo>::EsQueryFlavor, _, _>::new(
                     sqlx::query_as!(
                         Repo__DbEvent,
-                        "WITH entities AS (SELECT * FROM users WHERE id = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN user_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+                        "WITH entities AS (SELECT * FROM users WHERE id = $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN user_events e ON i.id = e.id ORDER BY i.id, e.sequence",
                         id as UserId,
                         <<<Self as es_entity::EsRepo>::Entity as EsEntity>::Event>::event_context(),
                     )
@@ -189,7 +194,7 @@ mod tests {
                 es_entity::EsQuery::<Self, <Self as es_entity::EsRepo>::EsQueryFlavor, _, _>::new(
                     sqlx::query_as!(
                         Repo__DbEvent,
-                        "WITH entities AS (SELECT * FROM my_custom_table WHERE id = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN my_custom_table_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+                        "WITH entities AS (SELECT * FROM my_custom_table WHERE id = $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN my_custom_table_events e ON i.id = e.id ORDER BY i.id, e.sequence",
                         id as MyCustomEntityId,
                         <<<Self as es_entity::EsRepo>::Entity as EsEntity>::Event>::event_context(),
                     )
@@ -231,7 +236,7 @@ mod tests {
                 es_entity::EsQuery::<Self, <Self as es_entity::EsRepo>::EsQueryFlavor, _, _>::new(
                     sqlx::query_as!(
                         Repo__DbEvent,
-                        "WITH entities AS (SELECT name, id FROM entities WHERE ((name, id) > ($3, $2)) OR $2 IS NULL ORDER BY name, id LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN entity_events e ON i.id = e.id ORDER BY i.name, i.id, i.id, e.sequence",
+                        "WITH entities AS (SELECT name, id FROM entities WHERE ((name, id) > ($3, $2)) OR $2 IS NULL ORDER BY name, id LIMIT $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN entity_events e ON i.id = e.id ORDER BY i.name, i.id, i.id, e.sequence",
                         (first + 1) as i64,
                         id as Option<MyCustomEntityId>,
                         name as Option<String>,

--- a/es-entity-macros/src/repo/list_by_fn.rs
+++ b/es-entity-macros/src/repo/list_by_fn.rs
@@ -48,6 +48,62 @@ pub fn assemble_select(
     query
 }
 
+/// Assemble the unified cursor query: the per-state cursor predicates emitted
+/// as `UNION ALL` branches in a single static query.
+///
+/// Each branch carries its own `ORDER BY ... LIMIT` — this is load-bearing:
+/// without the per-branch order+limit the planner falls back to a full-table
+/// top-N sort instead of an early-exit index walk (`Merge Append` of ordered
+/// index scans). The outer `ORDER BY ... LIMIT` then merges the branches.
+///
+/// Every branch is gated by a parameter-only nullness guard (see
+/// [`CursorStruct::cursor_branches`]) that Postgres lifts into a `One-Time
+/// Filter`, so dead branches are skipped at execution and the live branch gets
+/// a plan identical to its standalone per-state twin. `leading` conjuncts
+/// (scope, filter) and `trailing` conjuncts (soft-delete) are replicated
+/// inside every branch.
+///
+/// Within each branch the cursor `predicate` is emitted **before** the gate,
+/// and [`CursorStruct::cursor_branches`] orders the branches so the page-1
+/// branch (whose only reference to the cursor `id` parameter is the bare
+/// `$id IS NULL` guard) comes last. This guarantees every parameter's first
+/// textual occurrence in the statement is a typed column comparison — required
+/// because Postgres infers untyped prepared-statement parameter types from
+/// their leftmost use across a `UNION`, and a bare `$n IS NULL` there yields
+/// "could not determine data type of parameter". Ordering conjuncts is free
+/// for both correctness (all `AND`ed) and the plan (the One-Time Filter is
+/// still recognised regardless of conjunct order — verified via EXPLAIN).
+pub fn assemble_union_select(
+    select_columns: &str,
+    table_name: &str,
+    leading: &[String],
+    branches: &[(String, Option<String>)],
+    trailing: &[String],
+    order_by: &str,
+    limit_param_idx: u32,
+) -> String {
+    let branch_sqls: Vec<String> = branches
+        .iter()
+        .map(|(gate, predicate)| {
+            let mut conditions: Vec<String> = leading.to_vec();
+            if let Some(predicate) = predicate {
+                conditions.push(format!("({predicate})"));
+            }
+            conditions.push(format!("({gate})"));
+            conditions.extend(trailing.iter().cloned());
+            format!(
+                "(SELECT {select_columns} FROM {table_name} WHERE {} ORDER BY {order_by} LIMIT ${limit_param_idx})",
+                conditions.join(" AND "),
+            )
+        })
+        .collect();
+
+    format!(
+        "{} ORDER BY {order_by} LIMIT ${limit_param_idx}",
+        branch_sqls.join(" UNION ALL "),
+    )
+}
+
 /// The `deleted = FALSE` predicate for repos with soft delete, on the
 /// non-`include_deleted` fn variants.
 pub fn not_deleted_predicate(delete: DeleteOption) -> Option<String> {
@@ -249,6 +305,57 @@ impl CursorStruct<'_> {
         }
     }
 
+    /// The `UNION ALL` branches of the unified cursor query for one direction.
+    ///
+    /// Each branch is a `(gate, predicate)` pair. `gate` is a parameter-only
+    /// nullness guard — it references only `$id`/`$col`, never a row column —
+    /// so Postgres lifts it into a `One-Time Filter` Result node and skips dead
+    /// branches at execution; the single live branch then gets a plan identical
+    /// to its standalone per-state twin. `predicate` is the sargable cursor
+    /// comparison (`None` for the page-1 branch, which needs no predicate).
+    ///
+    /// - id / non-nullable sort column: 2 branches (First, After).
+    /// - `Option<T>` or `nullable`-annotated sort column: 3 branches (First,
+    ///   After, AfterNull).
+    ///
+    /// The `nullable`-annotated (non-`Option`) case shares the same 3-branch
+    /// form as `Option<T>`: the gates dispatch on `$col IS NULL` *in the
+    /// database*, where the encoded SQL NULL-ness is always visible — even
+    /// though Rust cannot see it from the non-`Option` type. This is what lets
+    /// these columns use the sargable branch form instead of the non-sargable
+    /// `COALESCE` catch-all (`CursorState::AfterMaybeNull`), making them
+    /// index-friendly for the first time.
+    ///
+    /// Branches are ordered so the page-1 (`First`) branch — whose only cursor
+    /// reference is the bare `$id IS NULL` guard — comes **last**. Every other
+    /// branch leads with a typed column comparison of the cursor parameters, so
+    /// each parameter's first textual occurrence in the assembled `UNION` is
+    /// type-determined. See [`assemble_union_select`] for why this matters.
+    pub fn cursor_branches(&self, offset: u32, ascending: bool) -> Vec<(String, Option<String>)> {
+        let id_offset = offset + 2;
+        let column_offset = offset + 3;
+
+        let first = (format!("${id_offset} IS NULL"), None);
+
+        if self.column.is_id() || !self.column.is_nullable_column() {
+            let after = (
+                format!("${id_offset} IS NOT NULL"),
+                self.condition_for_state(CursorState::After, offset, ascending),
+            );
+            vec![after, first]
+        } else {
+            let after = (
+                format!("${id_offset} IS NOT NULL AND ${column_offset} IS NOT NULL"),
+                self.condition_for_state(CursorState::After, offset, ascending),
+            );
+            let after_null = (
+                format!("${id_offset} IS NOT NULL AND ${column_offset} IS NULL"),
+                self.condition_for_state(CursorState::AfterNull, offset, ascending),
+            );
+            vec![after, after_null, first]
+        }
+    }
+
     /// Scrutinee elements (one or two bool expressions over the destructured
     /// cursor locals) identifying the cursor state at runtime.
     pub fn state_scrutinee_elems(&self) -> Vec<TokenStream> {
@@ -293,7 +400,11 @@ impl CursorStruct<'_> {
         }
     }
 
-    fn cursor_arg_tokens(&self) -> TokenStream {
+    /// The full cursor-value bindings (`id`, and the sort column for
+    /// non-id cursors), always in the same shape regardless of cursor state —
+    /// the unified query binds every parameter once and the branch gates
+    /// dispatch on their nullness in SQL.
+    pub fn cursor_arg_tokens(&self) -> TokenStream {
         let id = self.id;
 
         if self.column.is_id() {
@@ -607,54 +718,49 @@ impl ToTokens for ListByFn<'_> {
             let build_query_arms = |scope: Option<&ScopeInfo>| -> TokenStream {
                 let mut query_arms = TokenStream::new();
                 let offset = if scope.is_some() { 1 } else { 0 };
-                for state in cursor.cursor_states() {
-                    for ascending in [true, false] {
-                        let mut conditions: Vec<String> = Vec::new();
-                        if let Some(scope) = scope {
-                            conditions.push(scope.predicate(1));
-                        }
-                        if let Some(condition) =
-                            cursor.condition_for_state(*state, offset, ascending)
-                        {
-                            conditions.push(format!("({condition})"));
-                        }
-                        if delete == DeleteOption::No
-                            && let Some(not_deleted) = not_deleted_predicate(self.delete)
-                        {
-                            conditions.push(not_deleted);
-                        }
-                        let query = assemble_select(
-                            &select_columns,
-                            self.table_name,
-                            &conditions,
-                            &cursor.order_by(ascending),
-                            offset + 1,
-                        );
-                        let cursor_args = cursor.cursor_arg_tokens_for_state(*state);
-                        let scope_args = scope.map(|s| s.arg_tokens()).unwrap_or_default();
-                        let args = quote! {
-                            #scope_args
-                            (first + 1) as i64,
-                            #cursor_args
-                        };
-                        let es_query_call = make_es_query(&query, &args);
-                        let direction_pattern = if ascending {
-                            quote! { es_entity::ListDirection::Ascending }
-                        } else {
-                            quote! { es_entity::ListDirection::Descending }
-                        };
-                        let state_pattern = cursor.state_pattern_elems(*state);
-                        query_arms.append_all(quote! {
-                            (#direction_pattern, #(#state_pattern),*) => {
-                                #es_query_call.fetch_n(op, first).await?
-                            },
-                        });
+                for ascending in [true, false] {
+                    let mut leading: Vec<String> = Vec::new();
+                    if let Some(scope) = scope {
+                        leading.push(scope.predicate(1));
                     }
+                    let mut trailing: Vec<String> = Vec::new();
+                    if delete == DeleteOption::No
+                        && let Some(not_deleted) = not_deleted_predicate(self.delete)
+                    {
+                        trailing.push(not_deleted);
+                    }
+                    let branches = cursor.cursor_branches(offset, ascending);
+                    let query = assemble_union_select(
+                        &select_columns,
+                        self.table_name,
+                        &leading,
+                        &branches,
+                        &trailing,
+                        &cursor.order_by(ascending),
+                        offset + 1,
+                    );
+                    let cursor_args = cursor.cursor_arg_tokens();
+                    let scope_args = scope.map(|s| s.arg_tokens()).unwrap_or_default();
+                    let args = quote! {
+                        #scope_args
+                        (first + 1) as i64,
+                        #cursor_args
+                    };
+                    let es_query_call = make_es_query(&query, &args);
+                    let direction_pattern = if ascending {
+                        quote! { es_entity::ListDirection::Ascending }
+                    } else {
+                        quote! { es_entity::ListDirection::Descending }
+                    };
+                    query_arms.append_all(quote! {
+                        #direction_pattern => {
+                            #es_query_call.fetch_n(op, first).await?
+                        },
+                    });
                 }
                 query_arms
             };
             let query_arms = build_query_arms(None);
-            let cursor_state_scrutinee = cursor.state_scrutinee_elems();
 
             let (scope_fn_arg, scope_fn_pass, scope_convert) = match &self.scope {
                 Some(scope) => (scope.fn_arg(), scope.fn_pass(), scope.convert()),
@@ -664,19 +770,19 @@ impl ToTokens for ListByFn<'_> {
                 let scoped_query_arms = build_query_arms(Some(scope));
                 scope.dispatch(
                     quote! {
-                        match (direction, #(#cursor_state_scrutinee),*) {
+                        match direction {
                             #query_arms
                         }
                     },
                     quote! {
-                        match (direction, #(#cursor_state_scrutinee),*) {
+                        match direction {
                             #scoped_query_arms
                         }
                     },
                 )
             } else {
                 quote! {
-                    match (direction, #(#cursor_state_scrutinee),*) {
+                    match direction {
                         #query_arms
                     }
                 }
@@ -926,39 +1032,21 @@ mod tests {
                         None
                     };
 
-                    let (entities, has_next_page) = match (direction, id.is_none()) {
-                        (es_entity::ListDirection::Ascending, true) => {
+                    let (entities, has_next_page) = match direction {
+                        es_entity::ListDirection::Ascending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT id FROM entities WHERE deleted = FALSE ORDER BY id ASC LIMIT $1",
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Descending, true) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT id FROM entities WHERE deleted = FALSE ORDER BY id DESC LIMIT $1",
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Ascending, false) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT id FROM entities WHERE (id > $2) AND deleted = FALSE ORDER BY id ASC LIMIT $1",
+                                "(SELECT id FROM entities WHERE (id > $2) AND ($2 IS NOT NULL) AND deleted = FALSE ORDER BY id ASC LIMIT $1) UNION ALL (SELECT id FROM entities WHERE ($2 IS NULL) AND deleted = FALSE ORDER BY id ASC LIMIT $1) ORDER BY id ASC LIMIT $1",
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
                             )
                                 .fetch_n(op, first)
                                 .await?
                         },
-                        (es_entity::ListDirection::Descending, false) => {
+                        es_entity::ListDirection::Descending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT id FROM entities WHERE (id < $2) AND deleted = FALSE ORDER BY id DESC LIMIT $1",
+                                "(SELECT id FROM entities WHERE (id < $2) AND ($2 IS NOT NULL) AND deleted = FALSE ORDER BY id DESC LIMIT $1) UNION ALL (SELECT id FROM entities WHERE ($2 IS NULL) AND deleted = FALSE ORDER BY id DESC LIMIT $1) ORDER BY id DESC LIMIT $1",
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
                             )
@@ -1071,29 +1159,11 @@ mod tests {
                         (None, None)
                     };
 
-                    let (entities, has_next_page) = match (direction, id.is_none()) {
-                        (es_entity::ListDirection::Ascending, true) => {
+                    let (entities, has_next_page) = match direction {
+                        es_entity::ListDirection::Ascending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT name, id FROM entities ORDER BY name ASC, id ASC LIMIT $1",
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Descending, true) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT name, id FROM entities ORDER BY name DESC, id DESC LIMIT $1",
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Ascending, false) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT name, id FROM entities WHERE ((name, id) > ($3, $2)) ORDER BY name ASC, id ASC LIMIT $1",
+                                "(SELECT name, id FROM entities WHERE ((name, id) > ($3, $2)) AND ($2 IS NOT NULL) ORDER BY name ASC, id ASC LIMIT $1) UNION ALL (SELECT name, id FROM entities WHERE ($2 IS NULL) ORDER BY name ASC, id ASC LIMIT $1) ORDER BY name ASC, id ASC LIMIT $1",
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
                                 name as Option<String>,
@@ -1101,10 +1171,10 @@ mod tests {
                                 .fetch_n(op, first)
                                 .await?
                         },
-                        (es_entity::ListDirection::Descending, false) => {
+                        es_entity::ListDirection::Descending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT name, id FROM entities WHERE ((name, id) < ($3, $2)) ORDER BY name DESC, id DESC LIMIT $1",
+                                "(SELECT name, id FROM entities WHERE ((name, id) < ($3, $2)) AND ($2 IS NOT NULL) ORDER BY name DESC, id DESC LIMIT $1) UNION ALL (SELECT name, id FROM entities WHERE ($2 IS NULL) ORDER BY name DESC, id DESC LIMIT $1) ORDER BY name DESC, id DESC LIMIT $1",
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
                                 name as Option<String>,
@@ -1186,29 +1256,11 @@ mod tests {
                         (None, None)
                     };
 
-                    let (entities, has_next_page) = match (direction, id.is_some(), value.is_some()) {
-                        (es_entity::ListDirection::Ascending, false, _) => {
+                    let (entities, has_next_page) = match direction {
+                        es_entity::ListDirection::Ascending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT value, id FROM entities ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1",
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Descending, false, _) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT value, id FROM entities ORDER BY value DESC NULLS LAST, id DESC LIMIT $1",
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Ascending, true, true) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT value, id FROM entities WHERE ((value, id) > ($3, $2)) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1",
+                                "(SELECT value, id FROM entities WHERE ((value, id) > ($3, $2)) AND ($2 IS NOT NULL AND $3 IS NOT NULL) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1) UNION ALL (SELECT value, id FROM entities WHERE ((value IS NOT NULL OR id > $2)) AND ($2 IS NOT NULL AND $3 IS NULL) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1) UNION ALL (SELECT value, id FROM entities WHERE ($2 IS NULL) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1",
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
                                 value as Option<rust_decimal::Decimal>,
@@ -1216,33 +1268,13 @@ mod tests {
                                 .fetch_n(op, first)
                                 .await?
                         },
-                        (es_entity::ListDirection::Descending, true, true) => {
+                        es_entity::ListDirection::Descending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT value, id FROM entities WHERE ((value IS NULL OR (value, id) < ($3, $2))) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1",
+                                "(SELECT value, id FROM entities WHERE ((value IS NULL OR (value, id) < ($3, $2))) AND ($2 IS NOT NULL AND $3 IS NOT NULL) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1) UNION ALL (SELECT value, id FROM entities WHERE ((value IS NULL AND id < $2)) AND ($2 IS NOT NULL AND $3 IS NULL) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1) UNION ALL (SELECT value, id FROM entities WHERE ($2 IS NULL) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1",
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
                                 value as Option<rust_decimal::Decimal>,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Ascending, true, false) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT value, id FROM entities WHERE ((value IS NOT NULL OR id > $2)) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1",
-                                (first + 1) as i64,
-                                id as Option<EntityId>,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Descending, true, false) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT value, id FROM entities WHERE ((value IS NULL AND id < $2)) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1",
-                                (first + 1) as i64,
-                                id as Option<EntityId>,
                             )
                                 .fetch_n(op, first)
                                 .await?
@@ -1269,15 +1301,22 @@ mod tests {
         // The `nullable` attribute lets non-Option<T> Rust types (e.g. domain
         // enums whose custom sqlx::Encode writes NULL for one variant) opt
         // into the nullable-aware cursor SQL form. The Rust type is NOT
-        // syntactically Option<T>, but the emitted SQL should match what an
-        // Option<T> column would get: `NULLS FIRST/LAST` ordering, the
-        // `IS NOT DISTINCT FROM` cursor form, and the direction-aware NULL
-        // fallback.
+        // syntactically Option<T>, but the emitted SQL matches what an
+        // `Option<T>` column gets: the unified 3-branch `UNION ALL` query with
+        // `NULLS FIRST/LAST` ordering and the direction-aware NULL branches.
         //
-        // The query parameter cast (else branch of query_arg_tokens) still
+        // Crucially, the AfterNull branch's gate (`$3 IS NULL`) dispatches on
+        // the *encoded SQL* NULL-ness of the cursor value in the database —
+        // where it is always visible — even though Rust cannot see it from the
+        // non-`Option` type. This is what lets `nullable`-annotated columns use
+        // the sargable branch form instead of the non-sargable `COALESCE`
+        // catch-all (the eliminated `CursorState::AfterMaybeNull`), making them
+        // index-friendly for the first time.
+        //
+        // The query parameter cast (else branch of cursor_arg_tokens) still
         // wraps the Rust type in Option<...> because is_optional() remains
-        // false — the type itself drives binding, while the new
-        // is_nullable_column() drives SQL shape.
+        // false — the type itself drives binding, while is_nullable_column()
+        // drives SQL shape.
         let id_type = Ident::new("EntityId", Span::call_site());
         let entity = Ident::new("Entity", Span::call_site());
         let query_error = syn::Ident::new("EntityQueryError", Span::call_site());
@@ -1333,29 +1372,11 @@ mod tests {
                         (None, None)
                     };
 
-                    let (entities, has_next_page) = match (direction, id.is_none()) {
-                        (es_entity::ListDirection::Ascending, true) => {
+                    let (entities, has_next_page) = match direction {
+                        es_entity::ListDirection::Ascending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT value, id FROM entities ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1",
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Descending, true) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT value, id FROM entities ORDER BY value DESC NULLS LAST, id DESC LIMIT $1",
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Ascending, false) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT value, id FROM entities WHERE ((value IS NOT DISTINCT FROM $3) AND COALESCE(id > $2, true) OR COALESCE(value > $3, value IS NOT NULL)) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1",
+                                "(SELECT value, id FROM entities WHERE ((value, id) > ($3, $2)) AND ($2 IS NOT NULL AND $3 IS NOT NULL) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1) UNION ALL (SELECT value, id FROM entities WHERE ((value IS NOT NULL OR id > $2)) AND ($2 IS NOT NULL AND $3 IS NULL) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1) UNION ALL (SELECT value, id FROM entities WHERE ($2 IS NULL) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1) ORDER BY value ASC NULLS FIRST, id ASC LIMIT $1",
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
                                 value as Option<DomainEnum>,
@@ -1363,10 +1384,10 @@ mod tests {
                                 .fetch_n(op, first)
                                 .await?
                         },
-                        (es_entity::ListDirection::Descending, false) => {
+                        es_entity::ListDirection::Descending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT value, id FROM entities WHERE ((value IS NOT DISTINCT FROM $3) AND COALESCE(id < $2, true) OR COALESCE(value < $3, $2 IS NULL OR (value IS NULL AND $3 IS NOT NULL))) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1",
+                                "(SELECT value, id FROM entities WHERE ((value IS NULL OR (value, id) < ($3, $2))) AND ($2 IS NOT NULL AND $3 IS NOT NULL) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1) UNION ALL (SELECT value, id FROM entities WHERE ((value IS NULL AND id < $2)) AND ($2 IS NOT NULL AND $3 IS NULL) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1) UNION ALL (SELECT value, id FROM entities WHERE ($2 IS NULL) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1) ORDER BY value DESC NULLS LAST, id DESC LIMIT $1",
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
                                 value as Option<DomainEnum>,

--- a/es-entity-macros/src/repo/list_for_fn.rs
+++ b/es-entity-macros/src/repo/list_for_fn.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{TokenStreamExt, quote};
 
 use super::{
-    list_by_fn::{CursorStruct, assemble_select, not_deleted_predicate},
+    list_by_fn::{CursorStruct, assemble_union_select, not_deleted_predicate},
     options::*,
     scope::ScopeInfo,
 };
@@ -213,56 +213,51 @@ impl ToTokens for ListForFn<'_> {
             let build_query_arms = |scope: Option<&ScopeInfo>| -> TokenStream {
                 let mut query_arms = TokenStream::new();
                 let offset = if scope.is_some() { 2 } else { 1 };
-                for state in cursor.cursor_states() {
-                    for ascending in [true, false] {
-                        let mut conditions: Vec<String> =
-                            vec![format!("({for_column_name} {filter_op} $1)")];
-                        if let Some(scope) = scope {
-                            conditions.push(scope.predicate(2));
-                        }
-                        if let Some(condition) =
-                            cursor.condition_for_state(*state, offset, ascending)
-                        {
-                            conditions.push(format!("({condition})"));
-                        }
-                        if delete == DeleteOption::No
-                            && let Some(not_deleted) = not_deleted_predicate(self.delete)
-                        {
-                            conditions.push(not_deleted);
-                        }
-                        let query = assemble_select(
-                            &select_columns,
-                            self.table_name,
-                            &conditions,
-                            &cursor.order_by(ascending),
-                            offset + 1,
-                        );
-                        let cursor_args = cursor.cursor_arg_tokens_for_state(*state);
-                        let scope_args = scope.map(|s| s.arg_tokens()).unwrap_or_default();
-                        let args = quote! {
-                            #filter_arg_name as &#for_column_type,
-                            #scope_args
-                            (first + 1) as i64,
-                            #cursor_args
-                        };
-                        let es_query_call = make_es_query(&query, &args);
-                        let direction_pattern = if ascending {
-                            quote! { es_entity::ListDirection::Ascending }
-                        } else {
-                            quote! { es_entity::ListDirection::Descending }
-                        };
-                        let state_pattern = cursor.state_pattern_elems(*state);
-                        query_arms.append_all(quote! {
-                            (#direction_pattern, #(#state_pattern),*) => {
-                                #es_query_call.fetch_n(op, first).await?
-                            },
-                        });
+                for ascending in [true, false] {
+                    let mut leading: Vec<String> =
+                        vec![format!("({for_column_name} {filter_op} $1)")];
+                    if let Some(scope) = scope {
+                        leading.push(scope.predicate(2));
                     }
+                    let mut trailing: Vec<String> = Vec::new();
+                    if delete == DeleteOption::No
+                        && let Some(not_deleted) = not_deleted_predicate(self.delete)
+                    {
+                        trailing.push(not_deleted);
+                    }
+                    let branches = cursor.cursor_branches(offset, ascending);
+                    let query = assemble_union_select(
+                        &select_columns,
+                        self.table_name,
+                        &leading,
+                        &branches,
+                        &trailing,
+                        &cursor.order_by(ascending),
+                        offset + 1,
+                    );
+                    let cursor_args = cursor.cursor_arg_tokens();
+                    let scope_args = scope.map(|s| s.arg_tokens()).unwrap_or_default();
+                    let args = quote! {
+                        #filter_arg_name as &#for_column_type,
+                        #scope_args
+                        (first + 1) as i64,
+                        #cursor_args
+                    };
+                    let es_query_call = make_es_query(&query, &args);
+                    let direction_pattern = if ascending {
+                        quote! { es_entity::ListDirection::Ascending }
+                    } else {
+                        quote! { es_entity::ListDirection::Descending }
+                    };
+                    query_arms.append_all(quote! {
+                        #direction_pattern => {
+                            #es_query_call.fetch_n(op, first).await?
+                        },
+                    });
                 }
                 query_arms
             };
             let query_arms = build_query_arms(None);
-            let cursor_state_scrutinee = cursor.state_scrutinee_elems();
 
             let (scope_fn_arg, scope_fn_pass, scope_convert) = match &self.scope {
                 Some(scope) => (scope.fn_arg(), scope.fn_pass(), scope.convert()),
@@ -272,19 +267,19 @@ impl ToTokens for ListForFn<'_> {
                 let scoped_query_arms = build_query_arms(Some(scope));
                 scope.dispatch(
                     quote! {
-                        match (direction, #(#cursor_state_scrutinee),*) {
+                        match direction {
                             #query_arms
                         }
                     },
                     quote! {
-                        match (direction, #(#cursor_state_scrutinee),*) {
+                        match direction {
                             #scoped_query_arms
                         }
                     },
                 )
             } else {
                 quote! {
-                    match (direction, #(#cursor_state_scrutinee),*) {
+                    match direction {
                         #query_arms
                     }
                 }
@@ -476,31 +471,11 @@ mod tests {
                     } else {
                         None
                     };
-                    let (entities, has_next_page) = match (direction, id.is_none()) {
-                        (es_entity::ListDirection::Ascending, true) => {
+                    let (entities, has_next_page) = match direction {
+                        es_entity::ListDirection::Ascending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT customer_id, id FROM entities WHERE (customer_id = $1) ORDER BY id ASC LIMIT $2",
-                                filter_customer_id as &Uuid,
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Descending, true) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT customer_id, id FROM entities WHERE (customer_id = $1) ORDER BY id DESC LIMIT $2",
-                                filter_customer_id as &Uuid,
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Ascending, false) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT customer_id, id FROM entities WHERE (customer_id = $1) AND (id > $3) ORDER BY id ASC LIMIT $2",
+                                "(SELECT customer_id, id FROM entities WHERE (customer_id = $1) AND (id > $3) AND ($3 IS NOT NULL) ORDER BY id ASC LIMIT $2) UNION ALL (SELECT customer_id, id FROM entities WHERE (customer_id = $1) AND ($3 IS NULL) ORDER BY id ASC LIMIT $2) ORDER BY id ASC LIMIT $2",
                                 filter_customer_id as &Uuid,
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
@@ -508,10 +483,10 @@ mod tests {
                                 .fetch_n(op, first)
                                 .await?
                         },
-                        (es_entity::ListDirection::Descending, false) => {
+                        es_entity::ListDirection::Descending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT customer_id, id FROM entities WHERE (customer_id = $1) AND (id < $3) ORDER BY id DESC LIMIT $2",
+                                "(SELECT customer_id, id FROM entities WHERE (customer_id = $1) AND (id < $3) AND ($3 IS NOT NULL) ORDER BY id DESC LIMIT $2) UNION ALL (SELECT customer_id, id FROM entities WHERE (customer_id = $1) AND ($3 IS NULL) ORDER BY id DESC LIMIT $2) ORDER BY id DESC LIMIT $2",
                                 filter_customer_id as &Uuid,
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
@@ -596,31 +571,11 @@ mod tests {
                     } else {
                         (None, None)
                     };
-                    let (entities, has_next_page) = match (direction, id.is_none()) {
-                        (es_entity::ListDirection::Ascending, true) => {
+                    let (entities, has_next_page) = match direction {
+                        es_entity::ListDirection::Ascending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT email, id FROM entities WHERE (email = $1) ORDER BY email ASC, id ASC LIMIT $2",
-                                filter_email as &str,
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Descending, true) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT email, id FROM entities WHERE (email = $1) ORDER BY email DESC, id DESC LIMIT $2",
-                                filter_email as &str,
-                                (first + 1) as i64,
-                            )
-                                .fetch_n(op, first)
-                                .await?
-                        },
-                        (es_entity::ListDirection::Ascending, false) => {
-                            es_entity::es_query!(
-                                entity = Entity,
-                                "SELECT email, id FROM entities WHERE (email = $1) AND ((email, id) > ($4, $3)) ORDER BY email ASC, id ASC LIMIT $2",
+                                "(SELECT email, id FROM entities WHERE (email = $1) AND ((email, id) > ($4, $3)) AND ($3 IS NOT NULL) ORDER BY email ASC, id ASC LIMIT $2) UNION ALL (SELECT email, id FROM entities WHERE (email = $1) AND ($3 IS NULL) ORDER BY email ASC, id ASC LIMIT $2) ORDER BY email ASC, id ASC LIMIT $2",
                                 filter_email as &str,
                                 (first + 1) as i64,
                                 id as Option<EntityId>,
@@ -629,10 +584,10 @@ mod tests {
                                 .fetch_n(op, first)
                                 .await?
                         },
-                        (es_entity::ListDirection::Descending, false) => {
+                        es_entity::ListDirection::Descending => {
                             es_entity::es_query!(
                                 entity = Entity,
-                                "SELECT email, id FROM entities WHERE (email = $1) AND ((email, id) < ($4, $3)) ORDER BY email DESC, id DESC LIMIT $2",
+                                "(SELECT email, id FROM entities WHERE (email = $1) AND ((email, id) < ($4, $3)) AND ($3 IS NOT NULL) ORDER BY email DESC, id DESC LIMIT $2) UNION ALL (SELECT email, id FROM entities WHERE (email = $1) AND ($3 IS NULL) ORDER BY email DESC, id DESC LIMIT $2) ORDER BY email DESC, id DESC LIMIT $2",
                                 filter_email as &str,
                                 (first + 1) as i64,
                                 id as Option<EntityId>,

--- a/tests/unified_cursor_pagination.rs
+++ b/tests/unified_cursor_pagination.rs
@@ -1,0 +1,261 @@
+//! Acceptance tests for the unified cursor query emission.
+//!
+//! Since this change (unified `UNION ALL` cursor queries replacing the
+//! per-cursor-state matrix) two guarantees must hold and are covered here:
+//!
+//!  1. **Semantics are byte-identical** to the previous per-state / catch-all
+//!     forms — pagination through NULL and non-NULL sort values, in both
+//!     directions, must produce the exact same rows in the exact same order.
+//!     `unified_list_by_nullable_matches_reference_at_every_cursor` paginates
+//!     with page size 1 (and 2), so *every* row acts as a cursor and every
+//!     `NULL ↔ value` boundary is crossed, comparing against a Rust reference
+//!     ordering.
+//!  2. **The single query stays sargable** — Postgres lifts the per-branch
+//!     nullness guards into `One-Time Filter` nodes, skips the dead branches at
+//!     execution (`never executed`), and the live branch keeps the composite
+//!     `(col, id)` index qual. `unified_cursor_query_prunes_dead_branches`
+//!     asserts this on the pinned Postgres via `EXPLAIN ANALYZE`, guarding
+//!     against planner-behaviour drift across PG upgrades.
+
+mod entities;
+mod helpers;
+
+use sqlx::{PgPool, Row};
+
+use entities::transfer::*;
+use es_entity::*;
+
+/// Minimal repo over the shared `transfers` table with a nullable `score`
+/// sort column driving `list_by`.
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "Transfer",
+    columns(
+        account_id(ty = "AccountId"),
+        status(ty = "String"),
+        score(ty = "Option<i32>", list_by)
+    )
+)]
+pub struct Transfers {
+    pool: PgPool,
+}
+
+impl Transfers {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+async fn seed(
+    repo: &Transfers,
+    account_id: uuid::Uuid,
+    scores: &[Option<i32>],
+) -> anyhow::Result<()> {
+    for score in scores {
+        let new = NewTransfer::builder()
+            .id(TransferId::new())
+            .account_id(AccountId::from(account_id))
+            .status("unified_cursor_test")
+            .score(*score)
+            .build()
+            .unwrap();
+        repo.create(new).await?;
+    }
+    Ok(())
+}
+
+/// The Rust ground-truth order for `list_by_score`: ASC sorts NULLs first
+/// (then values by `(score, id)`), DESC sorts values by `(score, id)` desc then
+/// NULLs — mirroring `score ASC/DESC NULLS FIRST/LAST, id ASC/DESC`.
+fn reference_order(
+    rows: &[(uuid::Uuid, Option<i32>)],
+    direction: ListDirection,
+) -> Vec<uuid::Uuid> {
+    let mut nulls: Vec<_> = rows.iter().filter(|(_, s)| s.is_none()).collect();
+    let mut values: Vec<_> = rows.iter().filter(|(_, s)| s.is_some()).collect();
+    nulls.sort_by_key(|(id, _)| *id);
+    values.sort_by_key(|(id, s)| (*s, *id));
+    match direction {
+        ListDirection::Ascending => nulls.into_iter().chain(values).map(|(id, _)| *id).collect(),
+        ListDirection::Descending => values
+            .into_iter()
+            .rev()
+            .chain(nulls.into_iter().rev())
+            .map(|(id, _)| *id)
+            .collect(),
+    }
+}
+
+/// Paginate `list_by_score` fully at the given page size, retaining only the
+/// ids we seeded (the table is shared with other tests, but the ordering is
+/// total so filtering the returned stream preserves everything under test).
+async fn paginate(
+    repo: &Transfers,
+    direction: ListDirection,
+    first: usize,
+    ours: &std::collections::HashSet<uuid::Uuid>,
+) -> anyhow::Result<Vec<uuid::Uuid>> {
+    let mut out = Vec::new();
+    let mut after = None;
+    loop {
+        let ret = repo
+            .list_by_score(PaginatedQueryArgs { first, after }, direction)
+            .await?;
+        out.extend(ret.entities.iter().map(|t| uuid::Uuid::from(t.id)));
+        if !ret.has_next_page {
+            break;
+        }
+        after = ret.end_cursor;
+        assert!(after.is_some(), "has_next_page without end_cursor");
+    }
+    out.retain(|id| ours.contains(id));
+    Ok(out)
+}
+
+/// A page size of 1 makes *every* row act as a cursor, so both the `After`
+/// (cursor on a non-NULL score) and `AfterNull` (cursor on a NULL score)
+/// branches of the unified query — plus every `NULL ↔ value` boundary — are
+/// exercised in both directions. Page size 2 adds a second stride offset.
+#[tokio::test]
+async fn unified_list_by_nullable_matches_reference_at_every_cursor() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let repo = Transfers::new(pool.clone());
+
+    let account_id = uuid::Uuid::from(AccountId::new());
+    // Interleave NULLs and duplicate values so the (score, id) tiebreak and the
+    // NULL boundaries are both under test.
+    let scores = [
+        None,
+        Some(5),
+        None,
+        Some(3),
+        Some(7),
+        None,
+        Some(3),
+        Some(1),
+        None,
+        Some(5),
+    ];
+    seed(&repo, account_id, &scores).await?;
+
+    let rows: Vec<(uuid::Uuid, Option<i32>)> = {
+        let mut r = Vec::new();
+        for row in sqlx::query("SELECT id, score FROM transfers WHERE account_id = $1")
+            .bind(account_id)
+            .fetch_all(&pool)
+            .await?
+        {
+            r.push((
+                row.get::<uuid::Uuid, _>("id"),
+                row.get::<Option<i32>, _>("score"),
+            ));
+        }
+        r
+    };
+    let ours: std::collections::HashSet<uuid::Uuid> = rows.iter().map(|(id, _)| *id).collect();
+
+    for direction in [ListDirection::Ascending, ListDirection::Descending] {
+        let expected = reference_order(&rows, direction);
+        for first in [1usize, 2] {
+            let actual = paginate(&repo, direction, first, &ours).await?;
+            assert_eq!(
+                actual, expected,
+                "unified cursor pagination diverged from reference \
+                 (direction={direction:?}, page_size={first})"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// The unified query is one static `UNION ALL`; Postgres must lift the
+/// parameter-only nullness guards into `One-Time Filter` nodes so the dead
+/// branches are skipped (`never executed`) and the live `After` branch keeps
+/// the sargable composite-index qual. Verified on a single connection with a
+/// generic plan (the pooled prepared-statement condition) so the assertion
+/// reflects production planning, not a one-off custom plan.
+#[tokio::test]
+async fn unified_cursor_query_prunes_dead_branches() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut tx = pool.begin().await?;
+
+    sqlx::query("SET LOCAL plan_cache_mode = force_generic_plan")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("SET LOCAL enable_seqscan = off")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("CREATE TEMP TABLE u (id uuid, score int) ON COMMIT DROP")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(
+        "INSERT INTO u SELECT gen_random_uuid(), \
+         CASE WHEN g % 5 = 0 THEN NULL ELSE g END FROM generate_series(1, 300) g",
+    )
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query("CREATE INDEX ON u (score, id)")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("CREATE INDEX ON u (id)")
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("ANALYZE u").execute(&mut *tx).await?;
+
+    // A cursor sitting mid-table on a non-NULL score → the `After` branch is
+    // live, `AfterNull` and `First` must be pruned.
+    let mid_id: uuid::Uuid = sqlx::query("SELECT id FROM u WHERE score = 151 LIMIT 1")
+        .fetch_one(&mut *tx)
+        .await?
+        .get(0);
+
+    // The exact unified ASC query shape emitted by `assemble_union_select` for
+    // an `Option<i32>` sort column: predicate-before-gate, page-1 branch last,
+    // per-branch ORDER BY + LIMIT, outer ORDER BY + LIMIT. `$1` = limit,
+    // `$2` = cursor id, `$3` = cursor score. Prepared with explicit parameter
+    // types and executed via `EXECUTE` so `force_generic_plan` yields the
+    // pooled prepared-statement plan production uses (the guards stay symbolic,
+    // so the plan shows `never executed` rather than a constant-folded custom
+    // plan). `raw_sql` is used so sqlx does not treat the `$n` placeholders as
+    // its own bind parameters.
+    sqlx::raw_sql(
+        "PREPARE uq(int8, uuid, int) AS \
+         (SELECT score, id FROM u WHERE ((score, id) > ($3, $2)) AND ($2 IS NOT NULL AND $3 IS NOT NULL) ORDER BY score ASC NULLS FIRST, id ASC LIMIT $1) \
+         UNION ALL (SELECT score, id FROM u WHERE ((score IS NOT NULL OR id > $2)) AND ($2 IS NOT NULL AND $3 IS NULL) ORDER BY score ASC NULLS FIRST, id ASC LIMIT $1) \
+         UNION ALL (SELECT score, id FROM u WHERE ($2 IS NULL) ORDER BY score ASC NULLS FIRST, id ASC LIMIT $1) \
+         ORDER BY score ASC NULLS FIRST, id ASC LIMIT $1",
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    let plan = sqlx::raw_sql(&format!(
+        "EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) EXECUTE uq(5, '{mid_id}'::uuid, 151)"
+    ))
+    .fetch_all(&mut *tx)
+    .await?
+    .into_iter()
+    .map(|r| r.get::<String, _>(0))
+    .collect::<Vec<_>>()
+    .join("\n");
+
+    tx.rollback().await?;
+
+    // Guards lifted to One-Time Filters (a prerequisite for branch pruning).
+    assert!(
+        plan.contains("One-Time Filter"),
+        "expected the nullness guards to be lifted into One-Time Filter nodes, got:\n{plan}"
+    );
+    // Dead branches are skipped at execution.
+    assert!(
+        plan.contains("never executed"),
+        "expected the non-live branches to be pruned (never executed), got:\n{plan}"
+    );
+    // The live `After` branch keeps the sargable composite-index row qual.
+    assert!(
+        plan.contains("Index Cond: (ROW(score, id) > ROW($3, $2))"),
+        "expected the live branch to keep the sargable (score, id) index qual, got:\n{plan}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the [`design-es-entity-unified-cursor-queries.md`](https://github.com/GaloyMoney/drua-library/blob/main/spaces/es-entity-dev/design-es-entity-unified-cursor-queries.md) (approved direction by Justin, 2026-08-05): replace the per-cursor-state query matrix with a **single unified `UNION ALL` query per direction** in `list_by` and `list_for` codegen.

Since 0.11.9 (#162) every `list_by` sort column emits one static `es_query!` per cursor state × direction — **4** literals for non-nullable columns, **6** for `Option<T>`, per list-fn variant, doubled for scoped repos. This drove lana-bank's `.sqlx` count from 1319 → 3373 and `build_rc_release` from ~36 → ~53 min (lana-bank #7824). PR #175 proposed a per-column `cursor = "catch_all"` opt-out, but its COALESCE query is **non-sargable** (~270× slower at mid-table depth, measured).

This PR removes the tradeoff instead of naming it: the per-state predicates become `UNION ALL` branches, each gated by a parameter-only nullness guard that Postgres lifts into a **One-Time Filter**. Dead branches are skipped at execution (`never executed`) and the live branch keeps a plan **identical to its standalone per-state twin** — 4–6 queries → **2 per column**, zero runtime regression. Runtime dispatch collapses from `match (direction, id.is_some(), col.is_some())` to `match direction`.

`nullable`-annotated non-`Option` sort columns now share the sargable 3-branch form (the DB gates dispatch on encoded SQL NULL-ness, invisible to Rust) — index-friendly for the first time, no longer locked to the non-sargable COALESCE catch-all (`CursorState::AfterMaybeNull`).

## Verification (zero regression)

Confirmed on the pinned Postgres that the unified query's live branch is **plan-identical** to the current per-state query under `force_generic_plan` (both: `Index Cond: ROW(score,id) > ROW($3,$2)` on the composite index; dead branches `never executed`; guards lifted to `One-Time Filter`). The catch-all COALESCE #175 would have shipped was ~270× slower at the same depth.

- `nix flake check` — **all checks passed** (fmt, clippy `-D warnings`, audit, deny)
- `nix run .#nextest` — **149 passed** (147 prior + 2 new), incl. `sargable_list_queries.rs` and `scoped_repo_sargable.rs` **unmodified**
- macro unit tests — **110 passed** (6 token-stream snapshots regenerated for the new shape)
- doc tests — **3 passed**

New `tests/unified_cursor_pagination.rs`:
- `unified_list_by_nullable_matches_reference_at_every_cursor` — paginates a nullable column at page size 1 & 2 (every row a cursor, every NULL↔value boundary crossed) in both directions vs a Rust reference.
- `unified_cursor_query_prunes_dead_branches` — `EXPLAIN ANALYZE` asserts One-Time Filter nodes, dead branches `never executed`, and the live branch's sargable `(score, id)` index qual (guards against planner-behaviour drift across PG upgrades — design §9.5).

## Three `es_query!` integration details (all handled)

1. **ORDER BY extraction** — the regex grabs the first branch's `ORDER BY`, which is textually identical to the outer one → correct. All branch/outer ORDER BY texts are kept identical.
2. **Parameter type inference over `UNION ALL`** — Postgres infers untyped prepared-statement parameter types from their leftmost use across a UNION; a bare `$n IS NULL` there yields *"could not determine data type of parameter"* (breaks sqlx DESCRIBE). Fixed generically (no per-column SQL-type knowledge needed) by emitting **predicate-before-gate** with the **page-1 branch last**, so each parameter's first occurrence is a typed column comparison. Verified plan-equivalent to the design's cast-based gate-first shape.
3. **Nullability inference** — sqlx cannot infer the PK join key non-null through a `UNION ALL` CTE and would decode `entity_id` as `Option`. Fixed with `i.id AS "entity_id!: Repo__Id"` in `query/mod.rs` (safe no-op for non-union queries).

## Scope, semver, downstream

- **Scope: Phase 1 only** (`list_by` + `list_for`). The old `CursorState` machinery is retained — still used by `list_for_filters`. **P2** (unified cursors inside `list_for_filters` combo arms) and **P3** (`indexes()` attribute replacing `sargable_filters`, a breaking change needing a coordinated lana migration) are separate follow-ups.
- **Disposition of #175**: **superseded** by this design — recommend closing `feat/column-cursor-catch-all` and never releasing `cursor = "catch_all"`. Its reference-impl **test approach** is ported here.
- **Semver**: internal codegen change, no public trait break → **minor** (0.12.x on next release; CI handles the bump).
- **Downstream `.sqlx` regen**: es-entity commits no `.sqlx` cache, so the delta is entirely downstream — **cala** and **lana-bank** must regenerate `.sqlx` on the bump (large diff expected; byte-identical result semantics — same rows, order, NULL handling). Flagged, not touched here.

## Note

The clat PM channel was unreachable during this task (`ProjectFindError: NotFound(name=lana-data-delete)` on both `send_message` and `list_tasks` — a caller-project misconfiguration), so this DRAFT PR + the design doc are the plan-of-record. Left as **draft** for Justin's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated SQL and binding for every `list_by`/`list_for` repo; semantics are intended to be identical but mistakes would affect pagination and ordering. Planner-dependent branch pruning and downstream `.sqlx` regeneration add rollout surface area despite no public API break.
> 
> **Overview**
> Replaces the **per-cursor-state static query matrix** in `list_by` and `list_for` codegen with **one `UNION ALL` query per sort direction**. Each branch keeps the existing sargable cursor predicate and is gated by **parameter-only nullness checks** so Postgres can prune dead branches; runtime dispatch shrinks from `match (direction, cursor state)` to **`match direction`**.
> 
> Adds **`assemble_union_select`** and **`cursor_branches`** (predicate-before-gate, page-1 branch last for UNION parameter typing). **`nullable`-annotated non-`Option` sort columns** now emit the same three-branch sargable shape as `Option<T>` instead of the non-sargable `AfterMaybeNull` COALESCE path.
> 
> In **`es_query!`**, generated event hydration SQL uses **`entity_id!: Repo__Id`** so sqlx treats the PK join key as non-null through the `UNION ALL` entities CTE.
> 
> New acceptance tests in **`unified_cursor_pagination.rs`** compare full nullable pagination against a Rust reference order and **`EXPLAIN ANALYZE`** checks One-Time Filter pruning and composite index quals. **`list_for_filters`** still uses the old per-state `assemble_select` path (out of scope for this phase).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 106f16f238508c0cc13fcbef4225db053931e66e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->