### PR TITLE
fix: load_n(_,0) returns all entities & ManualClock::now() panics on huge advance()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +684,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "es-entity"
 version = "0.12.4-dev"
 dependencies = [
@@ -689,6 +714,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "pin-project",
+ "proptest",
  "schemars",
  "serde",
  "serde_json",
@@ -735,6 +761,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1250,6 +1282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +1674,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1770,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1846,6 +1918,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +1969,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2402,6 +2499,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,6 +2731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,6 +2828,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 tracing-subscriber = { workspace = true }
 criterion = { version = "0.8", features = ["html_reports", "async_tokio"] }
+proptest = "1"
 
 [[bench]]
 name = "context"

--- a/src/clock/manual.rs
+++ b/src/clock/manual.rs
@@ -15,6 +15,20 @@ fn truncate_to_millis(time: DateTime<Utc>) -> DateTime<Utc> {
     DateTime::from_timestamp_millis(time.timestamp_millis()).expect("valid timestamp")
 }
 
+/// Convert epoch milliseconds to a `DateTime`, saturating to chrono's
+/// representable range. `from_timestamp_millis` returns `None` out of range,
+/// so we fall back to chrono's own canonical bounds (`MAX_UTC` / `MIN_UTC`).
+/// This keeps `now()` and `advance_to_next_wake()` total — they never panic —
+/// even when an absurd `Duration` (e.g. `Duration::MAX`) overflows the `as i64`
+/// cast in `advance()` and leaves `current_ms` outside the representable range.
+fn datetime_from_millis(ms: i64) -> DateTime<Utc> {
+    DateTime::from_timestamp_millis(ms).unwrap_or(if ms > 0 {
+        DateTime::<Utc>::MAX_UTC
+    } else {
+        DateTime::<Utc>::MIN_UTC
+    })
+}
+
 /// Manual clock where time only advances via explicit controller calls.
 pub(crate) struct ManualClock {
     /// Current time as epoch milliseconds.
@@ -77,7 +91,7 @@ impl ManualClock {
 
     /// Get the current time.
     pub fn now(&self) -> DateTime<Utc> {
-        DateTime::from_timestamp_millis(self.now_ms()).expect("valid timestamp")
+        datetime_from_millis(self.now_ms())
     }
 
     /// Get the current time as epoch milliseconds.
@@ -164,7 +178,12 @@ impl ManualClock {
     /// Returns the number of wake events processed.
     pub async fn advance(&self, duration: Duration) -> usize {
         let start_ms = self.current_ms.load(Ordering::SeqCst);
-        let target_ms = start_ms + duration.as_millis() as i64;
+        // Saturating add over `as i64`: `duration.as_millis()` is `u128` and a
+        // huge duration must not wrap `target_ms` negative (which would both
+        // break monotonicity and, once stored, panic `now()`). `now()` clamps
+        // any out-of-range result back into chrono's range.
+        let added = i64::try_from(duration.as_millis()).unwrap_or(i64::MAX);
+        let target_ms = start_ms.saturating_add(added);
         let mut total_woken = 0;
 
         // Process regular wakes at intermediate boundaries
@@ -219,7 +238,7 @@ impl ManualClock {
         self.wake_coalesce_tasks_at(next_wake_ms);
         tokio::task::yield_now().await;
 
-        Some(DateTime::from_timestamp_millis(next_wake_ms).expect("valid timestamp"))
+        Some(datetime_from_millis(next_wake_ms))
     }
 
     /// Wake all coalesceable tasks scheduled at or before the given time.
@@ -266,6 +285,7 @@ impl ManualClock {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn test_manual_now() {
@@ -297,5 +317,112 @@ mod tests {
         clock.wake_tasks_at(2000);
 
         assert_eq!(clock.next_wake_time(), Some(3000));
+    }
+
+    proptest! {
+        /// After each insertion the heap's peek must equal the running minimum of
+        /// all registered `wake_at_ms`, and the count must stay in sync.
+        #[test]
+        fn next_wake_time_tracks_min_after_each_insert(
+            raw in proptest::collection::vec((any::<i64>(), any::<u64>()), 0..30),
+        ) {
+            let clock = ManualClock::new();
+            let mut seen = std::collections::HashSet::<u64>::new();
+            let mut running_min: Option<i64> = None;
+            let mut count = 0usize;
+            for (ms, id) in raw {
+                if !seen.insert(id) {
+                    continue;
+                }
+                clock.register_wake(ms, id, futures::task::noop_waker());
+                running_min = Some(running_min.map_or(ms, |m| m.min(ms)));
+                count += 1;
+                prop_assert_eq!(clock.next_wake_time(), running_min);
+                prop_assert_eq!(clock.pending_wake_count(), count);
+            }
+        }
+
+        /// Draining the heap by repeatedly popping at the current minimum must
+        /// produce wake times in non-decreasing order and wake every entry
+        /// exactly once. This exercises the reversed `Ord` impl.
+        #[test]
+        fn wakes_drain_in_nondecreasing_order(
+            raw in proptest::collection::vec((any::<i64>(), any::<u64>()), 0..30),
+        ) {
+            let clock = ManualClock::new();
+            let mut seen = std::collections::HashSet::<u64>::new();
+            let mut inserted = 0usize;
+            for (ms, id) in raw {
+                if seen.insert(id) {
+                    clock.register_wake(ms, id, futures::task::noop_waker());
+                    inserted += 1;
+                }
+            }
+            let mut prev: Option<i64> = None;
+            let mut total = 0usize;
+            while let Some(cur) = clock.next_wake_time() {
+                if let Some(p) = prev {
+                    prop_assert!(cur >= p, "wake time decreased: {cur} < {p}");
+                }
+                prev = Some(cur);
+                total += clock.wake_tasks_at(cur);
+            }
+            prop_assert_eq!(total, inserted);
+            prop_assert_eq!(clock.pending_wake_count(), 0);
+        }
+
+        /// `cancel_wake` removes exactly the targeted entry, is idempotent, and
+        /// leaves the remaining entries fully drainable.
+        #[test]
+        fn cancel_wake_removes_exactly_one(
+            raw in proptest::collection::vec((any::<i64>(), any::<u64>()), 1..20),
+        ) {
+            let clock = ManualClock::new();
+            let mut seen = std::collections::HashSet::<u64>::new();
+            let mut ids: Vec<u64> = Vec::new();
+            for (ms, id) in raw {
+                if seen.insert(id) {
+                    clock.register_wake(ms, id, futures::task::noop_waker());
+                    ids.push(id);
+                }
+            }
+            let before = clock.pending_wake_count();
+            let victim = ids[0];
+            clock.cancel_wake(victim);
+            prop_assert_eq!(clock.pending_wake_count(), before - 1);
+            // cancelling an already-cancelled id is a no-op.
+            clock.cancel_wake(victim);
+            prop_assert_eq!(clock.pending_wake_count(), before - 1);
+            // everything else still drains cleanly.
+            let mut total = 0usize;
+            while let Some(cur) = clock.next_wake_time() {
+                total += clock.wake_tasks_at(cur);
+            }
+            prop_assert_eq!(total, before - 1);
+        }
+
+        /// `now()` must never panic for *any* value held in `current_ms`,
+        /// including out-of-range values an absurd `advance()` could store.
+        #[test]
+        fn now_never_panics_for_any_stored_ms(ms in any::<i64>()) {
+            let clock = ManualClock::new();
+            clock
+                .current_ms
+                .store(ms, std::sync::atomic::Ordering::SeqCst);
+            let _ = clock.now();
+        }
+    }
+
+    /// Regression for the overflow panic: `Duration::MAX` overflowed
+    /// `as_millis() as i64`, stored an out-of-range `current_ms`, and the next
+    /// `now()` panicked in `from_timestamp_millis(...).expect(...)`.
+    #[tokio::test]
+    async fn advance_huge_duration_does_not_panic_in_now() {
+        let clock = ManualClock::new();
+        let start = clock.now();
+        clock.advance(Duration::MAX).await;
+        let after = clock.now();
+        // Must not panic, and time stays monotonic (saturated to MAX_UTC).
+        assert!(after >= start);
     }
 }

--- a/src/clock/sleep.rs
+++ b/src/clock/sleep.rs
@@ -62,7 +62,8 @@ impl ClockSleep {
                 sleep: rt.sleep(duration),
             },
             ClockInner::Manual(manual) => {
-                let wake_at_ms = manual.now_ms() + duration.as_millis() as i64;
+                let added = i64::try_from(duration.as_millis()).unwrap_or(i64::MAX);
+                let wake_at_ms = manual.now_ms().saturating_add(added);
 
                 ClockSleepInner::Manual {
                     wake_at_ms,

--- a/src/error.rs
+++ b/src/error.rs
@@ -101,6 +101,7 @@ impl<T: std::fmt::Debug + ?Sized> ToNotFoundValueFallback for NotFoundValue<'_, 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn parse_simple_uuid_value() {
@@ -180,5 +181,33 @@ mod tests {
 
         let val = OnlyDebug(7);
         assert_eq!(NotFoundValue(&val).to_not_found_value(), "OnlyDebug(7)");
+    }
+
+    proptest! {
+        /// The parser does byte-index arithmetic over attacker-controlled strings.
+        /// It must never panic, and any value it returns must be an honest
+        /// substring bounded by the real markers.
+        #[test]
+        fn constraint_detail_never_panics_and_is_honest(detail in ".*") {
+            match parse_constraint_detail_value(Some(&detail)) {
+                None => {}
+                Some(v) => {
+                    // Returned value is always a genuine substring of the input.
+                    prop_assert!(detail.contains(&v));
+                    // The markers that drove the indices must actually be present.
+                    let start = detail.find("=(").expect("start marker present") + 2;
+                    let end = detail
+                        .rfind(") already")
+                        .expect("end marker present");
+                    prop_assert!(start <= end);
+                    prop_assert_eq!(&detail[start..end], v.as_str());
+                }
+            }
+        }
+
+        #[test]
+        fn constraint_detail_none_input_returns_none(_ in Just(())) {
+            prop_assert_eq!(parse_constraint_detail_value(None), None);
+        }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -233,6 +233,14 @@ where
         events: impl IntoIterator<Item = GenericEvent<<T as EsEvent>::EntityId>>,
         n: usize,
     ) -> Result<(Vec<E>, bool), EntityHydrationError> {
+        if n == 0 {
+            // Asking for zero entities yields zero entities. `has_more` reports
+            // whether the stream was non-empty, mirroring the `LIMIT n + 1`
+            // over-fetch contract the generated repos rely on: callers query
+            // `LIMIT (first + 1)`, so a non-empty stream means a next page exists.
+            let has_more = events.into_iter().next().is_some();
+            return Ok((Vec::new(), has_more));
+        }
         let mut ret: Vec<E> = Vec::new();
         let mut current_id = None;
         let mut current = None;
@@ -355,7 +363,46 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use uuid::Uuid;
+
+    /// Builds a `GenericEvent` whose JSON deserializes to `Created(name)`.
+    fn valid_event(id: Uuid, sequence: i32, name: &str) -> GenericEvent<Uuid> {
+        GenericEvent {
+            entity_id: id,
+            sequence,
+            event: serde_json::to_value(DummyEntityEvent::Created(name.to_string()))
+                .expect("could not serialize"),
+            context: None,
+            recorded_at: chrono::Utc::now(),
+            forgettable_payload: None,
+        }
+    }
+
+    /// Small bounded JSON strategy covering null/bool/int/float/string plus one
+    /// level of array/object nesting. Cheap to shrink and enough to exercise the
+    /// serde error paths without ballooning runtime.
+    fn json_value() -> impl Strategy<Value = serde_json::Value> {
+        let scalar = prop_oneof![
+            Just(serde_json::Value::Null),
+            any::<bool>().prop_map(serde_json::Value::Bool),
+            any::<i64>().prop_map(serde_json::Value::from),
+            any::<f64>().prop_map(serde_json::Value::from),
+            ".{0,15}".prop_map(serde_json::Value::String),
+        ]
+        .boxed();
+        let nested = prop_oneof![
+            proptest::collection::vec(scalar.clone(), 0..4).prop_map(serde_json::Value::Array),
+            proptest::collection::vec((".{0,6}", scalar.clone()), 0..4).prop_map(|pairs| {
+                let mut m = serde_json::Map::new();
+                for (k, v) in pairs {
+                    m.insert(k, v);
+                }
+                serde_json::Value::Object(m)
+            },),
+        ];
+        prop_oneof![scalar, nested]
+    }
 
     #[derive(Debug, serde::Serialize, serde::Deserialize)]
     enum DummyEntityEvent {
@@ -492,5 +539,167 @@ mod tests {
         assert_eq!(events.last_persisted(10).count(), 1);
         // n == 0 yields nothing
         assert_eq!(events.last_persisted(0).count(), 0);
+    }
+
+    proptest! {
+        #[test]
+        fn load_first_empty_input_returns_none(_ in Just(())) {
+            let res = EntityEvents::<DummyEntityEvent>::load_first::<DummyEntity>(vec![]);
+            prop_assert!(matches!(res, Ok(None)));
+        }
+
+        #[test]
+        fn load_first_non_empty_valid_hydrates(
+            count in 1u8..8,
+            names in proptest::collection::vec(".{0,10}", 1..8),
+        ) {
+            let id = Uuid::nil();
+            let events: Vec<_> = (1..=count as i32)
+                .zip(names.iter())
+                .map(|(s, n)| valid_event(id, s, n))
+                .collect();
+            let res = EntityEvents::<DummyEntityEvent>::load_first::<DummyEntity>(events);
+            prop_assert!(matches!(res, Ok(Some(_))));
+        }
+
+        /// Feeds arbitrary JSON through the loader. It may hydrate or error, but
+        /// it must never panic — and `Ok(None)` is only possible for empty input.
+        #[test]
+        fn load_first_arbitrary_json_never_panics(
+            raw in proptest::collection::vec(json_value(), 0..10),
+        ) {
+            let events: Vec<_> = raw
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| GenericEvent {
+                    entity_id: Uuid::nil(),
+                    sequence: i as i32,
+                    event: v,
+                    context: None,
+                    recorded_at: chrono::Utc::now(),
+                    forgettable_payload: None,
+                })
+                .collect();
+            let is_empty = events.is_empty();
+            let res = EntityEvents::<DummyEntityEvent>::load_first::<DummyEntity>(events);
+            if let Ok(None) = res {
+                prop_assert!(is_empty);
+            }
+        }
+
+        /// With a grouped, ascending stream (the documented precondition) and
+        /// `n >= 1`, `load_n` returns `min(n, k)` entities and reports `has_more`
+        /// exactly when `n < k`.
+        #[test]
+        fn load_n_respects_limit_and_more_flag(
+            k in 1u8..8,
+            per in 1u8..4,
+            n in 1u8..12,
+        ) {
+            let mut events = Vec::new();
+            for i in 0..k {
+                let id = Uuid::from_u128(i as u128);
+                for s in 1..=per as i32 {
+                    events.push(valid_event(id, s, &format!("e{i}-{s}")));
+                }
+            }
+            let (entities, has_more) =
+                EntityEvents::<DummyEntityEvent>::load_n::<DummyEntity>(events, n as usize)
+                    .expect("valid events hydrate");
+            prop_assert_eq!(entities.len(), (n as usize).min(k as usize));
+            prop_assert_eq!(has_more, n < k);
+        }
+
+        /// Regression for the `n = 0` degenerate case: previously returned *all*
+        /// entities instead of zero. Now returns none and reports `has_more` iff
+        /// the stream was non-empty (the `LIMIT n + 1` contract).
+        #[test]
+        fn load_n_zero_returns_no_entities(k in 0u8..5, per in 1u8..3) {
+            let mut events = Vec::new();
+            for i in 0..k {
+                let id = Uuid::from_u128(i as u128);
+                for s in 1..=per as i32 {
+                    events.push(valid_event(id, s, &format!("e{i}-{s}")));
+                }
+            }
+            let (entities, has_more) =
+                EntityEvents::<DummyEntityEvent>::load_n::<DummyEntity>(events, 0)
+                    .expect("valid events hydrate");
+            prop_assert!(entities.is_empty());
+            prop_assert_eq!(has_more, k > 0);
+        }
+
+        #[test]
+        fn load_n_arbitrary_json_never_panics(
+            raw in proptest::collection::vec(json_value(), 0..10),
+            n in 0u8..12,
+        ) {
+            let events: Vec<_> = raw
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| GenericEvent {
+                    entity_id: Uuid::nil(),
+                    sequence: i as i32,
+                    event: v,
+                    context: None,
+                    recorded_at: chrono::Utc::now(),
+                    forgettable_payload: None,
+                })
+                .collect();
+            let _ = EntityEvents::<DummyEntityEvent>::load_n::<DummyEntity>(events, n as usize);
+        }
+
+        /// `last_persisted(n)` must clamp to the available events for any `n`,
+        /// generalizing the dedicated saturating-sub test above.
+        #[test]
+        fn last_persisted_clamps_for_any_n(
+            p in 1u8..8,
+            n in 0u16..12,
+        ) {
+            let id = Uuid::nil();
+            let events: Vec<_> = (1..=p as i32)
+                .map(|s| valid_event(id, s, &format!("n{s}")))
+                .collect();
+            let entity: DummyEntity =
+                EntityEvents::<DummyEntityEvent>::load_first::<DummyEntity>(events)
+                    .expect("load")
+                    .expect("some");
+            let count = entity.events().last_persisted(n as usize).count();
+            prop_assert_eq!(count, (n as usize).min(p as usize));
+        }
+
+        /// Marking new events as persisted must drain `new_events`, leave
+        /// `len_persisted` consistent, and assign contiguous 1-based sequences
+        /// across repeated calls.
+        #[test]
+        fn mark_new_events_assigns_contiguous_sequences(
+            a in 0u8..5,
+            b in 0u8..5,
+        ) {
+            let id = Uuid::nil();
+            let mut events = EntityEvents::init(
+                id,
+                (0..a).map(|i| DummyEntityEvent::Created(format!("n{i}"))),
+            );
+            let now = chrono::Utc::now();
+
+            prop_assert_eq!(events.mark_new_events_persisted_at(now), a as usize);
+            prop_assert!(!events.any_new());
+            prop_assert_eq!(events.len_persisted(), a as usize);
+            let seqs: Vec<usize> = events.iter_persisted().map(|e| e.sequence).collect();
+            prop_assert_eq!(seqs, (1..=a as usize).collect::<Vec<_>>());
+
+            for i in 0..b {
+                events.push(DummyEntityEvent::Created(format!("m{i}")));
+            }
+            if b > 0 {
+                prop_assert!(events.any_new());
+            }
+            prop_assert_eq!(events.mark_new_events_persisted_at(now), b as usize);
+            prop_assert!(!events.any_new());
+            prop_assert_eq!(events.len_persisted(), (a + b) as usize);
+            let seqs: Vec<usize> = events.iter_persisted().map(|e| e.sequence).collect();
+            prop_assert_eq!(seqs, (1..=(a + b) as usize).collect::<Vec<_>>());
+        }
     }
 }

--- a/src/forgettable.rs
+++ b/src/forgettable.rs
@@ -228,6 +228,31 @@ pub fn inject_forgettable_payload(event_json: &mut serde_json::Value, payload: s
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    /// Bounded JSON strategy (null/bool/int/float/string + one level of
+    /// array/object nesting) used to exercise the merge and serde paths.
+    fn json_value() -> impl Strategy<Value = serde_json::Value> {
+        let scalar = prop_oneof![
+            Just(serde_json::Value::Null),
+            any::<bool>().prop_map(serde_json::Value::Bool),
+            any::<i64>().prop_map(serde_json::Value::from),
+            any::<f64>().prop_map(serde_json::Value::from),
+            ".{0,15}".prop_map(serde_json::Value::String),
+        ]
+        .boxed();
+        let nested = prop_oneof![
+            proptest::collection::vec(scalar.clone(), 0..4).prop_map(serde_json::Value::Array),
+            proptest::collection::vec((".{0,6}", scalar.clone()), 0..4).prop_map(|pairs| {
+                let mut m = serde_json::Map::new();
+                for (k, v) in pairs {
+                    m.insert(k, v);
+                }
+                serde_json::Value::Object(m)
+            },),
+        ];
+        prop_oneof![scalar, nested]
+    }
 
     #[test]
     fn serialize_set_emits_null() {
@@ -370,5 +395,60 @@ mod tests {
         let f: Forgettable<String> = "Alice".to_string().into();
         assert!(f.is_set());
         assert_eq!(&*f.value().unwrap(), "Alice");
+    }
+
+    proptest! {
+        /// `inject_forgettable_payload` must never panic on any pair of JSON
+        /// values. When both sides are objects it merges payload over event
+        /// (payload wins on conflict); otherwise the event is left untouched.
+        #[test]
+        fn inject_never_panics_and_merges_only_objects(
+            event_in in json_value(),
+            payload in json_value(),
+        ) {
+            let mut event = event_in.clone();
+            inject_forgettable_payload(&mut event, payload.clone());
+
+            if event_in.is_object() && payload.is_object() {
+                let payload_obj = payload.as_object().unwrap();
+                // payload keys are present in the result with payload's values.
+                for (k, v) in payload_obj {
+                    prop_assert_eq!(event.get(k), Some(v));
+                }
+                // non-overwritten original keys are retained.
+                for (k, v) in event_in.as_object().unwrap() {
+                    if !payload_obj.contains_key(k) {
+                        prop_assert_eq!(event.get(k), Some(v));
+                    }
+                }
+            } else {
+                prop_assert_eq!(event, event_in);
+            }
+        }
+
+        /// A set `Forgettable` and a forgotten one serialize identically to
+        /// `null` (data-leakage guard), and the set/forgotten flags are always
+        /// mutually exclusive.
+        #[test]
+        fn forgettable_always_serializes_to_null(opt in any::<Option<String>>()) {
+            let v = serde_json::to_value(&opt).expect("serialize option");
+            let f: Forgettable<String> =
+                serde_json::from_value(v.clone()).expect("deserialize forgettable");
+            prop_assert_eq!(f.is_set(), opt.is_some());
+            prop_assert_eq!(f.is_forgotten(), opt.is_none());
+            prop_assert_eq!(serde_json::to_value(&f).unwrap(), serde_json::Value::Null);
+            // round-trip from null yields forgotten.
+            let from_null: Forgettable<String> =
+                serde_json::from_value(serde_json::Value::Null).unwrap();
+            prop_assert!(from_null.is_forgotten());
+        }
+
+        /// Deserializing a non-string, non-null value must error (never panic).
+        #[test]
+        fn forgettable_rejects_non_string_value(n in any::<i64>()) {
+            let res: Result<Forgettable<String>, _> =
+                serde_json::from_value(serde_json::Value::from(n));
+            prop_assert!(res.is_err());
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds property-based testing (via [`proptest`](https://docs.rs/proptest)) for the pure-logic modules, and fixes two bugs the fuzzing surfaced. All new tests run as part of `cargo test --lib` (no DB, ~0.07s).

Tier 1 of a fuzzing rollout (pure logic only). Follow-ups (proposed, not here): a `cargo-fuzz` sub-crate for the string-parsing hotspots, and Tier 2 DB-backed pagination/repo fuzzing.

## What's covered

| Module | Property |
|---|---|
| `error` | `parse_constraint_detail_value` never panics on arbitrary `&str`; any returned value is an honest substring bounded by the real markers |
| `events` | `load_first`/`load_n` never panic on arbitrary JSON; `Ok(None)` iff empty; `last_persisted` clamps for any `n`; `mark_new_events_persisted` assigns contiguous `1..=N` sequences |
| `forgettable` | `inject_forgettable_payload` only affects objects (payload wins on conflict); `Forgettable` always serializes to `null`; set/forgotten flags mutually exclusive |
| `clock` | `ManualClock` wake-heap ordering under random `(ms, id)` insertion; non-decreasing drain order; exact + idempotent `cancel_wake`; `now()` never panics |

## Bug 1 — `EntityEvents::load_n(_, 0)` returned all entities

`load_n(stream, 0)` returned **all** entities instead of zero — the early-return check `ret.len() == n` is unreachable for `n=0`.

**Fix:** explicit `n==0` short-circuit returning `(Vec::new(), has_more)` where `has_more = stream.next().is_some()`, matching the `LIMIT (first+1)` over-fetch contract the generated repos use (`es-entity-macros/src/repo/list_by_fn.rs`).

## Bug 2 — `ManualClock::now()` panic via `advance()` overflow

`advance()` did `start_ms + duration.as_millis() as i64`. `as_millis()` is `u128`; the `as i64` cast wraps, the wrapped value gets stored in `current_ms`, and the next `now()` panics in `from_timestamp_millis(...).expect()` (verified `from_timestamp_millis(i64::MAX) == None`). Same `as i64` bug in `sleep.rs`.

**Fix:**
- `now()` and `advance_to_next_wake()` saturate to chrono's own canonical bounds (`DateTime::<Utc>::MAX_UTC` / `MIN_UTC`) via a small `datetime_from_millis` helper — total for any `i64`, no hardcoded magic constants.
- `advance()` and `sleep.rs` use `saturating_add(i64::try_from(...).unwrap_or(i64::MAX))` instead of the wrapping cast — preserves monotonicity instead of wrapping negative.

## Checklist
- [x] `cargo test --lib` — 56 passed
- [x] `cargo fmt --check --all` — clean
- [x] `cargo clippy --lib` — 0 warnings; no lints in changed files
- [x] `cargo deny check` — advisories/bans/licenses/sources all ok (proptest + transitive deps clear)
- [ ] CI (DB-backed integration tests `tests/*.rs`) — runs in CI; not exercised locally without Postgres

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes entity pagination semantics for `load_n(..., 0)` used by generated repos, plus test-time clock behavior; changes are localized but affect core event loading and manual clock paths.
> 
> **Overview**
> Adds **proptest** as a dev-dependency and property tests across `error`, `events`, `forgettable`, and `clock` pure-logic modules.
> 
> **Bug fixes**
> 
> - **`EntityEvents::load_n(_, 0)`** — Previously hydrated **every** entity in the stream because `ret.len() == n` never fired for `n = 0`. Now short-circuits to an empty vec and sets **`has_more`** from whether the stream had any events, matching the generated repo **`LIMIT (first + 1)`** pagination contract.
> - **`ManualClock`** — **`advance()`** and manual **`ClockSleep`** no longer use wrapping `duration.as_millis() as i64`. They use **`saturating_add`** / **`i64::try_from`**, and **`now()`** / **`advance_to_next_wake()`** map out-of-range millis via **`datetime_from_millis`** to chrono’s **`MAX_UTC`** / **`MIN_UTC`** so huge durations (e.g. **`Duration::MAX`**) cannot panic **`now()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa6a90015e13743f7d9dd0d07dc9695c7a7919fe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->