### PR TITLE
ci(fuzz): self-bootstrapping fuzz job (no manual GCS seed)

### DIFF
--- a/ci/fuzz.sh
+++ b/ci/fuzz.sh
@@ -1,20 +1,25 @@
 #!/usr/bin/env bash
 #
-# Run the cargo-fuzz targets in parallel, with optional corpus restore/package.
+# Run the cargo-fuzz targets in parallel, with optional corpus restore/persist.
 #
-# This is the single source of truth for fuzzing logic, shared by:
-#   - the Concourse `fuzz` job (ci/pipeline.yml)  — sets CORPUS_TARBALL_IN/OUT (GCS)
-#   - `nix run .#fuzz`                             — flake-provided toolchain
-#   - `make fuzz`                                  — local, in the dev shell
+# Single source of truth, shared by:
+#   - the Concourse `fuzz` job (ci/pipeline.yml) — sets GCS_BUCKET/CREDS/PREFIX
+#   - `nix run .#fuzz`                          — flake-provided toolchain
+#   - `make fuzz`                               — local, in the dev shell
 #
-# Env vars (all optional, local-friendly defaults):
+# Corpus handling (mutually exclusive):
+#   GCS_BUCKET (+ GCS_CREDS + GCS_PREFIX)  — download latest / upload new via gsutil
+#                                            (CI). Self-bootstraps: first run
+#                                            finds no corpus and fuzzes from scratch.
+#   CORPUS_TARBALL_IN / CORPUS_TARBALL_OUT  — local tarball (elsewhere).
+#
+# Other env vars (optional, local-friendly defaults):
 #   FUZZ_SECONDS        seconds to fuzz each target (default: 60)
-#   FUZZ_JOBS           libFuzzer `-jobs` per target; total cores = 2 targets * FUZZ_JOBS
+#   FUZZ_JOBS           libFuzzer `-jobs` per target; cores = 2 targets * FUZZ_JOBS
 #                       (unset => 1 process per target => 2 cores)
-#   CORPUS_TARBALL_IN   glob of a corpus tarball to extract before fuzzing
-#   CORPUS_TARBALL_OUT  path to write the evolved corpus tarball after fuzzing
 #
 # Requires: bash, git, cargo, tar, and cargo-fuzz (auto-installed if missing).
+# GCS mode additionally requires: gcloud + gsutil (google-cloud-sdk).
 
 set -euo pipefail
 
@@ -28,9 +33,21 @@ fi
 
 FUZZ_SECONDS="${FUZZ_SECONDS:-60}"
 
-# Restore the corpus (no-op unless CORPUS_TARBALL_IN is set and matches a file).
+# ── Restore the corpus ────────────────────────────────────────────────
 mkdir -p fuzz/corpus
-if [ -n "${CORPUS_TARBALL_IN:-}" ] && compgen -G "$CORPUS_TARBALL_IN" >/dev/null; then
+if [ -n "${GCS_BUCKET:-}" ]; then
+  printf '%s' "${GCS_CREDS:?GCS_BUCKET set but GCS_CREDS missing}" > /tmp/gcs-key.json
+  gcloud auth activate-service-account --key-file=/tmp/gcs-key.json >/dev/null
+  prefix="gs://$GCS_BUCKET/${GCS_PREFIX:?GCS_BUCKET set but GCS_PREFIX missing}"
+  latest="$(gsutil ls "$prefix/corpus-v*.tgz" 2>/dev/null | sort | tail -1 || true)"
+  if [ -n "$latest" ]; then
+    echo "restoring corpus from $latest"
+    gsutil cp "$latest" /tmp/corpus-in.tgz
+    tar -xzf /tmp/corpus-in.tgz -C fuzz/
+  else
+    echo "no existing corpus in GCS; bootstrapping from scratch"
+  fi
+elif [ -n "${CORPUS_TARBALL_IN:-}" ] && compgen -G "$CORPUS_TARBALL_IN" >/dev/null; then
   echo "restoring corpus from $CORPUS_TARBALL_IN"
   tar -xzf $CORPUS_TARBALL_IN -C fuzz/
 fi
@@ -61,8 +78,13 @@ if [ "$rc" -ne 0 ]; then
   exit "$rc"
 fi
 
-# Package the evolved corpus (no-op unless CORPUS_TARBALL_OUT is set).
-if [ -n "${CORPUS_TARBALL_OUT:-}" ]; then
+# ── Persist the evolved corpus ────────────────────────────────────────
+if [ -n "${GCS_BUCKET:-}" ]; then
+  ts=$(date -u +%Y%m%d-%H%M%S)
+  tar -czf /tmp/corpus-v${ts}.tgz -C fuzz corpus
+  gsutil cp /tmp/corpus-v${ts}.tgz "$prefix/corpus-v${ts}.tgz"
+  echo "uploaded corpus-v${ts}.tgz"
+elif [ -n "${CORPUS_TARBALL_OUT:-}" ]; then
   mkdir -p "$(dirname "$CORPUS_TARBALL_OUT")"
   tar -czf "$CORPUS_TARBALL_OUT" -C fuzz corpus
   echo "packaged corpus -> $CORPUS_TARBALL_OUT"

--- a/ci/fuzz.sh
+++ b/ci/fuzz.sh
@@ -3,23 +3,20 @@
 # Run the cargo-fuzz targets in parallel, with optional corpus restore/persist.
 #
 # Single source of truth, shared by:
-#   - the Concourse `fuzz` job (ci/pipeline.yml) — sets GCS_BUCKET/CREDS/PREFIX
+#   - the Concourse `fuzz` job (ci/pipeline.yml) — restore/store steps pass the
+#     corpus in/out as a tarball via CORPUS_TARBALL_IN/OUT (GCS handled by the
+#     google/cloud-sdk steps, not here)
 #   - `nix run .#fuzz`                          — flake-provided toolchain
 #   - `make fuzz`                               — local, in the dev shell
 #
-# Corpus handling (mutually exclusive):
-#   GCS_BUCKET (+ GCS_CREDS + GCS_PREFIX)  — download latest / upload new via gsutil
-#                                            (CI). Self-bootstraps: first run
-#                                            finds no corpus and fuzzes from scratch.
-#   CORPUS_TARBALL_IN / CORPUS_TARBALL_OUT  — local tarball (elsewhere).
-#
-# Other env vars (optional, local-friendly defaults):
+# Env vars (all optional, local-friendly defaults):
 #   FUZZ_SECONDS        seconds to fuzz each target (default: 60)
 #   FUZZ_JOBS           libFuzzer `-jobs` per target; cores = 2 targets * FUZZ_JOBS
 #                       (unset => 1 process per target => 2 cores)
+#   CORPUS_TARBALL_IN   glob of a corpus tarball to extract before fuzzing
+#   CORPUS_TARBALL_OUT  path to write the evolved corpus tarball after fuzzing
 #
 # Requires: bash, git, cargo, tar, and cargo-fuzz (auto-installed if missing).
-# GCS mode additionally requires: gcloud + gsutil (google-cloud-sdk).
 
 set -euo pipefail
 
@@ -33,21 +30,9 @@ fi
 
 FUZZ_SECONDS="${FUZZ_SECONDS:-60}"
 
-# ── Restore the corpus ────────────────────────────────────────────────
+# Restore the corpus (no-op unless CORPUS_TARBALL_IN is set and matches a file).
 mkdir -p fuzz/corpus
-if [ -n "${GCS_BUCKET:-}" ]; then
-  printf '%s' "${GCS_CREDS:?GCS_BUCKET set but GCS_CREDS missing}" > /tmp/gcs-key.json
-  gcloud auth activate-service-account --key-file=/tmp/gcs-key.json >/dev/null
-  prefix="gs://$GCS_BUCKET/${GCS_PREFIX:?GCS_BUCKET set but GCS_PREFIX missing}"
-  latest="$(gsutil ls "$prefix/corpus-v*.tgz" 2>/dev/null | sort | tail -1 || true)"
-  if [ -n "$latest" ]; then
-    echo "restoring corpus from $latest"
-    gsutil cp "$latest" /tmp/corpus-in.tgz
-    tar -xzf /tmp/corpus-in.tgz -C fuzz/
-  else
-    echo "no existing corpus in GCS; bootstrapping from scratch"
-  fi
-elif [ -n "${CORPUS_TARBALL_IN:-}" ] && compgen -G "$CORPUS_TARBALL_IN" >/dev/null; then
+if [ -n "${CORPUS_TARBALL_IN:-}" ] && compgen -G "$CORPUS_TARBALL_IN" >/dev/null; then
   echo "restoring corpus from $CORPUS_TARBALL_IN"
   tar -xzf $CORPUS_TARBALL_IN -C fuzz/
 fi
@@ -78,13 +63,8 @@ if [ "$rc" -ne 0 ]; then
   exit "$rc"
 fi
 
-# ── Persist the evolved corpus ────────────────────────────────────────
-if [ -n "${GCS_BUCKET:-}" ]; then
-  ts=$(date -u +%Y%m%d-%H%M%S)
-  tar -czf /tmp/corpus-v${ts}.tgz -C fuzz corpus
-  gsutil cp /tmp/corpus-v${ts}.tgz "$prefix/corpus-v${ts}.tgz"
-  echo "uploaded corpus-v${ts}.tgz"
-elif [ -n "${CORPUS_TARBALL_OUT:-}" ]; then
+# Package the evolved corpus (no-op unless CORPUS_TARBALL_OUT is set).
+if [ -n "${CORPUS_TARBALL_OUT:-}" ]; then
   mkdir -p "$(dirname "$CORPUS_TARBALL_OUT")"
   tar -czf "$CORPUS_TARBALL_OUT" -C fuzz corpus
   echo "packaged corpus -> $CORPUS_TARBALL_OUT"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -46,13 +46,13 @@ jobs:
 #! Nightly coverage-guided fuzzing (cargo-fuzz / libFuzzer).
 #!
 #! The targets are pure (no Postgres), so this runs lighter than `tests`. The
-#! evolving corpus is persisted to GCS (not git): `get` restores the latest
-#! corpus tarball before fuzzing, and `put` uploads the grown one after, so
-#! coverage accumulates across daily runs. Each run fuzzes both targets in
-#! parallel (2 libFuzzer processes = 2 cores, bounded well under the worker's
-#! capacity) for FUZZ_SECONDS wall time. A crash fails the job (the existing
-#! Zenduty alert on failed jobs fires) and the crash input is left in the build
-#! log; the corpus tarball upload is skipped so we don't persist a crashing run.
+#! evolving corpus is persisted to GCS, NOT via a Concourse resource: the task
+#! itself downloads the latest corpus (gsutil) before fuzzing and uploads the
+#! grown one after — so the very first run self-bootstraps (no corpus → fuzzes
+#! from scratch → uploads). Each run fuzzes both targets in parallel (2
+#! libFuzzer processes = 2 cores) for FUZZ_SECONDS. A crash fails the job
+#! (existing Zenduty alert fires) and skips the upload so a crashing run isn't
+#! persisted.
 - name: fuzz
   serial: true
   plan:
@@ -60,16 +60,12 @@ jobs:
     - { get: repo }
     - { get: pipeline-tasks }
     - { get: fuzz-time, trigger: true }
-    - { get: fuzz-corpus }
   - task: fuzz
     config:
       platform: linux
       image_resource: #@ nix_task_image_config()
       inputs:
       - name: repo
-      - name: fuzz-corpus
-      outputs:
-      - name: fuzz-corpus-out
       caches:
       - path: cargo-home
       - path: cargo-target-dir
@@ -81,25 +77,22 @@ jobs:
             set -euo pipefail
             cd repo
             cachix use $CACHIX_CACHE_NAME
-            cachix watch-exec $CACHIX_CACHE_NAME -- nix -L develop . -c sh -exc '
+            # `nix develop .#fuzz` provides the Rust toolchain + cargo-fuzz +
+            # gsutil (google-cloud-sdk). ci/fuzz.sh restores the latest corpus
+            # from GCS (or bootstraps from scratch) and uploads the grown one.
+            cachix watch-exec $CACHIX_CACHE_NAME -- nix -L develop .#fuzz -c sh -exc '
               set -euo pipefail
               export CARGO_HOME=$PWD/../cargo-home
               export CARGO_TARGET_DIR=$PWD/../cargo-target-dir
-
-              # Delegate to the shared fuzz script (ci/fuzz.sh), which restores
-              # the corpus, runs both targets in parallel, detects crashes, and
-              # packages the evolved corpus. FUZZ_SECONDS comes from the task params.
-              export CORPUS_TARBALL_IN="../fuzz-corpus/*.tgz"
-              export CORPUS_TARBALL_OUT="../fuzz-corpus-out/corpus-v$(date -u +%Y%m%d-%H%M%S).tgz"
               bash ci/fuzz.sh
             '
       params:
         CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
         CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
         FUZZ_SECONDS: "3600"    #! 1h per target per daily run (bump to 4h once proven)
-  - put: fuzz-corpus
-    params:
-      file: fuzz-corpus-out/corpus-v*.tgz
+        GCS_BUCKET: ((staging-gcp-creds.bucket_name))
+        GCS_CREDS: ((staging-gcp-creds.creds_json))
+        GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-corpus"
   on_failure: #@ zenduty_notification_hook()
   on_error: #@ zenduty_notification_hook()
 
@@ -262,12 +255,6 @@ resources:
 #! UTC timestamp so the regex capture group orders them correctly).
 #! NOTE: reuses the shared `staging-gcp-creds` bucket like `bundled_deps_resource`;
 #! swap for a dedicated fuzz credential if that isn't available to this team.
-- name: fuzz-corpus
-  type: gcs-resource
-  source:
-    bucket: ((staging-gcp-creds.bucket_name))
-    json_key: ((staging-gcp-creds.creds_json))
-    regexp: #@ data.values.gh_repository + "-artifacts/fuzz-corpus/corpus-v(.*).tgz"
 - name: fuzz-time
   type: time
   source:
@@ -279,7 +266,6 @@ resources:
     webhook_url: #@ data.values.zenduty_webhook_url
 
 resource_types:
-- #@ gcr_resource_type()
 - name: zenduty-notification
   type: registry-image
   source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -9,7 +9,6 @@
 #@   "rust_task_image_config",
 #@   "gh_release_resource",
 #@   "nix_task_image_config",
-#@   "gcr_resource_type",
 #@ )
 
 #@ def retry_task():
@@ -43,16 +42,14 @@ groups:
   - fuzz
 
 jobs:
-#! Nightly coverage-guided fuzzing (cargo-fuzz / libFuzzer).
-#!
-#! The targets are pure (no Postgres), so this runs lighter than `tests`. The
-#! evolving corpus is persisted to GCS, NOT via a Concourse resource: the task
-#! itself downloads the latest corpus (gsutil) before fuzzing and uploads the
-#! grown one after — so the very first run self-bootstraps (no corpus → fuzzes
-#! from scratch → uploads). Each run fuzzes both targets in parallel (2
-#! libFuzzer processes = 2 cores) for FUZZ_SECONDS. A crash fails the job
-#! (existing Zenduty alert fires) and skips the upload so a crashing run isn't
-#! persisted.
+#! Nightly coverage-guided fuzzing (cargo-fuzz / libFuzzer), self-bootstrapping.
+#! Three steps: (1) restore the latest corpus from GCS via gsutil (or start
+#! empty), (2) fuzz both targets in parallel under nix, (3) upload the grown
+#! corpus. The very first run finds no corpus and fuzzes from scratch — no
+#! manual seed. GCS access uses the google/cloud-sdk image (reliable gsutil);
+#! the nix gsutil is broken (EVP_MD_CTX_NEW crypto mismatch), so GCS stays out
+#! of the nix step. A crash fails the job (existing Zenduty alert fires); the
+#! fuzz step exits non-zero before packaging, so the store step is skipped.
 - name: fuzz
   serial: true
   plan:
@@ -60,12 +57,44 @@ jobs:
     - { get: repo }
     - { get: pipeline-tasks }
     - { get: fuzz-time, trigger: true }
+  - task: restore-corpus
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: { repository: google/cloud-sdk }
+      outputs:
+      - { name: corpus }
+      params:
+        GCS_BUCKET: ((staging-gcp-creds.bucket_name))
+        GCS_CREDS: ((staging-gcp-creds.creds_json))
+        GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-corpus"
+      run:
+        path: sh
+        args:
+          - -exc
+          - |
+            set -euo pipefail
+            mkdir -p corpus
+            printf '%s' "$GCS_CREDS" > /tmp/key.json
+            gcloud auth activate-service-account --key-file=/tmp/key.json >/dev/null
+            prefix="gs://$GCS_BUCKET/$GCS_PREFIX"
+            latest="$(gsutil ls "$prefix/corpus-v*.tgz" 2>/dev/null | sort | tail -1 || true)"
+            if [ -n "$latest" ]; then
+              echo "restoring corpus from $latest"
+              gsutil cp "$latest" corpus/
+            else
+              echo "no existing corpus; bootstrapping from scratch"
+            fi
   - task: fuzz
     config:
       platform: linux
       image_resource: #@ nix_task_image_config()
       inputs:
       - name: repo
+      - name: corpus
+      outputs:
+      - name: corpus-out
       caches:
       - path: cargo-home
       - path: cargo-target-dir
@@ -77,22 +106,44 @@ jobs:
             set -euo pipefail
             cd repo
             cachix use $CACHIX_CACHE_NAME
-            # `nix develop .#fuzz` provides the Rust toolchain + cargo-fuzz +
-            # gsutil (google-cloud-sdk). ci/fuzz.sh restores the latest corpus
-            # from GCS (or bootstraps from scratch) and uploads the grown one.
-            cachix watch-exec $CACHIX_CACHE_NAME -- nix -L develop .#fuzz -c sh -exc '
+            cachix watch-exec $CACHIX_CACHE_NAME -- nix -L develop . -c sh -exc '
               set -euo pipefail
               export CARGO_HOME=$PWD/../cargo-home
               export CARGO_TARGET_DIR=$PWD/../cargo-target-dir
+              export CORPUS_TARBALL_IN="../corpus/*.tgz"
+              export CORPUS_TARBALL_OUT="../corpus-out/corpus-v$(date -u +%Y%m%d-%H%M%S).tgz"
               bash ci/fuzz.sh
             '
       params:
         CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
         CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
         FUZZ_SECONDS: "3600"    #! 1h per target per daily run (bump to 4h once proven)
+  - task: store-corpus
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: { repository: google/cloud-sdk }
+      inputs:
+      - { name: corpus-out }
+      params:
         GCS_BUCKET: ((staging-gcp-creds.bucket_name))
         GCS_CREDS: ((staging-gcp-creds.creds_json))
         GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-corpus"
+      run:
+        path: sh
+        args:
+          - -exc
+          - |
+            set -euo pipefail
+            if ! ls corpus-out/*.tgz >/dev/null 2>&1; then
+              echo "no corpus to store; nothing was packaged"
+              exit 0
+            fi
+            printf '%s' "$GCS_CREDS" > /tmp/key.json
+            gcloud auth activate-service-account --key-file=/tmp/key.json >/dev/null
+            gsutil cp corpus-out/corpus-v*.tgz "gs://$GCS_BUCKET/$GCS_PREFIX/"
+            echo "stored corpus"
   on_failure: #@ zenduty_notification_hook()
   on_error: #@ zenduty_notification_hook()
 

--- a/flake.nix
+++ b/flake.nix
@@ -446,6 +446,20 @@
           '';
         };
 
+        # Lean dev shell for fuzzing: Rust toolchain + cargo-fuzz + gsutil (for
+        # the CI corpus round-trip) + tar. No Postgres/devEnv needed — the fuzz
+        # targets are pure. Used by the Concourse `fuzz` job (`nix develop .#fuzz`).
+        devShells.fuzz = mkShell {
+          packages = [
+            rustToolchain
+            pkgs.cargo-fuzz
+            pkgs.google-cloud-sdk
+            pkgs.gnutar
+            pkgs.coreutils
+            pkgs.git
+          ];
+        };
+
         formatter = alejandra;
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -446,20 +446,6 @@
           '';
         };
 
-        # Lean dev shell for fuzzing: Rust toolchain + cargo-fuzz + gsutil (for
-        # the CI corpus round-trip) + tar. No Postgres/devEnv needed — the fuzz
-        # targets are pure. Used by the Concourse `fuzz` job (`nix develop .#fuzz`).
-        devShells.fuzz = mkShell {
-          packages = [
-            rustToolchain
-            pkgs.cargo-fuzz
-            pkgs.google-cloud-sdk
-            pkgs.gnutar
-            pkgs.coreutils
-            pkgs.git
-          ];
-        };
-
         formatter = alejandra;
       });
 }


### PR DESCRIPTION
## Summary

Fixes the fuzz-job **bootstrap gap** (build #1 was stuck "pending" on first run because the mandatory `get: fuzz-corpus` had no GCS version) and a **nix `gsutil` bug** found during end-to-end verification. The fuzz job is now self-bootstrapping — first run of any repo fuzzes from scratch with no manual seed.

Builds on #189 (merged). Tooling-only, no behavior change → `test:` (won't appear in the changelog).

## The two issues (found via `fly execute` against a real Concourse worker + GCS)

1. **Bootstrap gap:** #189 used a Concourse `gcs-resource` with a mandatory `get`, so an empty bucket on first run left the build pending — it required manually seeding the bucket before any first run.
2. **nix `gsutil` is broken:** a first attempt (single nix task doing GCS via `pkgs.google-cloud-sdk`) fuzzed fine but crashed at upload: `module 'lib' has no attribute 'EVP_MD_CTX_new'` — a nixpkgs `google-cloud-sdk` bundled-cryptography/OpenSSL mismatch. The `google/cloud-sdk` Docker image's gsutil works.

## The fix — self-bootstrapping 3-step job (no manual seed, no nix gsutil)

`ci/pipeline.yml` `fuzz` job is now three steps:
1. **`restore-corpus`** (`google/cloud-sdk`): `gsutil` downloads the latest `corpus-v*.tgz` from GCS, or starts empty on first run.
2. **`fuzz`** (nix): `ci/fuzz.sh` with `CORPUS_TARBALL_IN/OUT` (Rust toolchain only — no gsutil in nix). A crash exits non-zero before packaging.
3. **`store-corpus`** (`google/cloud-sdk`): `gsutil` uploads the grown corpus.

Dropped the Concourse `gcs-resource` (and its `resource_types` entry) entirely. Reverted the now-unneeded `devShells.fuzz` and the GCS branch in `ci/fuzz.sh` (the fuzz task uses the default dev shell again). Zenduty hooks unchanged.

## Verified end-to-end (`fly execute`, real worker + GCS)
- **Bootstrap**: empty GCS prefix → `"no existing corpus"` ✓
- **Store**: `gsutil cp` upload ✓ (the step nix gsutil couldn't do)
- **Reuse**: subsequent run → `"restoring ... corpus-v*.tgz"` ✓
- **Fuzz**: nix task fuzzes (no crash) ✓
- `ytt -f ci` renders cleanly

## Checklist
- [x] 3-step self-bootstrap verified via `fly execute` (bootstrap / store / reuse / fuzz)
- [x] `ytt` renders; nix gsutil removed from the path
- [ ] Full pipeline run after merge + repipe (warm caches + cachix → ~1h as configured)

## Follow-up (separate PR)
Extract a reusable `fuzz_job()` fragment + the shared `ci/fuzz.sh` into `galoy-concourse-shared`, so other repos adopt fuzzing with just their `fuzz/` crate + a one-line include.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only pipeline and comment changes; fuzz behavior and alerting are unchanged aside from fixing bootstrap and GCS upload.
> 
> **Overview**
> Replaces the mandatory Concourse **`fuzz-corpus` gcs-resource** with a **three-step** nightly fuzz job so the first run never blocks on an empty bucket and corpus I/O no longer uses nix’s broken **`gsutil`**.
> 
> **`restore-corpus`** and **`store-corpus`** run in the **`google/cloud-sdk`** image: download the latest **`corpus-v*.tgz`** (or bootstrap empty), then upload after a successful fuzz. The middle **`fuzz`** task stays on nix and only calls **`ci/fuzz.sh`** with **`CORPUS_TARBALL_IN/OUT`** paths. A crash still fails the job before packaging, so store is skipped.
> 
> **`ci/fuzz.sh`** header comments are updated to document that GCS is handled by the pipeline steps, not inside the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d44dc4689c01d8d1d3210c2c1d89014d28c746. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->