### PR TITLE
fix(macros): specialize list_for_filters on any equality index prefix

### DIFF
--- a/es-entity-macros/src/index_catalog.rs
+++ b/es-entity-macros/src/index_catalog.rs
@@ -155,9 +155,9 @@ impl IndexCatalog {
     /// Requiring the full `(equality…, sort)` composite — the previous behaviour
     /// — silently sent single-filter listings that were backed by only a
     /// `(filter)` index (no `(filter, sort)` composite) to the seq-scanning
-    /// fallback, a regression that grew linearly with table size
-    /// (lana-bank#7996). When the equality columns match *no* index the two
-    /// plans both seq-scan, so the fallback is correct and saves a query.
+    /// fallback, a regression whose cost grew linearly with table size. When
+    /// the equality columns match *no* index the two plans both seq-scan, so
+    /// the fallback is correct and saves a query.
     ///
     /// With no equality filter the only benefit is index-ordered pagination, so
     /// the sort column must lead an index. Partial indexes are conservatively
@@ -809,20 +809,12 @@ mod tests {
         // need NOT immediately follow it (`account_id = $1` is still an index
         // scan; the COALESCE fallback would seq-scan).
         assert!(c.specializes("transfers", &["account_id".to_string()], "id"));
-        // Regression guard (lana-bank#7996): a bare `(credit_facility_id)` index
-        // specializes the per-facility listing sorted by created_at.
-        let c4 = cat("CREATE INDEX ON core_disbursals (credit_facility_id);");
-        assert!(c4.specializes(
-            "core_disbursals",
-            &["credit_facility_id".to_string()],
-            "created_at"
-        ));
+        // A bare `(filter)` index (no `(filter, sort)` composite) still
+        // specializes the listing sorted by another column.
+        let c4 = cat("CREATE INDEX ON transfers (account_id);");
+        assert!(c4.specializes("transfers", &["account_id".to_string()], "created_at"));
         // No index covering the equality column → both plans seq-scan → fall back.
-        assert!(!c4.specializes(
-            "core_disbursals",
-            &["obligation_id".to_string()],
-            "created_at"
-        ));
+        assert!(!c4.specializes("transfers", &["reference".to_string()], "created_at"));
         // No equality filter: the sort column must lead an index.
         assert!(!c.specializes("transfers", &[], "created_at"));
         assert!(c.specializes("transfers", &[], "account_id"));

--- a/es-entity-macros/src/index_catalog.rs
+++ b/es-entity-macros/src/index_catalog.rs
@@ -140,13 +140,28 @@ impl IndexCatalog {
 
     /// Whether a `list_for_filters` query over `table`, filtering on the
     /// (order-insensitive) equality columns `equality_cols` and paginating by
-    /// `sort_col`, is backed by a physical composite index: some index's leading
-    /// key columns are a permutation of `equality_cols` immediately followed by
-    /// `sort_col`. The implied trailing `id` tiebreak and any further index
-    /// columns are irrelevant to the prefix match.
+    /// `sort_col`, should emit the sargable specialization rather than the
+    /// `COALESCE` fallback.
     ///
-    /// Partial indexes are conservatively ignored (those combos fall back —
-    /// correct, just not sargable).
+    /// It should whenever the equality columns are a **leading prefix** of some
+    /// (non-partial) index — then the specialized query's `col = $k` predicates
+    /// are an index qual (an index scan bounded to the matching rows), which the
+    /// `COALESCE(col = $k, $k IS NULL)` fallback can never be (the `COALESCE`
+    /// defeats index extraction, forcing a full sequential scan). That alone
+    /// makes the specialization strictly preferable; the sort column following
+    /// the equality prefix is a *further* optimisation (the planner can skip the
+    /// sort node), not a requirement.
+    ///
+    /// Requiring the full `(equality…, sort)` composite — the previous behaviour
+    /// — silently sent single-filter listings that were backed by only a
+    /// `(filter)` index (no `(filter, sort)` composite) to the seq-scanning
+    /// fallback, a regression that grew linearly with table size
+    /// (lana-bank#7996). When the equality columns match *no* index the two
+    /// plans both seq-scan, so the fallback is correct and saves a query.
+    ///
+    /// With no equality filter the only benefit is index-ordered pagination, so
+    /// the sort column must lead an index. Partial indexes are conservatively
+    /// ignored (those combos fall back — correct, just not sargable).
     pub fn specializes(&self, table: &str, equality_cols: &[String], sort_col: &str) -> bool {
         let table = table.to_lowercase();
         let sort = sort_col.to_lowercase();
@@ -157,12 +172,19 @@ impl IndexCatalog {
             if entry.partial || entry.table != table {
                 return false;
             }
-            if entry.columns.len() < eq.len() + 1 {
+            if entry.columns.len() < eq.len() {
                 return false;
             }
             let mut prefix = entry.columns[..eq.len()].to_vec();
             prefix.sort();
-            prefix == eq && entry.columns[eq.len()] == sort
+            if prefix != eq {
+                return false;
+            }
+            if eq.is_empty() {
+                entry.columns.first().map(String::as_str) == Some(sort.as_str())
+            } else {
+                true
+            }
         })
     }
 
@@ -776,17 +798,34 @@ mod tests {
     }
 
     #[test]
-    fn specializes_prefix_permutation_then_sort() {
+    fn specializes_on_equality_prefix() {
         // (account_id, created_at, id) supports {account_id} + sort created_at.
         let c = cat("CREATE INDEX ON transfers (account_id, created_at DESC, id);");
         assert!(c.specializes("transfers", &["account_id".to_string()], "created_at"));
         // Equality set is order-insensitive within the prefix.
         let c2 = cat("CREATE INDEX ON t (a, b, created_at, id);");
         assert!(c2.specializes("t", &["b".to_string(), "a".to_string()], "created_at"));
-        // Sort must immediately follow the equality prefix.
-        assert!(!c.specializes("transfers", &["account_id".to_string()], "id"));
-        // Missing equality column → no match.
+        // The equality being a leading prefix is sufficient — the sort column
+        // need NOT immediately follow it (`account_id = $1` is still an index
+        // scan; the COALESCE fallback would seq-scan).
+        assert!(c.specializes("transfers", &["account_id".to_string()], "id"));
+        // Regression guard (lana-bank#7996): a bare `(credit_facility_id)` index
+        // specializes the per-facility listing sorted by created_at.
+        let c4 = cat("CREATE INDEX ON core_disbursals (credit_facility_id);");
+        assert!(c4.specializes(
+            "core_disbursals",
+            &["credit_facility_id".to_string()],
+            "created_at"
+        ));
+        // No index covering the equality column → both plans seq-scan → fall back.
+        assert!(!c4.specializes(
+            "core_disbursals",
+            &["obligation_id".to_string()],
+            "created_at"
+        ));
+        // No equality filter: the sort column must lead an index.
         assert!(!c.specializes("transfers", &[], "created_at"));
+        assert!(c.specializes("transfers", &[], "account_id"));
         // Partial indexes are ignored.
         let c3 = cat("CREATE INDEX ON t (a, created_at) WHERE deleted = FALSE;");
         assert!(!c3.specializes("t", &["a".to_string()], "created_at"));

--- a/es-entity-macros/src/repo/list_for_filters_fn.rs
+++ b/es-entity-macros/src/repo/list_for_filters_fn.rs
@@ -1728,8 +1728,7 @@ mod tests {
             forgettable_table_name: None,
             scope: None,
             // A single composite; specialization keys on the equality columns
-            // being a *leading prefix* of it — the sort column need not follow
-            // (lana-bank#7996).
+            // being a *leading prefix* of it — the sort column need not follow.
             index_catalog: catalog("CREATE INDEX ON wides (a, b, id);"),
             #[cfg(feature = "instrument")]
             repo_name_snake: "test_repo".to_string(),
@@ -1746,7 +1745,7 @@ mod tests {
         // {a, b}: leading prefix `a, b` → specialized. The old "sort must
         // immediately follow the equality prefix" rule wrongly dropped this
         // (there is no `(a, b, id)`-vs-sort match), sending a table-growing
-        // seq-scan fallback into production (lana-bank#7996).
+        // seq-scan fallback into production.
         assert!(
             token_str.contains(
                 "(SELECT id FROM wides WHERE a = $1 AND b = $2 AND ($4 IS NULL) ORDER BY id ASC LIMIT $3)"

--- a/es-entity-macros/src/repo/list_for_filters_fn.rs
+++ b/es-entity-macros/src/repo/list_for_filters_fn.rs
@@ -1678,7 +1678,7 @@ mod tests {
     }
 
     #[test]
-    fn list_for_filters_specializes_only_indexed_combos() {
+    fn list_for_filters_specializes_equality_prefix_combos() {
         let entity = Ident::new("Wide", Span::call_site());
         let query_error = syn::Ident::new("WideQueryError", Span::call_site());
         let id = syn::Ident::new("WideId", proc_macro2::Span::call_site());
@@ -1727,15 +1727,10 @@ mod tests {
             post_hydrate_error: None,
             forgettable_table_name: None,
             scope: None,
-            index_catalog: catalog(
-                "CREATE INDEX ON wides (id); \
-                 CREATE INDEX ON wides (a, id); \
-                 CREATE INDEX ON wides (b, id); \
-                 CREATE INDEX ON wides (c, id); \
-                 CREATE INDEX ON wides (d, id); \
-                 CREATE INDEX ON wides (e, id); \
-                 CREATE INDEX ON wides (a, b, c, d, e, id);",
-            ),
+            // A single composite; specialization keys on the equality columns
+            // being a *leading prefix* of it — the sort column need not follow
+            // (lana-bank#7996).
+            index_catalog: catalog("CREATE INDEX ON wides (a, b, id);"),
             #[cfg(feature = "instrument")]
             repo_name_snake: "test_repo".to_string(),
         };
@@ -1744,29 +1739,30 @@ mod tests {
         list_for_filters_fn.to_tokens(&mut tokens);
         let token_str = tokens.to_string();
 
-        // Only the combinations backed by a declared index are specialized
-        // (shown here via each unified query's page-1 `First` branch): the
-        // no-filter, each single-filter and the all-filters combos.
-        assert!(
-            token_str
-                .contains("(SELECT id FROM wides WHERE ($2 IS NULL) ORDER BY id ASC LIMIT $1)")
-        );
+        // {a}: leading prefix `a` of `(a, b, id)` → specialized.
         assert!(token_str.contains(
             "(SELECT id FROM wides WHERE a = $1 AND ($3 IS NULL) ORDER BY id ASC LIMIT $2)"
         ));
-        assert!(token_str.contains(
-            "(SELECT id FROM wides WHERE a = $1 AND b = $2 AND c = $3 AND d = $4 AND e = $5 AND ($7 IS NULL) ORDER BY id ASC LIMIT $6)"
-        ));
-        // Intermediate combinations (e.g. exactly two filters) have no matching
-        // index, so they fall back to the catch-all COALESCE query — no
-        // specialized SQL exists for them.
+        // {a, b}: leading prefix `a, b` → specialized. The old "sort must
+        // immediately follow the equality prefix" rule wrongly dropped this
+        // (there is no `(a, b, id)`-vs-sort match), sending a table-growing
+        // seq-scan fallback into production (lana-bank#7996).
         assert!(
-            !token_str.contains("SELECT id FROM wides WHERE a = $1 AND b = $2 ORDER"),
-            "two-filter combination has no index and must not be specialized"
+            token_str.contains(
+                "(SELECT id FROM wides WHERE a = $1 AND b = $2 AND ($4 IS NULL) ORDER BY id ASC LIMIT $3)"
+            ),
+            "a combo whose equality is an index prefix must be specialized"
+        );
+        // {b}: `b` is not a leading prefix of `(a, b, id)` → both plans seq-scan,
+        // so it correctly falls back to the COALESCE query (a build win, no
+        // runtime loss).
+        assert!(
+            !token_str.contains("(SELECT id FROM wides WHERE b = $1 AND ($3 IS NULL)"),
+            "`b` alone is not a leading index prefix and must fall back"
         );
         assert!(
-            token_str.contains("COALESCE(a = $1, $1 IS NULL)"),
-            "COALESCE fallback must remain for un-indexed combinations"
+            token_str.contains("COALESCE(b = $2, $2 IS NULL)"),
+            "COALESCE fallback must remain for combos with no index prefix"
         );
     }
 

--- a/tests/index_catalog_verification.rs
+++ b/tests/index_catalog_verification.rs
@@ -48,18 +48,31 @@ async fn index_key_columns(
     Ok(out)
 }
 
-/// Mirrors `IndexCatalog::specializes`: some index's leading key columns are a
-/// permutation of `equality_cols` immediately followed by `sort_col`.
+/// Mirrors `IndexCatalog::specializes`: the equality columns are a **leading
+/// prefix** of some index — any key columns may follow, the sort column need
+/// not immediately succeed the prefix. A `col = $k` predicate is an index qual
+/// on such an index regardless of what trails it, which the `COALESCE` fallback
+/// can never be; that alone makes the specialization preferable (#185). With no
+/// equality filter the only benefit is index-ordered pagination, so the sort
+/// column must itself lead an index.
 fn covered(indexes: &[Vec<String>], equality_cols: &[&str], sort_col: &str) -> bool {
+    let sort = sort_col.to_lowercase();
     let mut eq: Vec<String> = equality_cols.iter().map(|c| c.to_lowercase()).collect();
     eq.sort();
     indexes.iter().any(|cols| {
-        if cols.len() < eq.len() + 1 {
+        if cols.len() < eq.len() {
             return false;
         }
         let mut prefix = cols[..eq.len()].to_vec();
         prefix.sort();
-        prefix == eq && cols[eq.len()] == sort_col.to_lowercase()
+        if prefix != eq {
+            return false;
+        }
+        if eq.is_empty() {
+            cols.first().map(String::as_str) == Some(sort.as_str())
+        } else {
+            true
+        }
     })
 }
 
@@ -91,14 +104,61 @@ async fn specialization_relied_on_indexes_physically_exist() -> anyhow::Result<(
          got {contacts:?}"
     );
 
-    // A combination with no matching index must correctly report *not* covered
-    // (guards the check itself against always-true bugs): transfers has no
-    // (status, created_at) index.
+    // Newly-permitted shape (#185): a bare `(status)` index covers the status
+    // listing sorted by created_at even though the sort column does not follow
+    // it in the index — the exact combo the pre-fix mirror wrongly reported
+    // uncovered while `specializes` accepted it.
     assert!(
-        !covered(&transfers, &["status"], "created_at"),
-        "sanity: transfers has no (status, created_at) index"
+        covered(&transfers, &["status"], "created_at"),
+        "transfers has a bare (status) index; the relaxed mirror must cover it; \
+         got {transfers:?}"
+    );
+
+    // A combination with no matching index must correctly report *not* covered
+    // (guards the check itself against always-true bugs): `reference` is
+    // unindexed, so no index has it as a leading prefix.
+    assert!(
+        !covered(&transfers, &["reference"], "created_at"),
+        "sanity: transfers has no index on `reference`"
     );
 
     conn.close().await?;
     Ok(())
+}
+
+/// Pins the `covered` mirror to `IndexCatalog::specializes` (macros crate
+/// `specializes_on_equality_prefix`) on the shapes #185 newly permitted — an
+/// equality prefix whose index does *not* continue with the sort column. Pure
+/// (no DB), so it also runs under offline `nix flake check`. The two functions
+/// live in different crates (the proc-macro crate cannot export the catalog),
+/// so this hand-checked parallel is the only thing keeping the mirror honest.
+#[test]
+fn covered_mirrors_specializes() {
+    // (account_id, created_at, id) supports {account_id} + sort created_at.
+    let transfers = vec![vec![
+        "account_id".to_string(),
+        "created_at".to_string(),
+        "id".to_string(),
+    ]];
+    assert!(covered(&transfers, &["account_id"], "created_at"));
+    // Equality set is order-insensitive within the prefix.
+    let abc = vec![vec![
+        "a".to_string(),
+        "b".to_string(),
+        "created_at".to_string(),
+        "id".to_string(),
+    ]];
+    assert!(covered(&abc, &["b", "a"], "created_at"));
+    // NEWLY PERMITTED (#185): the equality being a leading prefix is sufficient —
+    // the sort column need not immediately follow it.
+    assert!(covered(&transfers, &["account_id"], "id"));
+    // NEWLY PERMITTED (#185): a bare `(status)` index covers the status listing
+    // sorted by any column — the combo the pre-fix mirror wrongly rejected.
+    let bare = vec![vec!["status".to_string()]];
+    assert!(covered(&bare, &["status"], "created_at"));
+    // No index with the equality column as a leading prefix → not covered.
+    assert!(!covered(&bare, &["obligation_id"], "created_at"));
+    // No equality filter: the sort column must lead an index (preserved).
+    assert!(!covered(&transfers, &[], "created_at"));
+    assert!(covered(&transfers, &[], "account_id"));
 }


### PR DESCRIPTION
## Problem

`list_for_filters` generates two shapes of paginated query per filter combination:

- **Specialized (sargable):** `WHERE col = $1 AND (cursor) ORDER BY sort` — the `col = $1` predicate is an index qual, so the planner does an index scan bounded to the matching rows.
- **COALESCE fallback:** `WHERE COALESCE(col = $1, $1 IS NULL) AND …` — the `COALESCE` wrapper defeats index extraction, so Postgres **sequentially scans the whole table** and filters row-by-row.

`IndexCatalog::specializes` only emitted the specialized shape when the migrations declared the *full* `(equality…, sort)` composite index. A single-filter listing backed by only a **bare `(filter)` index** (no `(filter, sort)` composite) matched no such composite and silently fell to the COALESCE fallback.

That fallback seq-scans, so its cost grows **linearly with table size**. In production this surfaced as [lana-bank#7996](https://github.com/GaloyMoney/lana-bank/pull/7996): a per-facility disbursal listing (`core_disbursals` has a bare `(credit_facility_id)` index, no `(credit_facility_id, created_at)` composite) regressed ~7.5×.

`EXPLAIN` on the two shapes against that table:

| shape | plan |
|-------|------|
| old specialized (composite present) | Bitmap Index Scan |
| **regressed fallback (this bug)** | **Seq Scan** |
| fixed specialized (bare index) | Index Scan Backward |

## Fix

Relax `specializes`: emit the specialization whenever the equality columns are a **leading prefix** of some non-partial index — dropping the requirement that the sort column immediately follow the prefix.

Rationale: the `col = $k` predicates are an index qual regardless of what column follows in the index, which the `COALESCE` fallback can *never* be. So an equality-prefix match already makes the specialization strictly preferable. The sort column following the prefix is a **further** optimisation (the planner can also skip the sort node), not a precondition for beating a seq scan.

Preserved behaviour:
- **No equality filter:** the only remaining benefit is index-ordered pagination, so the sort column must still lead an index.
- **No matching index at all:** both plans seq-scan, so the combo still falls back (saves generating a redundant query).
- Partial indexes are still conservatively ignored.

## Tests

- `specializes_on_equality_prefix` (unit): asserts a bare `(credit_facility_id)` index now specializes the per-facility listing sorted by `created_at` — the exact regressed shape — and that non-covered columns / the no-filter case still fall back.
- `list_for_filters_specializes_equality_prefix_combos` (codegen): asserts a `{a, b}` combo whose equality is an index prefix of `(a, b, id)` now emits the specialized query, while `{b}` (not a leading prefix) still emits the COALESCE fallback. *(The prior test's `!contains` string was too specific and passed vacuously — it never actually guarded against this.)*
- Full macro suite (134) + integration reference-impl suite (154) green locally; the reference-impl tests confirm the newly-specialized combos return identical rows to the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which SQL shapes are generated at compile time for paginated listings; wrong matching could still emit seq-scan fallbacks or extra queries, but behavior is heavily covered by unit, codegen, and integration tests.
> 
> **Overview**
> **Fixes a production regression** where `list_for_filters` chose the `COALESCE` fallback (seq scan) for filter combos that only had a bare `(filter)` index, not a full `(filter, sort)` composite.
> 
> `IndexCatalog::specializes` now treats equality filters as specialized when they form a **leading prefix** of any non-partial index—`col = $k` stays sargable even if the sort column does not follow in the index. **Unchanged:** no equality filters still require the sort column to lead an index; combos with no matching index still use `COALESCE`; partial indexes are still ignored.
> 
> Tests and the integration `covered` mirror in `index_catalog_verification.rs` are updated so codegen and DB verification match the relaxed rule (including bare `(status)` + sort `created_at`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097a7818cecf1887d3b9d900d2f27b6a30cbb524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->