### PR TITLE
ci: fix pre-1.0 breaking-change detection in release version bump

### DIFF
--- a/ci/vendor/tasks/prep-release-src.sh
+++ b/ci/vendor/tasks/prep-release-src.sh
@@ -40,7 +40,7 @@ fi
 
 HAS_BREAKING=0
 HAS_FEATURES=0
-if grep -q '\[**breaking**\]' artifacts/gh-release-notes.md; then
+if grep -qF '[**breaking**]' artifacts/gh-release-notes.md; then
   HAS_BREAKING=1
 fi
 if grep -q '^### Features' artifacts/gh-release-notes.md; then
@@ -54,14 +54,11 @@ if [[ "$CURR_VER" == "0.0.0" ]]; then
 
 else
   if (( IS_PRE_1 == 1 )); then
-    # Pre-1.0.0 -> 0.MAJOR.(minor|patch)
+    # Pre-1.0.0 -> 0.MINOR.PATCH (breaking bumps the middle component: 0.Y.0)
     if (( HAS_BREAKING == 1 )); then
-      echo "Breaking change detected on pre-1.0.0. The middle component (0.Y.Z) is your MANUAL breaking channel." >&2
-      echo "Please bump the middle component manually (e.g., 0.$((VMIN+1)).0) and re-run." >&2
-      exit 2
-    fi
-
-    if (( HAS_FEATURES == 1 )); then
+      echo "Breaking change detected on pre-1.0.0 — bumping MINOR (middle component: 0.$((VMIN+1)).0)."
+      bump2version minor --current-version "$CURR_VER" --allow-dirty version/version
+    elif (( HAS_FEATURES == 1 )); then
       echo "Pre-1.0.0 feature detected — bumping PATCH (third component) to reflect new functionality safely."
       bump2version patch --current-version "$CURR_VER" --allow-dirty version/version
     else


### PR DESCRIPTION
## Problem

Breaking changes on the pre-1.0 line were silently released as **patch** bumps instead of the intended minor bump. Most recently, the breaking `feat(macros)!` in #178 shipped as **0.11.13** instead of **0.12.0**.

Root cause is in `ci/vendor/tasks/prep-release-src.sh`:

```sh
if grep -q '\[**breaking**\]' artifacts/gh-release-notes.md; then
```

That pattern is a **basic regex**, so the `*`s are quantifiers, not literals — it does **not** match the literal `[**breaking**]` string git-cliff emits. `HAS_BREAKING` therefore stayed `0` and the pre-1.0 path fell through to a patch bump.

Verified:

```
grep -q  '\[**breaking**\]'  → NO MATCH   (guard never fires)
grep -qF  '[**breaking**]'   → MATCH
```

## Fix

1. **Match the marker as a fixed string** (`grep -qF '[**breaking**]'`) so breaking changes are actually detected.
2. **Pre-1.0 breaking → auto `bump2version minor`** (`0.Y.0`) instead of `exit 2`. The old "bump manually and re-run" path was effectively broken: on the re-run `prev_ref=$(git rev-list -n1 <version>)` can't resolve a tag that doesn't exist yet, so notes come out empty and it patch-bumps to the wrong number anyway.

## Note

This file is auto-synced from [GaloyMoney/concourse-shared](https://github.com/GaloyMoney/concourse-shared) ("Don't change this file..."). This is a local stopgap — the same fix should be applied upstream so it survives the next `vendir sync`. The `>=1.0` breaking path still `exit 2`s (major is intentionally manual) and has the same latent broken-re-run issue worth addressing upstream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation only in vendor CI script; behavior change is intentional (correct semver on pre-1.0) with no runtime or security impact.
> 
> **Overview**
> Fixes **pre-1.0.0 release versioning** in `prep-release-src.sh` so git-cliff’s `[**breaking**]` marker is actually detected and acted on.
> 
> **Breaking detection** switches from `grep -q '\[**breaking**\]'` (where `*` are regex quantifiers) to **`grep -qF '[**breaking**]'`**, so `HAS_BREAKING` is set when release notes include the literal marker.
> 
> On the **pre-1.0.0** path, a detected breaking change no longer **`exit 2`** with a manual middle-component bump. It now runs **`bump2version minor`** (e.g. `0.11.13` → `0.12.0`) with an informational message, avoiding the broken re-run path where the version tag doesn’t exist yet and notes can be empty.
> 
> Comments are updated to describe **0.MINOR.PATCH** and that breaking bumps the middle component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42c825a7a5b3f8b96d84bafa36bf0f5ac2dc8e9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->