### PR TITLE
fix(macros): classify FK/CHECK/exclusion violations as ConstraintViolation

### DIFF
--- a/book/src/repo-errors.md
+++ b/book/src/repo-errors.md
@@ -31,7 +31,7 @@ pub enum UserCreateError {
 
 ### Handling constraint violations
 
-When a `create` or `create_all` operation violates a unique constraint, the error is returned as `ConstraintViolation` rather than a raw `Sqlx` error. The `column` field identifies which column caused the violation and the `value` field contains the conflicting value extracted from the PostgreSQL error detail.
+When a `create` or `create_all` operation violates a **named** database constraint — unique, foreign key, check, or exclusion — the error is returned as `ConstraintViolation` rather than a raw `Sqlx` error. (`NOT NULL` violations carry no constraint name in PostgreSQL and remain `Sqlx`.) For unique violations, the `column` field identifies which column caused the violation and the `value` field contains the conflicting value extracted from the PostgreSQL error detail. For other constraint kinds — or unique constraints not recognized as belonging to one of the entity's columns — `column` and `value` are `None`, and the violated constraint's name is available via the `constraint_name()` helper.
 
 > **Security note:** `value` (and the `duplicate_value()` helper) contains attacker-influenced input that was rejected by a unique constraint and is frequently PII (e.g. an email address). Do not propagate it to untrusted API clients — a caller can probe which values already exist (user enumeration) — and be aware it may end up in logs via the error's `Display`/`Debug` output. At trust boundaries, prefer the boolean helpers `was_duplicate()` / `was_duplicate_by(column)` and map the error to a neutral client-facing message.
 
@@ -52,6 +52,18 @@ match result {
     Err(e) if e.was_duplicate_by(UserColumn::Email) => {
         let value = e.duplicate_value(); // Option<&str>
         println!("email {} already taken", value.unwrap_or("unknown"));
+    }
+    Err(e) => return Err(e.into()),
+}
+```
+
+The `was_duplicate()` / `was_duplicate_by(column)` helpers only fire for **unique** violations. To dispatch on a hand-written foreign-key or check constraint, match the constraint name:
+
+```rust,ignore
+match result {
+    Ok(entry) => { /* success */ }
+    Err(e) if e.constraint_name() == Some("entries_account_not_account_set_fkey") => {
+        return Err(AppError::EntryTargetsAccountSet);
     }
     Err(e) => return Err(e.into()),
 }

--- a/book/src/repo-errors.md
+++ b/book/src/repo-errors.md
@@ -31,7 +31,7 @@ pub enum UserCreateError {
 
 ### Handling constraint violations
 
-When a `create` or `create_all` operation violates a **named** database constraint — unique, foreign key, check, or exclusion — the error is returned as `ConstraintViolation` rather than a raw `Sqlx` error. (`NOT NULL` violations carry no constraint name in PostgreSQL and remain `Sqlx`.) For unique violations, the `column` field identifies which column caused the violation and the `value` field contains the conflicting value extracted from the PostgreSQL error detail. For other constraint kinds — or unique constraints not recognized as belonging to one of the entity's columns — `column` and `value` are `None`, and the violated constraint's name is available via the `constraint_name()` helper.
+When a `create` or `create_all` operation violates a **unique**, **foreign key**, or **check** constraint, the error is returned as `ConstraintViolation` rather than a raw `Sqlx` error. (`NOT NULL` and exclusion violations are not classified and remain `Sqlx`.) For unique violations, the `column` field identifies which column caused the violation and the `value` field contains the conflicting value extracted from the PostgreSQL error detail. For foreign key and check violations — or unique constraints not recognized as belonging to one of the entity's columns — `column` and `value` are `None`; use the typed `violated_constraint()` helper (or the raw `constraint_name()`) to identify the constraint instead.
 
 > **Security note:** `value` (and the `duplicate_value()` helper) contains attacker-influenced input that was rejected by a unique constraint and is frequently PII (e.g. an email address). Do not propagate it to untrusted API clients — a caller can probe which values already exist (user enumeration) — and be aware it may end up in logs via the error's `Display`/`Debug` output. At trust boundaries, prefer the boolean helpers `was_duplicate()` / `was_duplicate_by(column)` and map the error to a neutral client-facing message.
 
@@ -57,16 +57,28 @@ match result {
 }
 ```
 
-The `was_duplicate()` / `was_duplicate_by(column)` helpers only fire for **unique** violations. To dispatch on a hand-written foreign-key or check constraint, match the constraint name:
+The `was_duplicate()` / `was_duplicate_by(column)` helpers only fire for **unique** violations; `was_foreign_key_violation()` and `was_check_violation()` cover the other classified kinds.
+
+### Typed constraints: `UserConstraint`
+
+Alongside the column enum, the macro derives a `UserConstraint` enum with one variant per constraint on the entity's table known at compile time: the declared columns' unique constraints (convention names like `users_email_key` / `users_pkey`) plus every unique, foreign key, and check constraint discoverable from the migrations directory (the same catalog that drives `list_for_filters` specialization). Variant names strip the table prefix — `entries_account_not_account_set_fkey` on table `entries` becomes `EntryConstraint::AccountNotAccountSetFkey`.
+
+This makes dispatching on a hand-written foreign-key or check constraint typo-proof — no string matching at the call site, and a renamed constraint in a migration surfaces as a compile error instead of a silently dead match arm:
 
 ```rust,ignore
 match result {
     Ok(entry) => { /* success */ }
-    Err(e) if e.constraint_name() == Some("entries_account_not_account_set_fkey") => {
+    Err(e) if e.violated_constraint() == Some(EntryConstraint::AccountNotAccountSetFkey) => {
         return Err(AppError::EntryTargetsAccountSet);
     }
     Err(e) => return Err(e.into()),
 }
+```
+
+Each variant knows its raw name (`constraint.name()` / `Display`) and kind (`constraint.kind()` → `ConstraintKind::{Unique, ForeignKey, Check}`). Constraints created outside discoverable migrations can't be typed; fall back to `constraint_name()` for those:
+
+```rust,ignore
+Err(e) if e.constraint_name() == Some("added_at_runtime_fkey") => { /* ... */ }
 ```
 
 The macro maps PostgreSQL constraint names to columns automatically. It uses the convention `{table}_{column}_key` for unique constraints and `{table}_pkey` for the primary key, and additionally derives the real names of any **named** single-column unique index from your migrations (the same index catalog that drives `list_for_filters` specialization — see [list_for_filters](./repo-list-for-filters.md)). So a `CREATE UNIQUE INDEX idx_unique_email ON users (email)` in a migration is mapped to the `email` column with no extra annotation — as long as the migrations directory is discoverable (crate-local `migrations/`, an ancestor `migrations/` up to the repo root, or `ES_ENTITY_MIGRATIONS_DIR`). A composite `UNIQUE (a, b)` is mapped to its **last** key column (`b`) — the discriminating column, with the leading columns acting as its scope — so a `UNIQUE (partner_id, name)` violation reports the `name` column.

--- a/es-entity-macros/src/index_catalog.rs
+++ b/es-entity-macros/src/index_catalog.rs
@@ -47,11 +47,37 @@ pub struct IndexEntry {
     pub partial: bool,
 }
 
+/// The kind of a classified table constraint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConstraintKind {
+    /// `UNIQUE` / `PRIMARY KEY` constraints and `UNIQUE` indexes.
+    Unique,
+    /// `FOREIGN KEY` / `REFERENCES` constraints.
+    ForeignKey,
+    /// `CHECK` constraints.
+    Check,
+}
+
+/// One named (or deterministically Postgres-auto-named) constraint on a table
+/// whose violation the generated repo error classifier can type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConstraintEntry {
+    /// Lowercased, unquoted table name (schema qualifier stripped).
+    pub table: String,
+    /// Constraint (or unique index) name as reported by Postgres at violation
+    /// time — explicit when the DDL names it, else synthesized with Postgres'
+    /// auto-naming convention.
+    pub name: String,
+    pub kind: ConstraintKind,
+}
+
 /// The set of indexes that exist after applying every migration statement in
 /// filename order.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct IndexCatalog {
     pub entries: Vec<IndexEntry>,
+    /// Classified constraints (unique / foreign key / check) per table.
+    pub constraints: Vec<ConstraintEntry>,
 }
 
 /// Sentinel column recorded for an expression/opaque index key element; it is
@@ -91,6 +117,7 @@ impl IndexCatalog {
 
         let dialect = PostgreSqlDialect {};
         let mut entries: Vec<IndexEntry> = Vec::new();
+        let mut constraints: Vec<ConstraintEntry> = Vec::new();
         for (_, sql) in sorted {
             let stripped = strip_comments(sql);
             for statement in split_statements(&stripped) {
@@ -98,13 +125,17 @@ impl IndexCatalog {
                 // does not discard the rest of the file.
                 if let Ok(parsed) = Parser::parse_sql(&dialect, &statement) {
                     for stmt in &parsed {
-                        apply_statement(&mut entries, stmt);
+                        apply_statement(&mut entries, &mut constraints, stmt);
                     }
                 }
             }
         }
         entries.dedup();
-        Self { entries }
+        constraints.dedup();
+        Self {
+            entries,
+            constraints,
+        }
     }
 
     /// Whether a `list_for_filters` query over `table`, filtering on the
@@ -157,23 +188,52 @@ impl IndexCatalog {
             .filter_map(|entry| entry.name.clone())
             .collect()
     }
+
+    /// Every classified constraint on `table` as `(name, kind)` pairs, deduped
+    /// by name in first-seen order. Feeds the generated `{Entity}Constraint`
+    /// enum.
+    pub fn table_constraints(&self, table: &str) -> Vec<(String, ConstraintKind)> {
+        let table = table.to_lowercase();
+        let mut seen: Vec<(String, ConstraintKind)> = Vec::new();
+        for entry in self.constraints.iter().filter(|c| c.table == table) {
+            if !seen.iter().any(|(name, _)| name == &entry.name) {
+                seen.push((entry.name.clone(), entry.kind));
+            }
+        }
+        seen
+    }
 }
 
 // ── AST → catalog ───────────────────────────────────────────────────────────
 
-fn apply_statement(entries: &mut Vec<IndexEntry>, stmt: &Statement) {
+fn apply_statement(
+    entries: &mut Vec<IndexEntry>,
+    constraints: &mut Vec<ConstraintEntry>,
+    stmt: &Statement,
+) {
     match stmt {
         Statement::CreateIndex(create) => {
             let Some(table) = last_ident(&create.table_name) else {
                 return;
             };
+            let columns: Vec<String> = create.columns.iter().map(index_column_name).collect();
+            let name = create.name.as_ref().and_then(last_ident);
+            if create.unique {
+                // Postgres names an unnamed index `{table}_{cols}_idx`.
+                let constraint_name = name
+                    .clone()
+                    .or_else(|| synthesized_name(&table, &columns, "idx"));
+                if let Some(constraint_name) = constraint_name {
+                    push_constraint(constraints, &table, constraint_name, ConstraintKind::Unique);
+                }
+            }
             push_entry(
                 entries,
                 IndexEntry {
                     table,
-                    columns: create.columns.iter().map(index_column_name).collect(),
+                    columns,
                     unique: create.unique,
-                    name: create.name.as_ref().and_then(last_ident),
+                    name,
                     partial: create.predicate.is_some(),
                 },
             );
@@ -183,31 +243,57 @@ fn apply_statement(entries: &mut Vec<IndexEntry>, stmt: &Statement) {
                 return;
             };
             // Inline column `PRIMARY KEY` / `UNIQUE` -> single-column unique index.
+            // All inline constraint kinds -> classified constraint entries.
             for column in &create.columns {
-                let inline_unique = column.options.iter().any(|opt| {
-                    matches!(
+                let col = column.name.value.to_lowercase();
+                for opt in &column.options {
+                    let explicit = |name: &Option<sqlparser::ast::Ident>| {
+                        name.as_ref()
+                            .or(opt.name.as_ref())
+                            .map(|i| i.value.to_lowercase())
+                    };
+                    let classified = match &opt.option {
+                        ColumnOption::PrimaryKey(pk) => Some((
+                            explicit(&pk.name).unwrap_or_else(|| format!("{table}_pkey")),
+                            ConstraintKind::Unique,
+                        )),
+                        ColumnOption::Unique(u) => Some((
+                            explicit(&u.name).unwrap_or_else(|| format!("{table}_{col}_key")),
+                            ConstraintKind::Unique,
+                        )),
+                        ColumnOption::ForeignKey(fk) => Some((
+                            explicit(&fk.name).unwrap_or_else(|| format!("{table}_{col}_fkey")),
+                            ConstraintKind::ForeignKey,
+                        )),
+                        ColumnOption::Check(c) => Some((
+                            explicit(&c.name).unwrap_or_else(|| format!("{table}_{col}_check")),
+                            ConstraintKind::Check,
+                        )),
+                        _ => None,
+                    };
+                    if let Some((name, kind)) = classified {
+                        push_constraint(constraints, &table, name, kind);
+                    }
+                    if matches!(
                         opt.option,
                         ColumnOption::PrimaryKey(_) | ColumnOption::Unique(_)
-                    )
-                });
-                if inline_unique {
-                    push_entry(
-                        entries,
-                        IndexEntry {
-                            table: table.clone(),
-                            columns: vec![column.name.value.to_lowercase()],
-                            unique: true,
-                            name: None,
-                            partial: false,
-                        },
-                    );
+                    ) {
+                        push_entry(
+                            entries,
+                            IndexEntry {
+                                table: table.clone(),
+                                columns: vec![col.clone()],
+                                unique: true,
+                                name: None,
+                                partial: false,
+                            },
+                        );
+                    }
                 }
             }
-            // Table-level `PRIMARY KEY (...)` / `UNIQUE (...)` constraints.
+            // Table-level constraints.
             for constraint in &create.constraints {
-                if let Some(entry) = constraint_entry(&table, constraint) {
-                    push_entry(entries, entry);
-                }
+                apply_table_constraint(entries, constraints, &table, constraint);
             }
         }
         Statement::AlterTable(alter) => {
@@ -217,13 +303,12 @@ fn apply_statement(entries: &mut Vec<IndexEntry>, stmt: &Statement) {
             for op in &alter.operations {
                 match op {
                     AlterTableOperation::AddConstraint { constraint, .. } => {
-                        if let Some(entry) = constraint_entry(&table, constraint) {
-                            push_entry(entries, entry);
-                        }
+                        apply_table_constraint(entries, constraints, &table, constraint);
                     }
                     AlterTableOperation::DropConstraint { name, .. } => {
                         let name = name.value.to_lowercase();
                         entries.retain(|e| e.name.as_deref() != Some(name.as_str()));
+                        constraints.retain(|c| !(c.table == table && c.name == name));
                     }
                     _ => {}
                 }
@@ -236,6 +321,7 @@ fn apply_statement(entries: &mut Vec<IndexEntry>, stmt: &Statement) {
                 for name in names {
                     if let Some(name) = last_ident(name) {
                         entries.retain(|e| e.name.as_deref() != Some(name.as_str()));
+                        constraints.retain(|c| c.name != name);
                     }
                 }
             }
@@ -243,6 +329,7 @@ fn apply_statement(entries: &mut Vec<IndexEntry>, stmt: &Statement) {
                 for name in names {
                     if let Some(table) = last_ident(name) {
                         entries.retain(|e| e.table != table);
+                        constraints.retain(|c| c.table != table);
                     }
                 }
             }
@@ -252,21 +339,118 @@ fn apply_statement(entries: &mut Vec<IndexEntry>, stmt: &Statement) {
     }
 }
 
-/// A `UNIQUE` / `PRIMARY KEY` table constraint as a unique index entry; other
-/// constraint kinds (foreign key, check, …) yield `None`.
-fn constraint_entry(table: &str, constraint: &TableConstraint) -> Option<IndexEntry> {
-    let (name, columns) = match constraint {
-        TableConstraint::PrimaryKey(pk) => (&pk.name, &pk.columns),
-        TableConstraint::Unique(u) => (&u.name, &u.columns),
-        _ => return None,
-    };
-    Some(IndexEntry {
+/// Apply one table-level constraint: `UNIQUE` / `PRIMARY KEY` become unique
+/// index entries, and every classifiable kind (unique, primary key, foreign
+/// key, check) becomes a classified constraint entry. Unnamed table-level
+/// `CHECK` constraints are skipped — Postgres derives their name from the
+/// columns referenced in the expression.
+fn apply_table_constraint(
+    entries: &mut Vec<IndexEntry>,
+    constraints: &mut Vec<ConstraintEntry>,
+    table: &str,
+    constraint: &TableConstraint,
+) {
+    match constraint {
+        TableConstraint::PrimaryKey(pk) => {
+            let columns: Vec<String> = pk.columns.iter().map(index_column_name).collect();
+            let name = pk.name.as_ref().map(|i| i.value.to_lowercase());
+            push_constraint(
+                constraints,
+                table,
+                name.clone().unwrap_or_else(|| format!("{table}_pkey")),
+                ConstraintKind::Unique,
+            );
+            push_entry(
+                entries,
+                IndexEntry {
+                    table: table.to_string(),
+                    columns,
+                    unique: true,
+                    name,
+                    partial: false,
+                },
+            );
+        }
+        TableConstraint::Unique(u) => {
+            let columns: Vec<String> = u.columns.iter().map(index_column_name).collect();
+            let name = u.name.as_ref().map(|i| i.value.to_lowercase());
+            let constraint_name = name
+                .clone()
+                .or_else(|| synthesized_name(table, &columns, "key"));
+            if let Some(constraint_name) = constraint_name {
+                push_constraint(constraints, table, constraint_name, ConstraintKind::Unique);
+            }
+            push_entry(
+                entries,
+                IndexEntry {
+                    table: table.to_string(),
+                    columns,
+                    unique: true,
+                    name,
+                    partial: false,
+                },
+            );
+        }
+        TableConstraint::ForeignKey(fk) => {
+            let columns: Vec<String> = fk.columns.iter().map(|i| i.value.to_lowercase()).collect();
+            let constraint_name = fk
+                .name
+                .as_ref()
+                .map(|i| i.value.to_lowercase())
+                .or_else(|| synthesized_name(table, &columns, "fkey"));
+            if let Some(constraint_name) = constraint_name {
+                push_constraint(
+                    constraints,
+                    table,
+                    constraint_name,
+                    ConstraintKind::ForeignKey,
+                );
+            }
+        }
+        TableConstraint::Check(c) => {
+            if let Some(name) = c.name.as_ref() {
+                push_constraint(
+                    constraints,
+                    table,
+                    name.value.to_lowercase(),
+                    ConstraintKind::Check,
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Postgres' auto-name for an unnamed constraint/index: `{table}_{cols}_{suffix}`.
+/// `None` when any key element is an expression (opaque) or the joined name
+/// would exceed Postgres' 63-byte identifier limit (Postgres shortens such
+/// names with heuristics this simulator does not replicate).
+fn synthesized_name(table: &str, columns: &[String], suffix: &str) -> Option<String> {
+    if columns.is_empty() || columns.iter().any(|c| c == OPAQUE_COLUMN) {
+        return None;
+    }
+    let name = format!("{table}_{}_{suffix}", columns.join("_"));
+    (name.len() <= 63).then_some(name)
+}
+
+fn push_constraint(
+    constraints: &mut Vec<ConstraintEntry>,
+    table: &str,
+    name: String,
+    kind: ConstraintKind,
+) {
+    // Postgres truncates identifiers beyond 63 bytes; skip rather than guess.
+    if name.len() > 63 {
+        return;
+    }
+    let entry = ConstraintEntry {
         table: table.to_string(),
-        columns: columns.iter().map(index_column_name).collect(),
-        unique: true,
-        name: name.as_ref().map(|i| i.value.to_lowercase()),
-        partial: false,
-    })
+        name,
+        kind,
+    };
+    if !constraints.contains(&entry) {
+        constraints.push(entry);
+    }
 }
 
 /// The last identifier of a (possibly schema-qualified) object name, lowercased.
@@ -606,5 +790,93 @@ mod tests {
         // Partial indexes are ignored.
         let c3 = cat("CREATE INDEX ON t (a, created_at) WHERE deleted = FALSE;");
         assert!(!c3.specializes("t", &["a".to_string()], "created_at"));
+    }
+
+    // ── classified constraint catalog ───────────────────────────────────────
+
+    #[test]
+    fn constraints_inline_fk_and_pk_synthesized_names() {
+        let c = cat("CREATE TABLE order_items (id uuid PRIMARY KEY, \
+             order_id uuid NOT NULL REFERENCES orders(id));");
+        assert_eq!(
+            c.table_constraints("order_items"),
+            vec![
+                ("order_items_pkey".to_string(), ConstraintKind::Unique),
+                (
+                    "order_items_order_id_fkey".to_string(),
+                    ConstraintKind::ForeignKey
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn constraints_inline_unique_and_check_synthesized_names() {
+        let c = cat("CREATE TABLE t (email varchar UNIQUE, a int CHECK (a > 0));");
+        let cons = c.table_constraints("t");
+        assert!(cons.contains(&("t_email_key".to_string(), ConstraintKind::Unique)));
+        assert!(cons.contains(&("t_a_check".to_string(), ConstraintKind::Check)));
+    }
+
+    #[test]
+    fn constraints_named_check_via_alter_then_drop() {
+        let sql = "CREATE TABLE profiles (id uuid PRIMARY KEY, email varchar NOT NULL); \
+             ALTER TABLE profiles ADD CONSTRAINT profiles_email_not_blank CHECK (email <> '');";
+        let c = cat(sql);
+        assert!(c.table_constraints("profiles").contains(&(
+            "profiles_email_not_blank".to_string(),
+            ConstraintKind::Check
+        )));
+
+        let dropped = cat(&format!(
+            "{sql} ALTER TABLE profiles DROP CONSTRAINT profiles_email_not_blank;"
+        ));
+        assert!(
+            !dropped
+                .table_constraints("profiles")
+                .iter()
+                .any(|(_, k)| *k == ConstraintKind::Check)
+        );
+    }
+
+    #[test]
+    fn constraints_table_level_fk_named_and_unnamed() {
+        let c = cat("CREATE TABLE t (a int, b int, \
+             CONSTRAINT my_fk FOREIGN KEY (a) REFERENCES o(x), \
+             FOREIGN KEY (b) REFERENCES o(y));");
+        let cons = c.table_constraints("t");
+        assert!(cons.contains(&("my_fk".to_string(), ConstraintKind::ForeignKey)));
+        assert!(cons.contains(&("t_b_fkey".to_string(), ConstraintKind::ForeignKey)));
+    }
+
+    #[test]
+    fn constraints_unnamed_table_level_check_skipped() {
+        // Postgres derives the name from the expression's columns — not simulated.
+        let c = cat("CREATE TABLE t (a int, CHECK (a > 0));");
+        assert!(
+            c.table_constraints("t")
+                .iter()
+                .all(|(_, k)| *k != ConstraintKind::Check)
+        );
+    }
+
+    #[test]
+    fn constraints_named_unique_index_and_drop_index() {
+        let sql = "CREATE TABLE users (id uuid, email varchar); \
+             CREATE UNIQUE INDEX idx_users_email ON users (email);";
+        let c = cat(sql);
+        assert!(
+            c.table_constraints("users")
+                .contains(&("idx_users_email".to_string(), ConstraintKind::Unique))
+        );
+
+        let dropped = cat(&format!("{sql} DROP INDEX idx_users_email;"));
+        assert!(dropped.table_constraints("users").is_empty());
+    }
+
+    #[test]
+    fn constraints_drop_table_removes_all() {
+        let c = cat("CREATE TABLE t (id uuid PRIMARY KEY, o uuid REFERENCES x(id)); DROP TABLE t;");
+        assert!(c.table_constraints("t").is_empty());
     }
 }

--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -143,7 +143,7 @@ impl ToTokens for CreateAllFn<'_> {
                        .fetch_all(op.as_executor())
                        .await
                        .map_err(|e| match &e {
-                           sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                           sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                                #create_error::ConstraintViolation {
                                    column: Self::map_constraint_column(db_err.constraint()),
                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -259,7 +259,7 @@ mod tests {
                         .fetch_all(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                                 EntityCreateError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),

--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -143,7 +143,7 @@ impl ToTokens for CreateAllFn<'_> {
                        .fetch_all(op.as_executor())
                        .await
                        .map_err(|e| match &e {
-                           sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                           sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                                #create_error::ConstraintViolation {
                                    column: Self::map_constraint_column(db_err.constraint()),
                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -259,7 +259,7 @@ mod tests {
                         .fetch_all(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                                 EntityCreateError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -158,7 +158,7 @@ impl ToTokens for CreateFn<'_> {
                     .execute(op.as_executor())
                     .await
                     .map_err(|e| match &e {
-                        sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                        sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                             #create_error::ConstraintViolation {
                                 column: Self::map_constraint_column(db_err.constraint()),
                                 value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -265,7 +265,7 @@ mod tests {
                     .execute(op.as_executor())
                     .await
                     .map_err(|e| match &e {
-                        sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                        sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                             EntityCreateError::ConstraintViolation {
                                 column: Self::map_constraint_column(db_err.constraint()),
                                 value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -368,7 +368,7 @@ mod tests {
                     .execute(op.as_executor())
                     .await
                     .map_err(|e| match &e {
-                        sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                        sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                             EntityCreateError::ConstraintViolation {
                                 column: Self::map_constraint_column(db_err.constraint()),
                                 value: es_entity::extract_constraint_value(db_err.as_ref()),

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -158,7 +158,7 @@ impl ToTokens for CreateFn<'_> {
                     .execute(op.as_executor())
                     .await
                     .map_err(|e| match &e {
-                        sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                        sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                             #create_error::ConstraintViolation {
                                 column: Self::map_constraint_column(db_err.constraint()),
                                 value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -265,7 +265,7 @@ mod tests {
                     .execute(op.as_executor())
                     .await
                     .map_err(|e| match &e {
-                        sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                        sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                             EntityCreateError::ConstraintViolation {
                                 column: Self::map_constraint_column(db_err.constraint()),
                                 value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -368,7 +368,7 @@ mod tests {
                     .execute(op.as_executor())
                     .await
                     .map_err(|e| match &e {
-                        sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                        sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                             EntityCreateError::ConstraintViolation {
                                 column: Self::map_constraint_column(db_err.constraint()),
                                 value: es_entity::extract_constraint_value(db_err.as_ref()),

--- a/es-entity-macros/src/repo/delete_fn.rs
+++ b/es-entity-macros/src/repo/delete_fn.rs
@@ -146,7 +146,7 @@ impl ToTokens for DeleteFn<'_> {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                                 #modify_error::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -244,7 +244,7 @@ mod tests {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -340,7 +340,7 @@ mod tests {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -428,7 +428,7 @@ mod tests {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),

--- a/es-entity-macros/src/repo/delete_fn.rs
+++ b/es-entity-macros/src/repo/delete_fn.rs
@@ -146,7 +146,7 @@ impl ToTokens for DeleteFn<'_> {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                                 #modify_error::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -244,7 +244,7 @@ mod tests {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -340,7 +340,7 @@ mod tests {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -428,7 +428,7 @@ mod tests {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),

--- a/es-entity-macros/src/repo/error_types.rs
+++ b/es-entity-macros/src/repo/error_types.rs
@@ -449,7 +449,8 @@ impl<'a> ErrorTypes<'a> {
 
                 pub fn was_duplicate(&self) -> bool {
                     match self {
-                        Self::ConstraintViolation { .. } => true,
+                        Self::ConstraintViolation { inner: sqlx::Error::Database(db_err), .. }
+                            if db_err.is_unique_violation() => true,
                         #(#nested_wd_checks)*
                         _ => false,
                     }
@@ -457,6 +458,18 @@ impl<'a> ErrorTypes<'a> {
 
                 pub fn was_duplicate_by(&self, column: #column_enum) -> bool {
                     matches!(self, Self::ConstraintViolation { column: Some(c), .. } if *c == column)
+                }
+
+                /// Returns the name of the violated database constraint, if any.
+                ///
+                /// Useful for dispatching on hand-written constraints (e.g. foreign
+                /// keys or check constraints) that don't map to a recognized unique
+                /// column.
+                pub fn constraint_name(&self) -> Option<&str> {
+                    match self {
+                        Self::ConstraintViolation { inner: sqlx::Error::Database(db_err), .. } => db_err.constraint(),
+                        _ => None,
+                    }
                 }
 
                 /// Returns the conflicting value extracted from the database error.
@@ -697,7 +710,8 @@ impl<'a> ErrorTypes<'a> {
 
                 pub fn was_duplicate(&self) -> bool {
                     match self {
-                        Self::ConstraintViolation { .. } => true,
+                        Self::ConstraintViolation { inner: sqlx::Error::Database(db_err), .. }
+                            if db_err.is_unique_violation() => true,
                         #(#modify_nested_wd_checks)*
                         _ => false,
                     }
@@ -705,6 +719,18 @@ impl<'a> ErrorTypes<'a> {
 
                 pub fn was_duplicate_by(&self, column: #column_enum) -> bool {
                     matches!(self, Self::ConstraintViolation { column: Some(c), .. } if *c == column)
+                }
+
+                /// Returns the name of the violated database constraint, if any.
+                ///
+                /// Useful for dispatching on hand-written constraints (e.g. foreign
+                /// keys or check constraints) that don't map to a recognized unique
+                /// column.
+                pub fn constraint_name(&self) -> Option<&str> {
+                    match self {
+                        Self::ConstraintViolation { inner: sqlx::Error::Database(db_err), .. } => db_err.constraint(),
+                        _ => None,
+                    }
                 }
 
                 /// Returns the conflicting value extracted from the database error.

--- a/es-entity-macros/src/repo/error_types.rs
+++ b/es-entity-macros/src/repo/error_types.rs
@@ -39,12 +39,14 @@ struct ConstraintVariant {
 /// A readable variant ident for a constraint name: the `{table}_` prefix is
 /// stripped when present (`profiles_email_not_blank` → `EmailNotBlank`),
 /// falling back to the full name when stripping yields an invalid or already
-/// taken ident. `None` when even the full name collides.
+/// taken ident. Total: distinct constraint names that still camel-case
+/// identically (e.g. `t_a_b_key` vs `t_a__b_key`) are disambiguated with a
+/// deterministic numeric suffix rather than silently dropped from the enum.
 fn constraint_variant_ident(
     table_name: &str,
     constraint_name: &str,
     taken: &mut HashSet<String>,
-) -> Option<syn::Ident> {
+) -> syn::Ident {
     let stripped = constraint_name
         .strip_prefix(&format!("{table_name}_"))
         .unwrap_or(constraint_name);
@@ -57,10 +59,24 @@ fn constraint_variant_ident(
     {
         candidate = constraint_name.to_case(Case::UpperCamel);
     }
-    if !taken.insert(candidate.clone()) {
-        return None;
+    if !candidate
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic())
+    {
+        // Degenerate quoted identifiers (e.g. a constraint named "2fa_check").
+        candidate = format!("Constraint{candidate}");
     }
-    Some(syn::Ident::new(&candidate, Span::call_site()))
+    if taken.contains(&candidate) {
+        let base = candidate.clone();
+        let mut n = 2;
+        while taken.contains(&candidate) {
+            candidate = format!("{base}{n}");
+            n += 1;
+        }
+    }
+    taken.insert(candidate.clone());
+    syn::Ident::new(&candidate, Span::call_site())
 }
 
 struct NestedErrorInfo {
@@ -141,15 +157,12 @@ impl<'a> ErrorTypes<'a> {
             if !seen_names.insert(constraint_name.clone()) {
                 continue;
             }
-            if let Some(variant_name) =
-                constraint_variant_ident(table_name, &constraint_name, &mut taken)
-            {
-                constraint_variants.push(ConstraintVariant {
-                    variant_name,
-                    constraint_name,
-                    kind,
-                });
-            }
+            let variant_name = constraint_variant_ident(table_name, &constraint_name, &mut taken);
+            constraint_variants.push(ConstraintVariant {
+                variant_name,
+                constraint_name,
+                kind,
+            });
         }
 
         let type_param_idents: Vec<&syn::Ident> =
@@ -1277,6 +1290,23 @@ mod tests {
             post_hydrate_hook,
             post_persist_hook,
         }
+    }
+
+    #[test]
+    fn constraint_variant_idents_disambiguate_instead_of_dropping() {
+        let mut taken = std::collections::HashSet::new();
+        // Table prefix stripped for readability.
+        let a = constraint_variant_ident("t", "t_a_b_key", &mut taken);
+        assert_eq!(a.to_string(), "ABKey");
+        // Camel-case collision with the stripped name → full-name fallback.
+        let b = constraint_variant_ident("t", "t_a__b_key", &mut taken);
+        assert_eq!(b.to_string(), "TABKey");
+        // Full name collides too → deterministic numeric suffix, never dropped.
+        let c = constraint_variant_ident("t", "t_a___b_key", &mut taken);
+        assert_eq!(c.to_string(), "TABKey2");
+        // Degenerate quoted identifier starting with a digit stays a valid ident.
+        let d = constraint_variant_ident("t", "2fa_check", &mut taken);
+        assert_eq!(d.to_string(), "Constraint2FaCheck");
     }
 
     #[test]

--- a/es-entity-macros/src/repo/error_types.rs
+++ b/es-entity-macros/src/repo/error_types.rs
@@ -2,11 +2,15 @@ use convert_case::{Case, Casing};
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
 
+use std::collections::HashSet;
+
 use super::options::{PostHydrateHookConfig, PostPersistHookConfig, RepositoryOptions};
+use crate::index_catalog::ConstraintKind;
 
 pub struct ErrorTypes<'a> {
     entity: &'a syn::Ident,
     column_enum: syn::Ident,
+    constraint_enum: syn::Ident,
     create_error: syn::Ident,
     modify_error: syn::Ident,
     find_error: syn::Ident,
@@ -14,6 +18,7 @@ pub struct ErrorTypes<'a> {
     forget_error: syn::Ident,
     forgettable: bool,
     column_variants: Vec<ColumnVariant>,
+    constraint_variants: Vec<ConstraintVariant>,
     nested: Vec<NestedErrorInfo>,
     post_hydrate_hook: &'a Option<PostHydrateHookConfig>,
     post_persist_hook: &'a Option<PostPersistHookConfig>,
@@ -23,6 +28,39 @@ struct ColumnVariant {
     variant_name: syn::Ident,
     column_name: String,
     constraint_names: Vec<String>,
+}
+
+struct ConstraintVariant {
+    variant_name: syn::Ident,
+    constraint_name: String,
+    kind: ConstraintKind,
+}
+
+/// A readable variant ident for a constraint name: the `{table}_` prefix is
+/// stripped when present (`profiles_email_not_blank` → `EmailNotBlank`),
+/// falling back to the full name when stripping yields an invalid or already
+/// taken ident. `None` when even the full name collides.
+fn constraint_variant_ident(
+    table_name: &str,
+    constraint_name: &str,
+    taken: &mut HashSet<String>,
+) -> Option<syn::Ident> {
+    let stripped = constraint_name
+        .strip_prefix(&format!("{table_name}_"))
+        .unwrap_or(constraint_name);
+    let mut candidate = stripped.to_case(Case::UpperCamel);
+    if !candidate
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic())
+        || taken.contains(&candidate)
+    {
+        candidate = constraint_name.to_case(Case::UpperCamel);
+    }
+    if !taken.insert(candidate.clone()) {
+        return None;
+    }
+    Some(syn::Ident::new(&candidate, Span::call_site()))
 }
 
 struct NestedErrorInfo {
@@ -88,6 +126,32 @@ impl<'a> ErrorTypes<'a> {
             })
             .collect();
 
+        // The typed constraint enum: the declared columns' unique constraint
+        // names (convention + catalog derived, so the enum works even with no
+        // discoverable migrations) plus every classified constraint (unique /
+        // foreign key / check) the catalog found on this table.
+        let mut taken = HashSet::new();
+        let mut seen_names = HashSet::new();
+        let mut constraint_variants: Vec<ConstraintVariant> = Vec::new();
+        let unique_seed = column_variants
+            .iter()
+            .flat_map(|v| v.constraint_names.iter())
+            .map(|name| (name.clone(), ConstraintKind::Unique));
+        for (constraint_name, kind) in unique_seed.chain(catalog.table_constraints(table_name)) {
+            if !seen_names.insert(constraint_name.clone()) {
+                continue;
+            }
+            if let Some(variant_name) =
+                constraint_variant_ident(table_name, &constraint_name, &mut taken)
+            {
+                constraint_variants.push(ConstraintVariant {
+                    variant_name,
+                    constraint_name,
+                    kind,
+                });
+            }
+        }
+
         let type_param_idents: Vec<&syn::Ident> =
             opts.generics.type_params().map(|p| &p.ident).collect();
 
@@ -119,6 +183,10 @@ impl<'a> ErrorTypes<'a> {
         Self {
             entity: opts.entity(),
             column_enum: opts.column_enum(),
+            constraint_enum: syn::Ident::new(
+                &format!("{}Constraint", opts.entity()),
+                Span::call_site(),
+            ),
             create_error: opts.create_error(),
             modify_error: opts.modify_error(),
             find_error: opts.find_error(),
@@ -126,6 +194,7 @@ impl<'a> ErrorTypes<'a> {
             forget_error: opts.forget_error(),
             forgettable: opts.forgettable_enabled(),
             column_variants,
+            constraint_variants,
             nested,
             post_hydrate_hook: &opts.post_hydrate_hook,
             post_persist_hook: &opts.post_persist_hook,
@@ -134,6 +203,7 @@ impl<'a> ErrorTypes<'a> {
 
     pub fn generate(&self) -> TokenStream {
         let column_enum = self.generate_column_enum();
+        let constraint_enum = self.generate_constraint_enum();
         let create_error = self.generate_create_error();
         let modify_error = self.generate_modify_error();
         let find_error = self.generate_find_error();
@@ -146,11 +216,94 @@ impl<'a> ErrorTypes<'a> {
 
         quote! {
             #column_enum
+            #constraint_enum
             #create_error
             #modify_error
             #find_error
             #query_error
             #forget_error
+        }
+    }
+
+    /// The typed constraint enum: one variant per constraint on the entity's
+    /// table known at compile time — the declared columns' unique constraints
+    /// plus every unique / foreign key / check constraint discoverable from
+    /// the migrations.
+    fn generate_constraint_enum(&self) -> TokenStream {
+        let constraint_enum = &self.constraint_enum;
+        let variants: Vec<_> = self
+            .constraint_variants
+            .iter()
+            .map(|v| &v.variant_name)
+            .collect();
+        let from_name_arms: Vec<_> = self
+            .constraint_variants
+            .iter()
+            .map(|v| {
+                let variant = &v.variant_name;
+                let name = &v.constraint_name;
+                quote! { #name => Some(Self::#variant), }
+            })
+            .collect();
+        let name_arms: Vec<_> = self
+            .constraint_variants
+            .iter()
+            .map(|v| {
+                let variant = &v.variant_name;
+                let name = &v.constraint_name;
+                quote! { Self::#variant => #name, }
+            })
+            .collect();
+        let kind_arms: Vec<_> = self
+            .constraint_variants
+            .iter()
+            .map(|v| {
+                let variant = &v.variant_name;
+                let kind = match v.kind {
+                    ConstraintKind::Unique => quote! { es_entity::ConstraintKind::Unique },
+                    ConstraintKind::ForeignKey => quote! { es_entity::ConstraintKind::ForeignKey },
+                    ConstraintKind::Check => quote! { es_entity::ConstraintKind::Check },
+                };
+                quote! { Self::#variant => #kind, }
+            })
+            .collect();
+
+        quote! {
+            #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+            pub enum #constraint_enum {
+                #(#variants,)*
+            }
+
+            impl #constraint_enum {
+                #[doc(hidden)]
+                #[inline(always)]
+                pub fn from_name(name: &str) -> Option<Self> {
+                    match name {
+                        #(#from_name_arms)*
+                        _ => None,
+                    }
+                }
+
+                /// The database constraint name.
+                pub fn name(&self) -> &'static str {
+                    match *self {
+                        #(#name_arms)*
+                    }
+                }
+
+                /// The kind of constraint (unique / foreign key / check).
+                pub fn kind(&self) -> es_entity::ConstraintKind {
+                    match *self {
+                        #(#kind_arms)*
+                    }
+                }
+            }
+
+            impl std::fmt::Display for #constraint_enum {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    f.write_str(self.name())
+                }
+            }
         }
     }
 
@@ -270,6 +423,7 @@ impl<'a> ErrorTypes<'a> {
     fn generate_create_error(&self) -> TokenStream {
         let create_error = &self.create_error;
         let column_enum = &self.column_enum;
+        let constraint_enum = &self.constraint_enum;
         let entity = self.entity;
 
         // Nested child variants
@@ -327,6 +481,22 @@ impl<'a> ErrorTypes<'a> {
             .map(|n| {
                 let variant = &n.variant_name;
                 quote! { Self::#variant(e) => e.was_duplicate(), }
+            })
+            .collect();
+        let nested_fk_checks: Vec<_> = self
+            .nested
+            .iter()
+            .map(|n| {
+                let variant = &n.variant_name;
+                quote! { Self::#variant(e) => e.was_foreign_key_violation(), }
+            })
+            .collect();
+        let nested_ck_checks: Vec<_> = self
+            .nested
+            .iter()
+            .map(|n| {
+                let variant = &n.variant_name;
+                quote! { Self::#variant(e) => e.was_check_violation(), }
             })
             .collect();
         let nested_dv_checks: Vec<_> = self
@@ -456,6 +626,24 @@ impl<'a> ErrorTypes<'a> {
                     }
                 }
 
+                pub fn was_foreign_key_violation(&self) -> bool {
+                    match self {
+                        Self::ConstraintViolation { inner: sqlx::Error::Database(db_err), .. }
+                            if db_err.is_foreign_key_violation() => true,
+                        #(#nested_fk_checks)*
+                        _ => false,
+                    }
+                }
+
+                pub fn was_check_violation(&self) -> bool {
+                    match self {
+                        Self::ConstraintViolation { inner: sqlx::Error::Database(db_err), .. }
+                            if db_err.is_check_violation() => true,
+                        #(#nested_ck_checks)*
+                        _ => false,
+                    }
+                }
+
                 pub fn was_duplicate_by(&self, column: #column_enum) -> bool {
                     matches!(self, Self::ConstraintViolation { column: Some(c), .. } if *c == column)
                 }
@@ -470,6 +658,14 @@ impl<'a> ErrorTypes<'a> {
                         Self::ConstraintViolation { inner: sqlx::Error::Database(db_err), .. } => db_err.constraint(),
                         _ => None,
                     }
+                }
+
+                /// The violated constraint as a typed value, when the constraint
+                /// is known at compile time — the declared columns' unique
+                /// constraints plus every constraint discoverable from the
+                /// migrations.
+                pub fn violated_constraint(&self) -> Option<#constraint_enum> {
+                    self.constraint_name().and_then(#constraint_enum::from_name)
                 }
 
                 /// Returns the conflicting value extracted from the database error.
@@ -498,6 +694,7 @@ impl<'a> ErrorTypes<'a> {
     fn generate_modify_error(&self) -> TokenStream {
         let modify_error = &self.modify_error;
         let column_enum = &self.column_enum;
+        let constraint_enum = &self.constraint_enum;
         let entity = self.entity;
 
         // Nested variants: both Modify and Create for each child
@@ -575,6 +772,34 @@ impl<'a> ErrorTypes<'a> {
                 vec![
                     quote! { Self::#modify_variant(e) => e.was_duplicate(), },
                     quote! { Self::#create_variant(e) => e.was_duplicate(), },
+                ]
+            })
+            .collect();
+        let modify_nested_fk_checks: Vec<_> = self
+            .nested
+            .iter()
+            .flat_map(|n| {
+                let modify_variant =
+                    syn::Ident::new(&format!("{}Modify", n.variant_name), Span::call_site());
+                let create_variant =
+                    syn::Ident::new(&format!("{}Create", n.variant_name), Span::call_site());
+                vec![
+                    quote! { Self::#modify_variant(e) => e.was_foreign_key_violation(), },
+                    quote! { Self::#create_variant(e) => e.was_foreign_key_violation(), },
+                ]
+            })
+            .collect();
+        let modify_nested_ck_checks: Vec<_> = self
+            .nested
+            .iter()
+            .flat_map(|n| {
+                let modify_variant =
+                    syn::Ident::new(&format!("{}Modify", n.variant_name), Span::call_site());
+                let create_variant =
+                    syn::Ident::new(&format!("{}Create", n.variant_name), Span::call_site());
+                vec![
+                    quote! { Self::#modify_variant(e) => e.was_check_violation(), },
+                    quote! { Self::#create_variant(e) => e.was_check_violation(), },
                 ]
             })
             .collect();
@@ -717,6 +942,24 @@ impl<'a> ErrorTypes<'a> {
                     }
                 }
 
+                pub fn was_foreign_key_violation(&self) -> bool {
+                    match self {
+                        Self::ConstraintViolation { inner: sqlx::Error::Database(db_err), .. }
+                            if db_err.is_foreign_key_violation() => true,
+                        #(#modify_nested_fk_checks)*
+                        _ => false,
+                    }
+                }
+
+                pub fn was_check_violation(&self) -> bool {
+                    match self {
+                        Self::ConstraintViolation { inner: sqlx::Error::Database(db_err), .. }
+                            if db_err.is_check_violation() => true,
+                        #(#modify_nested_ck_checks)*
+                        _ => false,
+                    }
+                }
+
                 pub fn was_duplicate_by(&self, column: #column_enum) -> bool {
                     matches!(self, Self::ConstraintViolation { column: Some(c), .. } if *c == column)
                 }
@@ -731,6 +974,14 @@ impl<'a> ErrorTypes<'a> {
                         Self::ConstraintViolation { inner: sqlx::Error::Database(db_err), .. } => db_err.constraint(),
                         _ => None,
                     }
+                }
+
+                /// The violated constraint as a typed value, when the constraint
+                /// is known at compile time — the declared columns' unique
+                /// constraints plus every constraint discoverable from the
+                /// migrations.
+                pub fn violated_constraint(&self) -> Option<#constraint_enum> {
+                    self.constraint_name().and_then(#constraint_enum::from_name)
                 }
 
                 /// Returns the conflicting value extracted from the database error.
@@ -1013,6 +1264,7 @@ mod tests {
         ErrorTypes {
             entity,
             column_enum: Ident::new("OrderColumn", Span::call_site()),
+            constraint_enum: Ident::new("OrderConstraint", Span::call_site()),
             create_error: Ident::new("OrderCreateError", Span::call_site()),
             modify_error: Ident::new("OrderModifyError", Span::call_site()),
             find_error: Ident::new("OrderFindError", Span::call_site()),
@@ -1020,6 +1272,7 @@ mod tests {
             forget_error: Ident::new("OrderForgetError", Span::call_site()),
             forgettable: false,
             column_variants: vec![],
+            constraint_variants: vec![],
             nested,
             post_hydrate_hook,
             post_persist_hook,
@@ -1233,6 +1486,7 @@ mod tests {
         ErrorTypes {
             entity,
             column_enum: Ident::new("OrderColumn", Span::call_site()),
+            constraint_enum: Ident::new("OrderConstraint", Span::call_site()),
             create_error: Ident::new("OrderCreateError", Span::call_site()),
             modify_error: Ident::new("OrderModifyError", Span::call_site()),
             find_error: Ident::new("OrderFindError", Span::call_site()),
@@ -1240,6 +1494,7 @@ mod tests {
             forget_error: Ident::new("OrderForgetError", Span::call_site()),
             forgettable: false,
             column_variants: vec![],
+            constraint_variants: vec![],
             nested,
             post_hydrate_hook: ph,
             post_persist_hook: pp,

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -84,7 +84,7 @@ impl ToTokens for UpdateAllFn<'_> {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                                 #modify_error::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -288,7 +288,7 @@ mod tests {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -84,7 +84,7 @@ impl ToTokens for UpdateAllFn<'_> {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                                 #modify_error::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -288,7 +288,7 @@ mod tests {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -63,7 +63,7 @@ impl ToTokens for UpdateFn<'_> {
                 .execute(op.as_executor())
                 .await
                 .map_err(|e| match &e {
-                    sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                    sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                         #modify_error::ConstraintViolation {
                             column: Self::map_constraint_column(db_err.constraint()),
                             value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -248,7 +248,7 @@ mod tests {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -63,7 +63,7 @@ impl ToTokens for UpdateFn<'_> {
                 .execute(op.as_executor())
                 .await
                 .map_err(|e| match &e {
-                    sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                    sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                         #modify_error::ConstraintViolation {
                             column: Self::map_constraint_column(db_err.constraint()),
                             value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -248,7 +248,7 @@ mod tests {
                         .execute(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),

--- a/migrations/20260807000000_repo_errors_check_constraint.sql
+++ b/migrations/20260807000000_repo_errors_check_constraint.sql
@@ -1,0 +1,10 @@
+-- CHECK-constraint fixture for tests/repo_errors.rs.
+--
+-- The repo error classifier maps any database error that names a constraint
+-- (unique, foreign key, check, exclusion) to the typed `ConstraintViolation`
+-- variant. This CHECK constraint exercises the non-unique path: creating or
+-- updating a profile with a blank email surfaces as
+-- `ConstraintViolation { column: None, .. }` since the constraint name is not
+-- a recognized unique index of the `email` column.
+ALTER TABLE profiles
+  ADD CONSTRAINT profiles_email_not_blank CHECK (email <> '');

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,25 @@ pub fn extract_constraint_value(db_err: &dyn sqlx::error::DatabaseError) -> Opti
     parse_constraint_detail_value(pg_err.detail())
 }
 
+/// The kind of database constraint behind a classified `ConstraintViolation`.
+///
+/// Returned by the generated `{Entity}Constraint::kind()` method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConstraintKind {
+    Unique,
+    ForeignKey,
+    Check,
+}
+
+#[doc(hidden)]
+/// `true` when the database error is a violation kind the generated repo
+/// classifiers surface as `ConstraintViolation`: unique (SQLSTATE 23505),
+/// foreign key (23503), or check (23514). `NOT NULL` (23502) and exclusion
+/// (23P01) violations are not classified and surface as `Sqlx`.
+pub fn is_classified_constraint_violation(db_err: &dyn sqlx::error::DatabaseError) -> bool {
+    db_err.is_unique_violation() || db_err.is_foreign_key_violation() || db_err.is_check_violation()
+}
+
 #[doc(hidden)]
 /// Wrapper used by generated code to format not-found values.
 /// Prefers `Display` over `Debug` via inherent-vs-trait method resolution.

--- a/tests/repo_errors.rs
+++ b/tests/repo_errors.rs
@@ -97,6 +97,16 @@ async fn create_duplicate_email_returns_constraint_violation_with_value() -> any
     assert!(err.was_duplicate_by(ProfileColumn::Email));
     assert_eq!(err.duplicate_value(), Some(email.as_str()));
     assert_eq!(err.constraint_name(), Some("idx_profiles_email"));
+    assert_eq!(
+        err.violated_constraint(),
+        Some(ProfileConstraint::IdxProfilesEmail)
+    );
+    assert_eq!(
+        ProfileConstraint::IdxProfilesEmail.kind(),
+        ConstraintKind::Unique
+    );
+    assert!(!err.was_foreign_key_violation());
+    assert!(!err.was_check_violation());
 
     Ok(())
 }
@@ -121,6 +131,8 @@ async fn create_duplicate_id_returns_constraint_violation_with_value() -> anyhow
     assert!(err.was_duplicate_by(UserColumn::Id));
     assert_eq!(err.duplicate_value(), Some(id.to_string().as_str()));
     assert_eq!(err.constraint_name(), Some("users_pkey"));
+    assert_eq!(err.violated_constraint(), Some(UserConstraint::Pkey));
+    assert_eq!(UserConstraint::Pkey.kind(), ConstraintKind::Unique);
 
     Ok(())
 }
@@ -188,7 +200,17 @@ async fn create_fk_violation_returns_constraint_violation() -> anyhow::Result<()
 
     // FK violations are classified but are not duplicates.
     assert!(!err.was_duplicate());
+    assert!(err.was_foreign_key_violation());
+    assert!(!err.was_check_violation());
     assert_eq!(err.constraint_name(), Some("order_items_order_id_fkey"));
+    assert_eq!(
+        err.violated_constraint(),
+        Some(OrderItemConstraint::OrderIdFkey)
+    );
+    assert_eq!(
+        OrderItemConstraint::OrderIdFkey.kind(),
+        ConstraintKind::ForeignKey
+    );
     assert_eq!(err.duplicate_value(), None);
     match &err {
         OrderItemCreateError::ConstraintViolation { column: None, .. } => {}
@@ -217,7 +239,12 @@ async fn create_all_fk_violation_returns_constraint_violation() -> anyhow::Resul
     };
 
     assert!(!err.was_duplicate());
+    assert!(err.was_foreign_key_violation());
     assert_eq!(err.constraint_name(), Some("order_items_order_id_fkey"));
+    assert_eq!(
+        err.violated_constraint(),
+        Some(OrderItemConstraint::OrderIdFkey)
+    );
     match &err {
         OrderItemCreateError::ConstraintViolation { column: None, .. } => {}
         other => panic!("expected ConstraintViolation without column, got: {other:?}"),
@@ -244,7 +271,17 @@ async fn create_check_violation_returns_constraint_violation() -> anyhow::Result
     };
 
     assert!(!err.was_duplicate());
+    assert!(err.was_check_violation());
+    assert!(!err.was_foreign_key_violation());
     assert_eq!(err.constraint_name(), Some("profiles_email_not_blank"));
+    assert_eq!(
+        err.violated_constraint(),
+        Some(ProfileConstraint::EmailNotBlank)
+    );
+    assert_eq!(
+        ProfileConstraint::EmailNotBlank.kind(),
+        ConstraintKind::Check
+    );
     assert_eq!(err.duplicate_value(), None);
     match &err {
         ProfileCreateError::ConstraintViolation { column: None, .. } => {}
@@ -275,7 +312,12 @@ async fn update_check_violation_returns_constraint_violation() -> anyhow::Result
     };
 
     assert!(!err.was_duplicate());
+    assert!(err.was_check_violation());
     assert_eq!(err.constraint_name(), Some("profiles_email_not_blank"));
+    assert_eq!(
+        err.violated_constraint(),
+        Some(ProfileConstraint::EmailNotBlank)
+    );
     match &err {
         ProfileModifyError::ConstraintViolation { column: None, .. } => {}
         other => panic!("expected ConstraintViolation without column, got: {other:?}"),

--- a/tests/repo_errors.rs
+++ b/tests/repo_errors.rs
@@ -1,7 +1,7 @@
 mod entities;
 mod helpers;
 
-use entities::{profile::*, user::*};
+use entities::{order::*, profile::*, user::*};
 use es_entity::*;
 use sqlx::PgPool;
 
@@ -44,6 +44,25 @@ impl Profiles {
     }
 }
 
+/// Same shape as the nested repo in tests/nested_entities.rs — used here
+/// standalone to violate the hand-written `order_items_order_id_fkey` foreign
+/// key through generated ops.
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "OrderItem",
+    delete = "soft",
+    columns(order_id(ty = "OrderId", update(persist = false), parent))
+)]
+pub struct OrderItems {
+    pool: PgPool,
+}
+
+impl OrderItems {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
 // ===========================================================================
 // Constraint violation tests
 // ===========================================================================
@@ -77,6 +96,7 @@ async fn create_duplicate_email_returns_constraint_violation_with_value() -> any
     assert!(err.was_duplicate());
     assert!(err.was_duplicate_by(ProfileColumn::Email));
     assert_eq!(err.duplicate_value(), Some(email.as_str()));
+    assert_eq!(err.constraint_name(), Some("idx_profiles_email"));
 
     Ok(())
 }
@@ -100,6 +120,7 @@ async fn create_duplicate_id_returns_constraint_violation_with_value() -> anyhow
     assert!(err.was_duplicate());
     assert!(err.was_duplicate_by(UserColumn::Id));
     assert_eq!(err.duplicate_value(), Some(id.to_string().as_str()));
+    assert_eq!(err.constraint_name(), Some("users_pkey"));
 
     Ok(())
 }
@@ -138,6 +159,127 @@ async fn update_to_duplicate_email_returns_constraint_violation_with_value() -> 
     assert!(err.was_duplicate());
     assert!(err.was_duplicate_by(ProfileColumn::Email));
     assert_eq!(err.duplicate_value(), Some(email_a.as_str()));
+
+    Ok(())
+}
+
+// ===========================================================================
+// Non-unique constraint classification tests (foreign key / check)
+// ===========================================================================
+
+#[tokio::test]
+async fn create_fk_violation_returns_constraint_violation() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let order_items = OrderItems::new(pool);
+
+    // No such order exists — violates order_items_order_id_fkey.
+    let item = NewOrderItem::builder()
+        .id(OrderItemId::new())
+        .order_id(OrderId::new())
+        .product_name("Orphan")
+        .quantity(1)
+        .price(1.0)
+        .build()
+        .unwrap();
+    let err = match order_items.create(item).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected constraint violation"),
+    };
+
+    // FK violations are classified but are not duplicates.
+    assert!(!err.was_duplicate());
+    assert_eq!(err.constraint_name(), Some("order_items_order_id_fkey"));
+    assert_eq!(err.duplicate_value(), None);
+    match &err {
+        OrderItemCreateError::ConstraintViolation { column: None, .. } => {}
+        other => panic!("expected ConstraintViolation without column, got: {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_all_fk_violation_returns_constraint_violation() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let order_items = OrderItems::new(pool);
+
+    let item = NewOrderItem::builder()
+        .id(OrderItemId::new())
+        .order_id(OrderId::new())
+        .product_name("Orphan")
+        .quantity(1)
+        .price(1.0)
+        .build()
+        .unwrap();
+    let err = match order_items.create_all(vec![item]).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected constraint violation"),
+    };
+
+    assert!(!err.was_duplicate());
+    assert_eq!(err.constraint_name(), Some("order_items_order_id_fkey"));
+    match &err {
+        OrderItemCreateError::ConstraintViolation { column: None, .. } => {}
+        other => panic!("expected ConstraintViolation without column, got: {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_check_violation_returns_constraint_violation() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let profiles = Profiles::new(pool);
+
+    // Blank email violates the profiles_email_not_blank CHECK constraint.
+    let profile = NewProfile::builder()
+        .id(ProfileId::new())
+        .name("Blank")
+        .email("")
+        .build()
+        .unwrap();
+    let err = match profiles.create(profile).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected constraint violation"),
+    };
+
+    assert!(!err.was_duplicate());
+    assert_eq!(err.constraint_name(), Some("profiles_email_not_blank"));
+    assert_eq!(err.duplicate_value(), None);
+    match &err {
+        ProfileCreateError::ConstraintViolation { column: None, .. } => {}
+        other => panic!("expected ConstraintViolation without column, got: {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_check_violation_returns_constraint_violation() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let profiles = Profiles::new(pool);
+
+    let email = format!("check_{}@test.com", ProfileId::new());
+    let profile = NewProfile::builder()
+        .id(ProfileId::new())
+        .name("Check")
+        .email(&email)
+        .build()
+        .unwrap();
+    let mut profile = profiles.create(profile).await?;
+
+    let _ = profile.update_email(String::new());
+    let err = match profiles.update(&mut profile).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected constraint violation"),
+    };
+
+    assert!(!err.was_duplicate());
+    assert_eq!(err.constraint_name(), Some("profiles_email_not_blank"));
+    match &err {
+        ProfileModifyError::ConstraintViolation { column: None, .. } => {}
+        other => panic!("expected ConstraintViolation without column, got: {other:?}"),
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Bug

Fixes the bug documented in the drua library space:
https://raw.githubusercontent.com/GaloyMoney/drua-library/main/spaces/es-entity-dev/bug-constraint-violation-unique-only.md

The generated repo error classifier guarded on `db_err.is_unique_violation()` (SQLSTATE 23505 only), so FK (23503) and CHECK (23514) violations raised inside generated ops (`create`, `create_all`, `update`, `update_all`, `delete`) fell through as raw `{Entity}CreateError::Sqlx` / `{Entity}ModifyError::Sqlx`. Downstream crates (cala attach-fence work, GaloyMoney/cala#816) were forced to string-match `constraint()` against the untyped variant.

## Fix (commit 1 — classifier widening)

- **Kind-explicit classifier guard**: `is_unique_violation() || is_foreign_key_violation() || is_check_violation()` (via `es_entity::is_classified_constraint_violation`, one definition applied uniformly across all five generators) — per the bug doc's kind-gating alternative. `NOT NULL` (23502) and exclusion (23P01, no sqlx kind helper) are not classified and remain `Sqlx` (documented in the book). Unrecognized constraint names yield `column: None`, `value: None`.
- **`was_duplicate()` gated** on the inner error being a unique violation so FK/CHECK violations don't report as duplicates; new symmetric `was_foreign_key_violation()` / `was_check_violation()` helpers (nested-cascading like `was_duplicate()`).
- **`ConcurrentModification` detection unchanged**: `extract_concurrent_modification` (events-table unique violation in `persist_events`) intentionally still keys on `is_unique_violation()`.

## Typed constraints (commit 2 — no string matching at call sites)

Per review discussion: constraint dispatch is now **typesafe**, derived from the migration catalog (same zero-annotation philosophy as the #178 index catalog — the migrations directory is the source of truth).

- The index catalog now records classified constraints **explicitly by kind** (unique / FK / check): named in DDL, or synthesized with Postgres' auto-naming convention (`{table}_{cols}_fkey` / `_key` / `_check` / `_pkey`, 63-byte-limit respected). Handles CREATE TABLE inline + table-level constraints, CREATE UNIQUE INDEX, ALTER TABLE ADD/DROP CONSTRAINT, DROP INDEX/TABLE.
- New derived **`{Entity}Constraint` enum** — one variant per compile-time-known constraint; variant names strip the table prefix (`order_items_order_id_fkey` → `OrderItemConstraint::OrderIdFkey`). Each variant exposes `name()` (raw DDL name, also `Display`) and `kind()` → `es_entity::ConstraintKind::{Unique, ForeignKey, Check}`.
- New **`violated_constraint()`** helper on Create/Modify errors:

```rust
Err(e) if e.violated_constraint() == Some(EntryConstraint::AccountNotAccountSetFkey) => {
    return Err(AppError::EntryTargetsAccountSet);
}
```

  Typos are impossible, and a constraint renamed in a migration becomes a **compile error** at the consumer instead of a silently dead match arm. Constraints created outside discoverable migrations fall back to the string `constraint_name()` accessor.

## Tests

- 287 tests pass (`nix run .#nextest`), doc tests 31+3 pass.
- Integration (`tests/repo_errors.rs`, live PG): FK via `order_items_order_id_fkey` through `create` **and** `create_all` (the exact path reported by cala); CHECK via new `profiles_email_not_blank` migration through `create` and `update`; unique tests extended — all assert the typed `violated_constraint()` variant, `kind()`, the kind helpers, and `ConstraintViolation { column: None }` shape. Synthesized FK auto-names verified against what Postgres actually reports.
- 7 new catalog unit tests: inline/table-level FK + CHECK cataloging, auto-name synthesis, ADD/DROP CONSTRAINT, DROP INDEX/TABLE.

Verified: `cargo fmt` ✓, `git add -A && nix flake check` ✓ (fmt / clippy -D warnings / deny / audit / offline nextest), `nix run .#nextest` ✓ 287/287.

## Semver / downstream ripple (flagged, NOT touched)

Behavior change, marked breaking → recommend **0.13.0** under 0.x: FK/CHECK violations from generated ops now surface as `ConstraintViolation { column: None, value: None, inner }` instead of `Sqlx(inner)`. Everything else is additive (`{Entity}Constraint`, `violated_constraint()`, `constraint_name()`, kind helpers, `es_entity::ConstraintKind`).

Known downstream call sites (audited in the bug doc, 2026-08-07):
- `cala-ledger/src/entry/error.rs` — already matches BOTH shapes defensively; survives unchanged, and can migrate to `violated_constraint()` for the typed end state
- `cala-ledger/src/account_set/error.rs` (`MemberAlreadyAdded`) and `cala-ledger/src/velocity/error.rs` (`LimitAlreadyAddedToControl`) — raised via raw sqlx in repo code, not generated ops → unaffected
- `cala-ledger/src/ledger/error.rs` — matches on `message().contains("duplicate key")`; unrelated but fragile regardless
- obix / lana-bank — audit `Sqlx(e)`-matching arms for FK/CHECK at upgrade time
- cala pinned regression tests that catch mapping drift: `ec_streaming_rollup::rejects_direct_entry_to_account_set`, `ec_streaming_rollup::missing_account_is_not_reported_as_account_set`

Left as draft for @bodymindarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> FK/CHECK errors from generated ops change shape from `Sqlx` to `ConstraintViolation`, which can break downstream matchers; constraint enum contents depend on discoverable migrations and synthesized names may miss edge cases Postgres names differently.
> 
> **Overview**
> **Behavior change:** create/update/delete paths no longer gate on `is_unique_violation()` alone—they use `es_entity::is_classified_constraint_violation` so foreign-key and CHECK failures surface as `ConstraintViolation` with `column`/`value` often `None`. `NOT NULL` and exclusion violations still stay `Sqlx`. **`was_duplicate()`** is narrowed to unique violations only; **`was_foreign_key_violation()`** / **`was_check_violation()`** are added (with nested error cascading).
> 
> **Typed dispatch:** the migration **index catalog** now records classified constraints (unique / FK / check), including Postgres auto-names where DDL is unnamed. Macros emit **`{Entity}Constraint`** plus **`violated_constraint()`**, **`constraint_name()`**, and **`kind()`** on create/modify errors so call sites can match FK/CHECK without string literals.
> 
> Book docs, a CHECK fixture migration, catalog unit tests, and live PG tests in `tests/repo_errors.rs` cover the new paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a985eb8e1d08e2fad39c11246c3957e26e687c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->