### PR TITLE
docs(macros): drop downstream-repo references from specializes comments

### DIFF
--- a/es-entity-macros/src/index_catalog.rs
+++ b/es-entity-macros/src/index_catalog.rs
@@ -155,9 +155,9 @@ impl IndexCatalog {
     /// Requiring the full `(equality…, sort)` composite — the previous behaviour
     /// — silently sent single-filter listings that were backed by only a
     /// `(filter)` index (no `(filter, sort)` composite) to the seq-scanning
-    /// fallback, a regression that grew linearly with table size
-    /// (lana-bank#7996). When the equality columns match *no* index the two
-    /// plans both seq-scan, so the fallback is correct and saves a query.
+    /// fallback, a regression whose cost grew linearly with table size. When
+    /// the equality columns match *no* index the two plans both seq-scan, so
+    /// the fallback is correct and saves a query.
     ///
     /// With no equality filter the only benefit is index-ordered pagination, so
     /// the sort column must lead an index. Partial indexes are conservatively
@@ -809,20 +809,12 @@ mod tests {
         // need NOT immediately follow it (`account_id = $1` is still an index
         // scan; the COALESCE fallback would seq-scan).
         assert!(c.specializes("transfers", &["account_id".to_string()], "id"));
-        // Regression guard (lana-bank#7996): a bare `(credit_facility_id)` index
-        // specializes the per-facility listing sorted by created_at.
-        let c4 = cat("CREATE INDEX ON core_disbursals (credit_facility_id);");
-        assert!(c4.specializes(
-            "core_disbursals",
-            &["credit_facility_id".to_string()],
-            "created_at"
-        ));
+        // A bare `(filter)` index (no `(filter, sort)` composite) still
+        // specializes the listing sorted by another column.
+        let c4 = cat("CREATE INDEX ON transfers (account_id);");
+        assert!(c4.specializes("transfers", &["account_id".to_string()], "created_at"));
         // No index covering the equality column → both plans seq-scan → fall back.
-        assert!(!c4.specializes(
-            "core_disbursals",
-            &["obligation_id".to_string()],
-            "created_at"
-        ));
+        assert!(!c4.specializes("transfers", &["reference".to_string()], "created_at"));
         // No equality filter: the sort column must lead an index.
         assert!(!c.specializes("transfers", &[], "created_at"));
         assert!(c.specializes("transfers", &[], "account_id"));

--- a/es-entity-macros/src/repo/list_for_filters_fn.rs
+++ b/es-entity-macros/src/repo/list_for_filters_fn.rs
@@ -1728,8 +1728,7 @@ mod tests {
             forgettable_table_name: None,
             scope: None,
             // A single composite; specialization keys on the equality columns
-            // being a *leading prefix* of it — the sort column need not follow
-            // (lana-bank#7996).
+            // being a *leading prefix* of it — the sort column need not follow.
             index_catalog: catalog("CREATE INDEX ON wides (a, b, id);"),
             #[cfg(feature = "instrument")]
             repo_name_snake: "test_repo".to_string(),
@@ -1746,7 +1745,7 @@ mod tests {
         // {a, b}: leading prefix `a, b` → specialized. The old "sort must
         // immediately follow the equality prefix" rule wrongly dropped this
         // (there is no `(a, b, id)`-vs-sort match), sending a table-growing
-        // seq-scan fallback into production (lana-bank#7996).
+        // seq-scan fallback into production.
         assert!(
             token_str.contains(
                 "(SELECT id FROM wides WHERE a = $1 AND b = $2 AND ($4 IS NULL) ORDER BY id ASC LIMIT $3)"


### PR DESCRIPTION
## What

Follow-up to #185 (stacked on its branch): removes the downstream-repo
references the specializes-relaxation comments and test data carried.

## Changes

- `index_catalog.rs` `specializes` doc comment: drops the
  `lana-bank#7996` citation; the rationale is reworded generically
  ("a regression whose cost grew linearly with table size").
- `index_catalog.rs` `specializes_on_equality_prefix` test: the
  `core_disbursals` / `credit_facility_id` / `obligation_id` regression
  guard becomes `transfers` / `account_id` / `reference` — same
  assertions, repo-generic schema names.
- `list_for_filters_fn.rs`: two `(lana-bank#7996)` comment citations
  dropped; the explanatory wording is kept.

Pre-existing references on main (`index_catalog.rs` "mirrors lana's
composite constraint usage", `list_for_filters_fn.rs` "+2054-query
regression" from #168) are not part of #185's diff and are left alone.
The `(#185)` self-references in `tests/index_catalog_verification.rs`
are kept — they cite this change, not a downstream repo.

No behaviour change; comment/test-data only.

## Testing

- `cargo fmt` clean
- `cargo test -p es-entity-macros`: 134/134 pass (incl. both touched
  tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and test-data edits only; `specializes` logic and generated queries are untouched.
> 
> **Overview**
> Follow-up documentation cleanup: **downstream repo citations** (`lana-bank#7996`) are removed from `specializes` rationale in `index_catalog.rs` and from related comments in `list_for_filters_fn.rs`, while the generic explanation of the equality-prefix specialization rule stays the same.
> 
> In **`specializes_on_equality_prefix`**, regression coverage is unchanged but uses **repo-generic** names (`transfers` / `account_id` / `reference` instead of `core_disbursals` / `credit_facility_id` / `obligation_id`).
> 
> **No runtime or codegen behavior change**—comments and test fixtures only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30d6dadef7a4aefe5312fb14a29513f82a182b5a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->