### PR TITLE
feat(repo): id(scope) — scope a repo by its own id column

### DIFF
--- a/book/src/scoped-repositories.md
+++ b/book/src/scoped-repositories.md
@@ -42,6 +42,47 @@ There is deliberately **no** `From<Option<PartnerId>>`: mapping `None` to
 `All` would turn a stray `None` into silent all-scope access. All-scope reads
 must be written explicitly — `CustomerScope::All` is greppable and auditable.
 
+## Tenancy roots: `id(scope)`
+
+The tenancy-root entity itself — the `Partner` in a partner-scoped system —
+has no separate tenant column: its rows' scope value **is their own id**. For
+that case, mark the implicit id column:
+
+```rust,ignore
+#[derive(EsRepo)]
+#[es_repo(
+    entity = "Partner",
+    columns(
+        id(scope),
+        name(ty = "String", list_by),
+    )
+)]
+pub struct Partners {
+    pool: PgPool,
+}
+```
+
+The id column is macro-owned — its type comes from the repo-level `id`
+attribute and `find_by`/`list_by` are always on — so `id(scope)` is the only
+accepted entry; anything else (`ty`, `find_by = ...`) is a compile error.
+
+The generated surface is the ordinary scoped one: a `PartnerScope` enum and a
+leading scope argument on every read. Under `Only(p)` every query carries an
+`id = p` conjunct, so reads collapse to **self-or-nothing**:
+`find_by_id(Only(a), b)` is `NotFound` unless `a == b`, `find_all` intersects
+down to at most the own row, and every list returns the own row or nothing.
+Unlike ordinary scope columns, the id column keeps its point-read — under
+`Only` it is simply double-specified, composing exactly like a caller filter
+on the scope column (see below). No scope-led composite index is needed: the
+primary key already serves the `Only` arm.
+
+```rust,ignore
+// authz-derived scope: a tenant subject reads itself or nothing,
+// an all-access subject reads any row
+let scope: PartnerScope = self.authz.enforce_permission(sub, obj, act).await?.into();
+self.partners.maybe_find_by_id(scope, id).await?
+```
+
 ## The scoped read surface
 
 Every generated read function gains a leading `scope: impl Into<{Entity}Scope>`

--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -193,8 +193,9 @@ mod tests {
         let create_error = syn::Ident::new("EntityCreateError", Span::call_site());
 
         use darling::FromMeta;
-        let input: syn::Meta = syn::parse_quote!(columns(id = "EntityId", name = "String",));
-        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        let input: syn::Meta = syn::parse_quote!(columns(name = "String",));
+        let mut columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        columns.set_id_column(&Ident::new("EntityId", Span::call_site()));
 
         let create_fn = CreateAllFn {
             table_name: "entities",

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -298,11 +298,10 @@ mod tests {
         let create_error = syn::Ident::new("EntityCreateError", Span::call_site());
 
         use darling::FromMeta;
-        let input: syn::Meta = syn::parse_quote!(columns(
-            id = "EntityId",
-            name(ty = "String", create(accessor = "name()"))
-        ));
-        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        let input: syn::Meta =
+            syn::parse_quote!(columns(name(ty = "String", create(accessor = "name()"))));
+        let mut columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        columns.set_id_column(&Ident::new("EntityId", Span::call_site()));
 
         let create_fn = CreateFn {
             table_name: "entities",

--- a/es-entity-macros/src/repo/options/columns.rs
+++ b/es-entity-macros/src/repo/options/columns.rs
@@ -4,22 +4,29 @@ use quote::quote;
 #[derive(Default)]
 pub struct Columns {
     all: Vec<Column>,
+    /// Set by an `id(scope)` entry in `columns(...)`: marks the implicit
+    /// `id` column as the repo's scope column (applied in
+    /// [`Self::set_id_column`]). Used by tenancy-root repos whose rows' scope
+    /// value is their own id.
+    id_scope: bool,
 }
 
 impl Columns {
     #[cfg(test)]
     pub fn new(id: &syn::Ident, columns: impl IntoIterator<Item = Column>) -> Self {
         let all = columns.into_iter().collect();
-        let mut res = Columns { all };
+        let mut res = Columns {
+            all,
+            id_scope: false,
+        };
         res.set_id_column(id);
         res
     }
 
     pub fn set_id_column(&mut self, ty: &syn::Ident) {
-        let mut all = vec![
-            Column::for_created_at(),
-            Column::for_id(syn::parse_str(&ty.to_string()).unwrap()),
-        ];
+        let mut id_column = Column::for_id(syn::parse_str(&ty.to_string()).unwrap());
+        id_column.opts.scope = self.id_scope;
+        let mut all = vec![Column::for_created_at(), id_column];
         all.append(&mut self.all);
         self.all = all;
     }
@@ -424,12 +431,40 @@ impl Columns {
 
 impl FromMeta for Columns {
     fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
-        let all = items
-            .iter()
-            .map(Column::from_nested_meta)
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Columns { all })
+        let mut id_scope = false;
+        let mut all = Vec::new();
+        for item in items {
+            if let darling::ast::NestedMeta::Meta(meta) = item
+                && meta.path().is_ident("id")
+            {
+                if id_scope {
+                    return Err(darling::Error::custom("duplicate `id` column").with_span(meta));
+                }
+                id_scope = id_scope_from_meta(meta)?;
+                continue;
+            }
+            all.push(Column::from_nested_meta(item)?);
+        }
+        Ok(Columns { all, id_scope })
     }
+}
+
+/// The implicit `id` column is macro-owned — its type comes from the
+/// repo-level `id` attribute and `find_by`/`list_by` are always on — so the
+/// only supported entry is the `id(scope)` marker.
+fn id_scope_from_meta(meta: &syn::Meta) -> darling::Result<bool> {
+    let err =
+        || darling::Error::custom("the `id` column only supports `id(scope)`").with_span(meta);
+    let syn::Meta::List(list) = meta else {
+        return Err(err());
+    };
+    let inner: syn::punctuated::Punctuated<syn::Ident, syn::Token![,]> = list
+        .parse_args_with(syn::punctuated::Punctuated::parse_terminated)
+        .map_err(|_| err())?;
+    if inner.len() != 1 || inner[0] != "scope" {
+        return Err(err());
+    }
+    Ok(true)
 }
 
 #[derive(PartialEq)]
@@ -1116,5 +1151,70 @@ mod tests {
         assert_eq!(values.list_for_by_columns().len(), 2);
         assert_eq!(values.list_for_by_columns()[0].to_string(), "created_at");
         assert_eq!(values.list_for_by_columns()[1].to_string(), "id");
+    }
+
+    #[test]
+    fn id_scope_from_list() {
+        let input: syn::Meta = parse_quote!(columns(id(scope), name = "String"));
+        let mut columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        assert_eq!(columns.all.len(), 1);
+        columns.set_id_column(&parse_quote!(TestId));
+
+        let scope = columns.scope_column().expect("id should be scope column");
+        assert_eq!(scope.name().to_string(), "id");
+        // The id column keeps its point-read and cursor fns despite being
+        // the scope column (`for_id` opts in explicitly).
+        assert!(scope.opts.find_by());
+        assert!(scope.opts.list_by());
+        assert!(columns.validate_scope().is_ok());
+    }
+
+    #[test]
+    fn id_without_scope_stays_unscoped() {
+        let input: syn::Meta = parse_quote!(columns(name = "String"));
+        let mut columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        columns.set_id_column(&parse_quote!(TestId));
+        assert!(columns.scope_column().is_none());
+    }
+
+    fn parse_columns_err(input: syn::Meta) -> String {
+        match Columns::from_meta(&input) {
+            Err(err) => err.to_string(),
+            Ok(_) => panic!("expected error"),
+        }
+    }
+
+    #[test]
+    fn id_column_rejects_everything_but_scope() {
+        for input in [
+            parse_quote!(columns(id(ty = "TestId"), name = "String")),
+            parse_quote!(columns(id = "TestId")),
+            parse_quote!(columns(id(scope, find_by = false))),
+        ] {
+            let err = parse_columns_err(input);
+            assert!(
+                err.contains("id(scope)"),
+                "error should point at the id(scope) form: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_id_column_rejected() {
+        let err = parse_columns_err(parse_quote!(columns(id(scope), id(scope))));
+        assert!(err.contains("duplicate"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn id_scope_conflicts_with_column_scope() {
+        let input: syn::Meta =
+            parse_quote!(columns(id(scope), partner_id(ty = "PartnerId", scope)));
+        let mut columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        columns.set_id_column(&parse_quote!(TestId));
+        let err = columns.validate_scope().unwrap_err().to_string();
+        assert!(
+            err.contains("only one scope column"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/migrations/20260807000001_scoped_by_id_test.sql
+++ b/migrations/20260807000001_scoped_by_id_test.sql
@@ -1,0 +1,15 @@
+CREATE TABLE partners (
+  id UUID PRIMARY KEY,
+  name VARCHAR NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE partner_events (
+  id UUID NOT NULL REFERENCES partners(id),
+  sequence INT NOT NULL,
+  event_type VARCHAR NOT NULL,
+  event JSONB NOT NULL,
+  context JSONB DEFAULT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(id, sequence)
+);

--- a/tests/entities/mod.rs
+++ b/tests/entities/mod.rs
@@ -1,6 +1,7 @@
 pub mod contact;
 pub mod customer;
 pub mod order;
+pub mod partner;
 pub mod profile;
 pub mod task;
 pub mod transfer;

--- a/tests/entities/partner.rs
+++ b/tests/entities/partner.rs
@@ -1,0 +1,67 @@
+#![allow(dead_code)]
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use es_entity::*;
+
+pub use super::contact::PartnerId;
+
+/// Mirrors the shape of lana's tenancy-root entity: the rows' scope value is
+/// their own `id` — there is no separate tenant column. Scoped repos for such
+/// entities mark the implicit id column via `id(scope)`.
+#[derive(EsEvent, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "PartnerId")]
+pub enum PartnerEvent {
+    Initialized { id: PartnerId, name: String },
+}
+
+#[derive(EsEntity, Builder)]
+#[builder(pattern = "owned", build_fn(error = "EntityHydrationError"))]
+pub struct Partner {
+    pub id: PartnerId,
+    pub name: String,
+
+    events: EntityEvents<PartnerEvent>,
+}
+
+impl TryFromEvents<PartnerEvent> for Partner {
+    fn try_from_events(events: EntityEvents<PartnerEvent>) -> Result<Self, EntityHydrationError> {
+        let mut builder = PartnerBuilder::default();
+        for event in events.iter_all() {
+            match event {
+                PartnerEvent::Initialized { id, name } => {
+                    builder = builder.id(*id).name(name.clone());
+                }
+            }
+        }
+        builder.events(events).build()
+    }
+}
+
+#[derive(Debug, Builder)]
+pub struct NewPartner {
+    #[builder(setter(into))]
+    pub id: PartnerId,
+    #[builder(setter(into))]
+    pub name: String,
+}
+
+impl NewPartner {
+    pub fn builder() -> NewPartnerBuilder {
+        NewPartnerBuilder::default()
+    }
+}
+
+impl IntoEvents<PartnerEvent> for NewPartner {
+    fn into_events(self) -> EntityEvents<PartnerEvent> {
+        EntityEvents::init(
+            self.id,
+            [PartnerEvent::Initialized {
+                id: self.id,
+                name: self.name,
+            }],
+        )
+    }
+}

--- a/tests/scoped_repo_by_id.rs
+++ b/tests/scoped_repo_by_id.rs
@@ -1,0 +1,238 @@
+mod entities;
+mod helpers;
+
+use sqlx::PgPool;
+
+use entities::partner::*;
+use es_entity::*;
+
+/// Id-scoped repo — the tenancy-root variant of a scoped repository. The
+/// entity has no separate tenant column: its rows' scope value is its own
+/// `id`, marked via `id(scope)`. Every generated read fn requires a leading
+/// `scope: impl Into<PartnerScope>` argument; under `Only(id)` every query
+/// carries an `id = $n` conjunct, so reads collapse to self-or-nothing —
+/// missing and not-yours look identical. `All` reads across scopes. Writes
+/// (`create`, `update`, `delete`) keep their unscoped signatures.
+#[derive(EsRepo, Debug)]
+#[es_repo(entity = "Partner", columns(id(scope), name(ty = "String", list_by)))]
+pub struct Partners {
+    pool: PgPool,
+}
+
+impl Partners {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+async fn seed_partner(repo: &Partners, name: &str) -> anyhow::Result<PartnerId> {
+    let id = PartnerId::new();
+    let new = NewPartner::builder()
+        .id(id)
+        .name(format!("{name}-{id}"))
+        .build()
+        .unwrap();
+    // create is deliberately unscoped: the id is ordinary NewEntity data.
+    repo.create(new).await?;
+    Ok(id)
+}
+
+#[tokio::test]
+async fn id_scoped_point_reads() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let partners = Partners::new(pool);
+
+    let partner_a = seed_partner(&partners, "a").await?;
+    let partner_b = seed_partner(&partners, "b").await?;
+
+    // own scope: found — `impl Into<PartnerScope>` accepts the id directly
+    // (From<PartnerId> => Only), a reference, or the explicit enum.
+    let found = partners.find_by_id(partner_a, partner_a).await?;
+    assert_eq!(found.id, partner_a);
+    partners.find_by_id(&partner_a, partner_a).await?;
+    partners
+        .find_by_id(PartnerScope::Only(partner_a), partner_a)
+        .await?;
+
+    // foreign scope: missing and not-yours look identical
+    let err = partners.find_by_id(partner_b, partner_a).await;
+    assert!(matches!(err, Err(PartnerFindError::NotFound { .. })));
+    assert!(
+        partners
+            .maybe_find_by_id(partner_a, partner_b)
+            .await?
+            .is_none()
+    );
+
+    // All: reads across scopes (audited escape hatch)
+    partners.find_by_id(PartnerScope::All, partner_a).await?;
+    partners.find_by_id(PartnerScope::All, partner_b).await?;
+
+    // lookup columns are scoped the same way: another partner's name is
+    // invisible under your scope
+    let name = partners.find_by_id(partner_a, partner_a).await?.name;
+    partners.find_by_name(partner_a, &name).await?;
+    assert!(
+        partners
+            .maybe_find_by_name(partner_b, &name)
+            .await?
+            .is_none()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn id_scoped_reads_in_op() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let partners = Partners::new(pool);
+
+    let partner_a = seed_partner(&partners, "op-a").await?;
+    let partner_b = seed_partner(&partners, "op-b").await?;
+
+    let mut op = partners.begin_op().await?;
+    partners
+        .find_by_id_in_op(&mut op, partner_a, partner_a)
+        .await?;
+    assert!(
+        partners
+            .maybe_find_by_id_in_op(&mut op, partner_b, partner_a)
+            .await?
+            .is_none()
+    );
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn id_scoped_find_all_intersects_to_own_row() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let partners = Partners::new(pool);
+
+    let partner_a = seed_partner(&partners, "fa").await?;
+    let partner_b = seed_partner(&partners, "fb").await?;
+    let all_ids = [partner_a, partner_b];
+
+    // Only(a): at most the own row — foreign ids are silently absent.
+    let found = partners.find_all::<Partner>(partner_a, &all_ids).await?;
+    assert_eq!(found.len(), 1);
+    assert!(found.contains_key(&partner_a));
+
+    // All: everything.
+    let found = partners
+        .find_all::<Partner>(PartnerScope::All, &all_ids)
+        .await?;
+    assert_eq!(found.len(), 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn id_scoped_lists_return_own_row() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let partners = Partners::new(pool);
+
+    let partner_a = seed_partner(&partners, "la").await?;
+    let partner_b = seed_partner(&partners, "lb").await?;
+
+    // Only(a): exactly the own row, whatever the page size.
+    let ret = partners
+        .list_by_created_at(
+            partner_a,
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert_eq!(ret.entities.len(), 1);
+    assert_eq!(ret.entities[0].id, partner_a);
+    assert!(!ret.has_next_page);
+
+    // unified dispatch: no filter routes through the (scoped) list_by proxy
+    let ret = partners
+        .list_for_filters(
+            partner_a,
+            PartnerFilters::default(),
+            Sort {
+                by: PartnerSortBy::CreatedAt,
+                direction: ListDirection::Descending,
+            },
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+        )
+        .await?;
+    assert_eq!(ret.entities.len(), 1);
+    assert_eq!(ret.entities[0].id, partner_a);
+
+    // All sees both rows (fresh seeds are newest under Descending).
+    let ret = partners
+        .list_by_created_at(
+            PartnerScope::All,
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert!(ret.entities.iter().any(|p| p.id == partner_a));
+    assert!(ret.entities.iter().any(|p| p.id == partner_b));
+
+    Ok(())
+}
+
+/// The `repo.scoped(scope)` bound view captures the scope once and exposes
+/// every read fn without the per-call scope argument.
+#[tokio::test]
+async fn id_scoped_view_delegates() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let partners = Partners::new(pool);
+
+    let partner_a = seed_partner(&partners, "va").await?;
+    let partner_b = seed_partner(&partners, "vb").await?;
+
+    let view = partners.scoped(partner_a);
+    view.find_by_id(partner_a).await?;
+    assert!(view.maybe_find_by_id(partner_b).await?.is_none());
+
+    let found = view.find_all::<Partner>(&[partner_a, partner_b]).await?;
+    assert_eq!(found.len(), 1);
+
+    let ret = view
+        .list_by_created_at(
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert_eq!(ret.entities.len(), 1);
+
+    // `_in_op` variants through the view
+    let mut op = partners.begin_op().await?;
+    view.find_by_id_in_op(&mut op, partner_a).await?;
+    assert!(
+        view.maybe_find_by_id_in_op(&mut op, partner_b)
+            .await?
+            .is_none()
+    );
+    op.commit().await?;
+
+    // All through the view
+    let all_view = partners.scoped(PartnerScope::All);
+    assert_eq!(
+        all_view
+            .find_all::<Partner>(&[partner_a, partner_b])
+            .await?
+            .len(),
+        2
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Scoped repositories require a scope column, and until now that column had to be a user-declared one — the implicit `id` column is synthesized with `scope: false` hardcoded. That leaves the **tenancy root** entity out: the `Partner` in a partner-scoped system has no separate tenant column, because its rows' scope value *is their own id*. This PR closes that gap with an `id(scope)` marker.

## Declaring

```rust
#[derive(EsRepo)]
#[es_repo(
    entity = "Partner",
    columns(id(scope), name(ty = "String", list_by))
)]
pub struct Partners {
    pool: PgPool,
}
```

The id column stays macro-owned: its type comes from the repo-level `id` attribute and `find_by`/`list_by` remain always on. `id(scope)` is therefore the **only** accepted entry — `id(ty = ...)`, `id = "..."`, `id(scope, find_by = false)`, and duplicate `id` entries are all targeted compile errors. (As a side effect this closes a pre-existing loophole where `id = "T"` inside `columns(...)` silently created a second, colliding `id` column.)

## Generated functions

The surface is the ordinary scoped one — an entity-named scope enum plus a leading `scope: impl Into<PartnerScope>` argument on every read fn:

```rust
pub enum PartnerScope {
    All,              // no filter — reads across all scopes
    Only(PartnerId),  // restricts every read to this id
}

// point reads (find_by columns: id, name)
partners.find_by_id(scope, id).await?;
partners.maybe_find_by_id(scope, id).await?;
partners.find_by_id_in_op(&mut op, scope, id).await?;
partners.maybe_find_by_id_in_op(&mut op, scope, id).await?;
partners.find_by_name(scope, name).await?;            // + maybe / _in_op variants

// batch + lists
partners.find_all::<Partner>(scope, &ids).await?;     // + _in_op
partners.list_by_id(scope, args, direction).await?;
partners.list_by_created_at(scope, args, direction).await?;
partners.list_by_name(scope, args, direction).await?;
partners.list_for_filters(scope, filters, sort, args).await?;

// bound view: capture the scope once
let view = partners.scoped(scope);                    // ScopedPartners<'_>
view.maybe_find_by_id(id).await?;
```

Writes (`create`, `create_all`, `update`, `delete`) keep their unscoped signatures, as on every scoped repo.

## Semantics

`All` executes byte-identical SQL to an unscoped repo. `Only(p)` adds an `id = $n` conjunct to every query, so reads collapse to **self-or-nothing** — missing and not-yours look identical:

```rust
partners.find_by_id(partner_a, partner_a).await?;                  // found
partners.find_by_id(partner_b, partner_a).await;                   // NotFound
partners.maybe_find_by_id(partner_a, partner_b).await?;            // None
partners.find_all::<Partner>(partner_a, &[a, b]).await?;           // {a} only
partners.list_by_created_at(partner_a, args, dir).await?;          // exactly own row
```

The intended caller shape (authz-derived scope, e.g. lana's partner module):

```rust
let scope: PartnerScope = self.authz.enforce_permission(sub, obj, act).await?.into();
self.partner_repo.maybe_find_by_id(scope, id).await?   // tenant: self-or-None; bank: any row
```

`find_by_id` under `Only` is double-specified (`id = $1 AND id = $2`) — the same contradictory-predicate composition as a caller filter on an ordinary scope column: it can narrow, never widen. No scope-led composite index is needed; the primary key already serves the `Only` arm.

## Implementation

The flag is parsed in `Columns::from_list` and applied in `set_id_column`; from there `scope_column()`, `validate_scope` (incl. the one-scope-column rule catching `id(scope)` + a column-level `scope`), the scope-enum generation, all five read emitters, and the `.scoped()` view pick it up unchanged — zero edits outside `options/columns.rs` apart from moving two `create_fn`/`create_all_fn` unit tests off the now-rejected `id = "EntityId"` fixture onto the production `set_id_column` path (identical expected tokens).

## Tests & docs

- unit: parse/reject/duplicate/conflict cases, `find_by`/`list_by` retention on the id column
- integration (`tests/scoped_repo_by_id.rs`, new `Partner` tenancy-root entity + migration): scoped point reads incl. `find_by_name`, `_in_op` variants, `find_all` intersection, lists returning exactly the own row, `.scoped()` view delegation, `All` escape hatch
- book: "Tenancy roots: `id(scope)`" section in *Scoped Repositories*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
