### PR TITLE
feat(hooks): add sync CommitHook::on_rollback (rollback-first-then-notify)

### DIFF
--- a/book/src/commit-hooks.md
+++ b/book/src/commit-hooks.md
@@ -27,6 +27,14 @@ pub trait CommitHook: Send + 'static + Sized {
         // Default: do nothing
     }
 
+    /// Called when a failed commit rolls the transaction back, after this
+    /// hook's `pre_commit` had already completed. Synchronous, infallible and
+    /// signal-only (mirrors `post_commit`) — the transaction is already gone,
+    /// so signal an out-of-band worker here rather than doing database work.
+    fn on_rollback(self) {
+        // Default: do nothing
+    }
+
     /// Try to merge `other` into `self`.
     /// Returns true if merged (other will be dropped).
     /// Returns false if not merged (both will execute separately).
@@ -43,6 +51,10 @@ pub trait CommitHook: Send + 'static + Sized {
 3. **Pre-commit**: All `pre_commit()` methods are called sequentially before the transaction commits
 4. **Commit**: The underlying transaction is committed
 5. **Post-commit**: All `post_commit()` methods are called sequentially after successful commit
+
+If the commit **fails** instead, `on_rollback()` is called — in place of `post_commit()` —
+on every hook whose `pre_commit()` had already completed. See
+[Rollback Notification](#rollback-notification) below.
 
 ```rust,ignore
 let mut op = DbOp::init(&pool).await?;
@@ -75,6 +87,59 @@ impl CommitHook for MyHook {
 ```
 
 `HookOperation` implements `AtomicOperation` so it can be passed to any function expecting that trait.
+
+## Rollback Notification
+
+When a commit **fails**, `on_rollback()` is called — in place of `post_commit()` — on every
+hook whose `pre_commit()` had already completed. It is the failure-path counterpart of
+`post_commit()`: **synchronous, infallible, and signal-only**.
+
+Two situations trigger it:
+
+1. **A later hook's `pre_commit()` errors.** The transaction is rolled back *first*, and only
+   then are the earlier hooks notified. This ordering is the point: a hook's compensating work
+   (for example, writing a placeholder row) runs after the failed transaction is gone, so it
+   never contends with that transaction's own locks.
+2. **The `COMMIT` itself errors.** The transaction is over server-side either way — it may have
+   landed despite the client error, or aborted — so `on_rollback()` runs directly. Any side
+   effect it triggers must therefore be idempotent against a possibly-landed commit.
+
+`on_rollback()` fires in registration order, the same as `post_commit()`. Because it is
+synchronous and the transaction is already gone, do **not** perform database work in it — hand
+the work to an out-of-band worker (for example, over a channel the hook holds).
+
+```rust,ignore
+impl CommitHook for EventPublisher {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        // ... stage work inside the transaction ...
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        // Commit succeeded: publish for real.
+        publish_events(self.events);
+    }
+
+    fn on_rollback(self) {
+        // Commit failed after pre_commit ran; the transaction is already gone.
+        // Signal an out-of-band worker rather than doing database work here:
+        // let _ = self.compensator_tx.send(self.events);
+    }
+}
+```
+
+### When `on_rollback()` does *not* fire
+
+- **On a successful commit** — `post_commit()` runs instead.
+- **For the hook whose own `pre_commit()` failed** — that hook is consumed by the failing call,
+  so it signals from its own error branch instead.
+- **For an operation dropped without `commit()`** — `pre_commit()` never ran, so there is
+  nothing to compensate.
+- **For a `commit()` future cancelled mid-flight** — there is no synchronous point at which to
+  run it; rely on an external backstop if you need coverage there.
 
 ## Hook Merging
 

--- a/src/operation/hooks.rs
+++ b/src/operation/hooks.rs
@@ -16,6 +16,12 @@
 //! 4. **Commit**: The underlying database transaction is committed
 //! 5. **Post-commit**: [`CommitHook::post_commit()`] executes after successful commit
 //!
+//! If the commit **fails** instead — either a later hook's `pre_commit` errors (the
+//! transaction is rolled back first) or the `COMMIT` itself errors — then
+//! [`CommitHook::on_rollback()`] is fired on every hook whose `pre_commit` had already
+//! completed, in registration order, in place of `post_commit`. It is a synchronous,
+//! infallible, signal-only callback (see its docs).
+//!
 //! # Hook Ordering
 //!
 //! Hooks execute in **registration order** — per hook, not per type:
@@ -198,6 +204,32 @@ pub trait CommitHook: Send + 'static + Sized {
         // Default: do nothing
     }
 
+    /// Called when the operation's commit has **failed** after this hook's
+    /// [`pre_commit()`](Self::pre_commit) had already completed successfully.
+    ///
+    /// Two situations trigger it:
+    /// 1. A *later* hook's `pre_commit` returned an error. The transaction has
+    ///    been **rolled back before this runs** — so any downstream side effect
+    ///    the signal triggers never contends with the failed transaction's own
+    ///    locks.
+    /// 2. The `COMMIT` itself returned an error. The transaction is over
+    ///    server-side either way (it may have landed despite the client error,
+    ///    or aborted), so downstream side effects must be idempotent against a
+    ///    possibly-landed commit.
+    ///
+    /// Signal-only, synchronous and infallible — mirrors
+    /// [`post_commit()`](Self::post_commit). Do **not** perform database work
+    /// here (the transaction is gone and there is no async context); hand work
+    /// to an out-of-band task via a channel send / flag set instead.
+    ///
+    /// Not called when `pre_commit` never ran (an operation dropped without
+    /// `commit()` produced no effects to compensate), nor for the hook whose
+    /// own `pre_commit` failed — that hook is consumed by the failing call and
+    /// must signal from its own error branch.
+    fn on_rollback(self) {
+        // Default: do nothing
+    }
+
     /// Try to merge another hook of the same type into this one.
     ///
     /// Returns `true` if merged (other will be dropped), `false` if not (both execute separately).
@@ -271,6 +303,8 @@ trait DynHook: Send {
 
     fn post_commit_boxed(self: Box<Self>);
 
+    fn on_rollback_boxed(self: Box<Self>);
+
     fn try_merge(&mut self, other: &mut dyn DynHook) -> bool;
 
     fn as_any(&self) -> &dyn Any;
@@ -291,6 +325,10 @@ impl<H: CommitHook> DynHook for H {
 
     fn post_commit_boxed(self: Box<Self>) {
         (*self).post_commit()
+    }
+
+    fn on_rollback_boxed(self: Box<Self>) {
+        (*self).on_rollback()
     }
 
     fn try_merge(&mut self, other: &mut dyn DynHook) -> bool {
@@ -347,17 +385,30 @@ impl CommitHooks {
             .and_then(|(_, hook)| hook.as_any().downcast_ref::<H>())
     }
 
+    /// Runs each hook's `pre_commit` in registration order.
+    ///
+    /// On failure the already-executed hooks travel back **with** the error (as
+    /// a [`PostCommitHooks`]) instead of being dropped, so the caller can fire
+    /// their [`CommitHook::on_rollback`] after rolling the transaction back.
+    /// Hooks after the failing one never ran their `pre_commit`, produced no
+    /// effects, and are simply dropped.
     pub(super) async fn execute_pre(
         self,
         op: &mut impl AtomicOperation,
-    ) -> Result<PostCommitHooks, sqlx::Error> {
+    ) -> Result<PostCommitHooks, (sqlx::Error, PostCommitHooks)> {
         let mut op = HookOperation::new(op);
         let mut post_hooks = Vec::with_capacity(self.hooks.len());
 
         for (_, hook) in self.hooks {
-            let (new_op, hook) = hook.pre_commit_boxed(op).await?;
-            op = new_op;
-            post_hooks.push(hook);
+            match hook.pre_commit_boxed(op).await {
+                Ok((new_op, hook)) => {
+                    op = new_op;
+                    post_hooks.push(hook);
+                }
+                Err(error) => {
+                    return Err((error, PostCommitHooks { hooks: post_hooks }));
+                }
+            }
         }
 
         Ok(PostCommitHooks { hooks: post_hooks })
@@ -378,6 +429,15 @@ impl PostCommitHooks {
     pub(super) fn execute(self) {
         for hook in self.hooks {
             hook.post_commit_boxed();
+        }
+    }
+
+    /// Fires [`CommitHook::on_rollback`] on each already-pre_committed hook in
+    /// registration order (same order as [`execute`](Self::execute)). Sync and
+    /// infallible, mirroring `execute`.
+    pub(super) fn execute_rollback(self) {
+        for hook in self.hooks {
+            hook.on_rollback_boxed();
         }
     }
 }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -107,12 +107,49 @@ impl<'c> DbOp<'c> {
     }
 
     /// Commits the inner transaction.
+    ///
+    /// On the failure paths the commit hooks' [`on_rollback`] runs **after** the
+    /// transaction is definitively gone, so hook-side compensation never
+    /// contends with the dying transaction's own locks:
+    ///
+    /// - A later hook's `pre_commit` fails → the transaction is rolled back
+    ///   first, *then* the earlier (already-pre_committed) hooks are notified.
+    /// - The `COMMIT` itself fails → the transaction is over server-side either
+    ///   way, so the hooks are notified directly (their side effects must be
+    ///   idempotent against a possibly-landed commit).
+    ///
+    /// [`on_rollback`]: hooks::CommitHook::on_rollback
     pub async fn commit(mut self) -> Result<(), sqlx::Error> {
         let commit_hooks = self.commit_hooks.take().expect("no hooks");
-        let post_hooks = commit_hooks.execute_pre(&mut self).await?;
-        self.tx.commit().await?;
-        post_hooks.execute();
-        Ok(())
+        match commit_hooks.execute_pre(&mut self).await {
+            Ok(post_hooks) => match self.tx.commit().await {
+                Ok(()) => {
+                    post_hooks.execute();
+                    Ok(())
+                }
+                Err(error) => {
+                    // The commit attempt is definitively over server-side (it
+                    // may have landed despite the error, or aborted) — there is
+                    // no rollback to issue. Fire `on_rollback` so hooks can
+                    // signal; their side effects must be idempotent against a
+                    // possibly-landed commit.
+                    post_hooks.execute_rollback();
+                    Err(error)
+                }
+            },
+            Err((error, executed)) => {
+                // A later hook's `pre_commit` failed. Roll back BEFORE
+                // signalling: the rollback is awaited so it has landed
+                // server-side before any `on_rollback` fires, so a hook's
+                // downstream compensation never contends with this dying
+                // transaction's own locks. A rollback error means the
+                // connection is being torn down (which aborts the transaction
+                // anyway) — swallow it and surface the original hook error.
+                let _ = self.tx.rollback().await;
+                executed.execute_rollback();
+                Err(error)
+            }
+        }
     }
 
     /// Gets a mutable handle to the inner transaction

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -4,6 +4,7 @@ use es_entity::operation::{
     AtomicOperation, DbOp, OpWithTime,
     hooks::{CommitHook, HookOperation, PreCommitRet},
 };
+use sqlx::Connection;
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
@@ -571,6 +572,334 @@ async fn supports_hooks_reflects_op_capability() -> anyhow::Result<()> {
     let tx = pool.begin().await?;
     assert!(!tx.supports_hooks());
     tx.rollback().await?;
+
+    Ok(())
+}
+
+// ===========================================================================
+// on_rollback tests
+// ===========================================================================
+
+/// Records lifecycle callbacks by label. Optionally fails its own `pre_commit`
+/// (to drive the rollback path for the *other*, earlier hooks).
+#[derive(Debug)]
+struct RollbackProbe {
+    label: &'static str,
+    fail_pre: bool,
+    pre_order: Arc<Mutex<Vec<&'static str>>>,
+    post_order: Arc<Mutex<Vec<&'static str>>>,
+    rollback_order: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl CommitHook for RollbackProbe {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.pre_order.lock().unwrap().push(self.label);
+        if self.fail_pre {
+            return Err(sqlx::Error::Protocol(format!(
+                "hook '{}' intentionally fails pre_commit",
+                self.label
+            )));
+        }
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.post_order.lock().unwrap().push(self.label);
+    }
+
+    fn on_rollback(self) {
+        self.rollback_order.lock().unwrap().push(self.label);
+    }
+}
+
+#[tokio::test]
+async fn on_rollback_fires_for_earlier_hooks_when_later_hook_fails() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre = Arc::new(Mutex::new(Vec::new()));
+    let post = Arc::new(Mutex::new(Vec::new()));
+    let rollback = Arc::new(Mutex::new(Vec::new()));
+
+    let mk = |label: &'static str, fail_pre: bool| RollbackProbe {
+        label,
+        fail_pre,
+        pre_order: pre.clone(),
+        post_order: post.clone(),
+        rollback_order: rollback.clone(),
+    };
+
+    op.add_commit_hook(mk("a", false)).unwrap();
+    op.add_commit_hook(mk("b", true)).unwrap();
+    // Registered after the failing hook: its pre_commit never runs.
+    op.add_commit_hook(mk("c", false)).unwrap();
+
+    let result = op.commit().await;
+    assert!(
+        result.is_err(),
+        "commit must fail because hook 'b' fails pre_commit"
+    );
+
+    // 'a' and 'b' ran pre_commit; 'c' never did (the loop stops at the failure).
+    assert_eq!(*pre.lock().unwrap(), vec!["a", "b"]);
+    // Only 'a' is notified: 'b' is consumed by its own failing pre_commit and
+    // signals from that branch; 'c' never ran.
+    assert_eq!(*rollback.lock().unwrap(), vec!["a"]);
+    // No post_commit on the failure path.
+    assert!(post.lock().unwrap().is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_rollback_not_fired_on_commit_success() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre = Arc::new(Mutex::new(Vec::new()));
+    let post = Arc::new(Mutex::new(Vec::new()));
+    let rollback = Arc::new(Mutex::new(Vec::new()));
+
+    op.add_commit_hook(RollbackProbe {
+        label: "a",
+        fail_pre: false,
+        pre_order: pre.clone(),
+        post_order: post.clone(),
+        rollback_order: rollback.clone(),
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    assert_eq!(*pre.lock().unwrap(), vec!["a"]);
+    assert_eq!(*post.lock().unwrap(), vec!["a"]);
+    assert!(
+        rollback.lock().unwrap().is_empty(),
+        "on_rollback must not fire on a successful commit"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_rollback_not_fired_when_op_dropped_without_commit() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+
+    let pre = Arc::new(Mutex::new(Vec::new()));
+    let post = Arc::new(Mutex::new(Vec::new()));
+    let rollback = Arc::new(Mutex::new(Vec::new()));
+
+    {
+        let mut op = DbOp::init(&pool).await?;
+        op.add_commit_hook(RollbackProbe {
+            label: "a",
+            fail_pre: false,
+            pre_order: pre.clone(),
+            post_order: post.clone(),
+            rollback_order: rollback.clone(),
+        })
+        .unwrap();
+        // `op` is dropped here without commit(): pre_commit never ran, so there
+        // is nothing to compensate.
+    }
+
+    assert!(
+        pre.lock().unwrap().is_empty(),
+        "pre_commit only runs at commit()"
+    );
+    assert!(post.lock().unwrap().is_empty());
+    assert!(
+        rollback.lock().unwrap().is_empty(),
+        "on_rollback must not fire for an op dropped without commit()"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn on_rollback_fires_in_registration_order() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre = Arc::new(Mutex::new(Vec::new()));
+    let post = Arc::new(Mutex::new(Vec::new()));
+    let rollback = Arc::new(Mutex::new(Vec::new()));
+
+    let mk = |label: &'static str, fail_pre: bool| RollbackProbe {
+        label,
+        fail_pre,
+        pre_order: pre.clone(),
+        post_order: post.clone(),
+        rollback_order: rollback.clone(),
+    };
+
+    op.add_commit_hook(mk("a1", false)).unwrap();
+    op.add_commit_hook(mk("a2", false)).unwrap();
+    op.add_commit_hook(mk("a3", false)).unwrap();
+    op.add_commit_hook(mk("boom", true)).unwrap();
+
+    assert!(op.commit().await.is_err());
+
+    // on_rollback mirrors post_commit's registration order.
+    assert_eq!(*rollback.lock().unwrap(), vec!["a1", "a2", "a3"]);
+    assert!(post.lock().unwrap().is_empty());
+
+    Ok(())
+}
+
+/// A hook that does NOT override `on_rollback`, exercising the defaulted no-op.
+#[derive(Debug)]
+struct DefaultOnRollbackHook {
+    pre_order: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl CommitHook for DefaultOnRollbackHook {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.pre_order.lock().unwrap().push("default");
+        PreCommitRet::ok(self, op)
+    }
+    // `on_rollback` intentionally not overridden — uses the default no-op.
+}
+
+#[tokio::test]
+async fn default_on_rollback_is_a_harmless_noop() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre = Arc::new(Mutex::new(Vec::new()));
+    let rollback = Arc::new(Mutex::new(Vec::new()));
+
+    // Earlier hook relies on the DEFAULT on_rollback (no override).
+    op.add_commit_hook(DefaultOnRollbackHook {
+        pre_order: pre.clone(),
+    })
+    .unwrap();
+    // Later hook fails, so the earlier hook's default no-op on_rollback fires.
+    op.add_commit_hook(RollbackProbe {
+        label: "boom",
+        fail_pre: true,
+        pre_order: pre.clone(),
+        post_order: Arc::new(Mutex::new(Vec::new())),
+        rollback_order: rollback.clone(),
+    })
+    .unwrap();
+
+    assert!(op.commit().await.is_err());
+
+    // The default hook ran pre_commit and its default no-op on_rollback did not
+    // panic; the failing hook is consumed by its own failure.
+    assert_eq!(*pre.lock().unwrap(), vec!["default", "boom"]);
+    assert!(rollback.lock().unwrap().is_empty());
+
+    Ok(())
+}
+
+/// Holds a transaction-scoped advisory lock in `pre_commit`; when its
+/// `on_rollback` fires it probes, from a *separate* connection, whether the lock
+/// is free — which it can only be if the operation's transaction has already
+/// been rolled back. Proves `on_rollback` runs strictly after the rollback.
+#[derive(Debug)]
+struct AdvisoryLockProbe {
+    lock_key: i64,
+    /// `Some(true)` iff the second connection acquired the lock inside on_rollback.
+    acquired_after_rollback: Arc<Mutex<Option<bool>>>,
+}
+
+impl CommitHook for AdvisoryLockProbe {
+    async fn pre_commit(
+        self,
+        mut op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        // Transaction-scoped: auto-released only when this operation's tx ends.
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(self.lock_key)
+            .execute(op.as_executor())
+            .await?;
+        PreCommitRet::ok(self, op)
+    }
+
+    fn on_rollback(self) {
+        // The callback is sync, so run the async probe on its own thread with a
+        // dedicated runtime and a fresh connection — fully independent of the
+        // test's runtime and connection pool. A plain SELECT of the row is not a
+        // valid probe (under READ COMMITTED an uncommitted row is invisible to
+        // other sessions whether the tx is open or rolled back); lock contention
+        // is what distinguishes the two.
+        let key = self.lock_key;
+        let acquired = std::thread::spawn(move || {
+            let pg_con = std::env::var("PG_CON").expect("PG_CON must be set");
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build probe runtime");
+            rt.block_on(async move {
+                let mut conn = sqlx::PgConnection::connect(&pg_con)
+                    .await
+                    .expect("probe connection");
+                let got: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
+                    .bind(key)
+                    .fetch_one(&mut conn)
+                    .await
+                    .expect("advisory lock probe");
+                // `conn` drops at scope end, releasing any session lock acquired.
+                got
+            })
+        })
+        .join()
+        .expect("probe thread panicked");
+
+        *self.acquired_after_rollback.lock().unwrap() = Some(acquired);
+    }
+}
+
+#[tokio::test]
+async fn on_rollback_runs_after_transaction_is_rolled_back() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    // A distinctive key unlikely to collide with concurrent tests.
+    let lock_key: i64 = 728_192_374_651;
+    let acquired = Arc::new(Mutex::new(None));
+
+    op.add_commit_hook(AdvisoryLockProbe {
+        lock_key,
+        acquired_after_rollback: acquired.clone(),
+    })
+    .unwrap();
+
+    // A later hook fails, forcing the rollback-then-notify path for the probe.
+    let sink = Arc::new(Mutex::new(Vec::new()));
+    op.add_commit_hook(RollbackProbe {
+        label: "boom",
+        fail_pre: true,
+        pre_order: sink.clone(),
+        post_order: sink.clone(),
+        rollback_order: sink.clone(),
+    })
+    .unwrap();
+
+    let result = op.commit().await;
+    assert!(
+        result.is_err(),
+        "commit must fail due to the later failing hook"
+    );
+
+    let acquired = acquired
+        .lock()
+        .unwrap()
+        .expect("on_rollback should have run and probed the advisory lock");
+    assert!(
+        acquired,
+        "the second connection must acquire the advisory lock inside on_rollback — \
+         proving the operation's transaction had already rolled back (releasing the lock) \
+         before on_rollback fired"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## What

Adds a **default-implemented, synchronous, infallible** `on_rollback` lifecycle callback to `CommitHook`, mirroring `post_commit`. It fires on every hook whose `pre_commit` had already completed when a commit **fails** — either because a *later* hook's `pre_commit` errored, or because the `COMMIT` itself errored.

**Semver: minor** — the method is defaulted (no-op), so no existing implementor breaks. All in-crate `CommitHook` implementors are in `tests/hooks.rs`; there are zero production implementors.

## Why — the ordering invariant (rollback-first-then-notify)

On the pre-commit-failure path, `DbOp::commit` now issues `tx.rollback().await` **first** and only then fires the hooks' `on_rollback`. This lets a hook's downstream compensation run without ever contending with the *dying transaction's own* speculative-insertion locks.

That ordering is the reason obix's gap-fill Tier-1 needs an **explicit** hook rather than `Drop`: `Drop` fires while the failed transaction is still open, so a compensating `INSERT` is *guaranteed* to park on the aborting tx's locks. Only es-entity owns the transaction, so only es-entity can sequence "roll back first, then notify". See the investigation in the research doc's Amendment.

On the `COMMIT`-failure path the transaction is over server-side either way (landed despite the client error, or aborted), so `on_rollback` is fired directly — side effects must be idempotent against a possibly-landed commit (obix's `ON CONFLICT DO NOTHING` is).

## Changes

- `CommitHook::on_rollback(self)` — defaulted no-op. **Signal-only**: do DB work out-of-band (channel send / flag set), never in the callback.
- internal `DynHook::on_rollback_boxed` (mirrors `post_commit_boxed`).
- `CommitHooks::execute_pre` now returns the already-executed hooks **alongside** the error (`Result<PostCommitHooks, (sqlx::Error, PostCommitHooks)>`) instead of `?`-dropping them, so they can be notified after rollback.
- `PostCommitHooks::execute_rollback` fires `on_rollback` in registration order.

### Explicit contract
- The **failing** hook is consumed by its own `pre_commit` and signals from that error branch — making `pre_commit`'s `Err` carry `Self` would be a breaking trait change (**rejected**).
- An op **dropped without `commit()`** never ran `pre_commit`, so nothing is signalled — nothing to compensate.
- A **cancelled `commit()` future** cannot fire it (no async rollback from a sync drop); such cases fall to obix's proof-gated backstop — out of es-entity scope, documented as the boundary.

## Tests (`tests/hooks.rs`, live-PG)

- default no-op runs harmlessly;
- signal delivery + exactly-once on later-hook-failure (failing hook and never-ran hook do **not** fire);
- not fired on commit success (`post_commit` runs instead);
- not fired on drop-without-commit;
- registration-order firing across multiple succeeded hooks;
- **fire-order proof** (load-bearing): an advisory lock taken in `pre_commit` is observed *free* from a second connection inside `on_rollback` — proving the transaction had already rolled back before the callback ran. (A plain `SELECT` can't distinguish open-vs-rolled-back under READ COMMITTED; lock contention is the valid observable.)

Local: `282/282` workspace tests pass; flake-matching clippy (`--all-features -D warnings`) clean; `cargo fmt --check` clean.

## Source of truth
- drua **es-entity-dev/handoff-commit-hook-on-rollback.md** (implementation-ready handoff)
- drua **obix-dev/research-gap-fill-reactive-alternatives.md** (Amendment section)

## Downstream (out of scope here)
After this lands + releases (minor), **obix PR #116** bumps the es-entity dep and swaps its Tier-1 mechanism `Drop` → `on_rollback` (signal to the `AbandonedCompensator`), plus adds explicit own-failure-branch reporting. The `Drop` variant never ships in a release. That swap is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the commit failure path in core transaction hook infrastructure; backward compatible via a default no-op, but incorrect ordering or notification could break compensating side effects in consumers.
> 
> **Overview**
> Adds a default **`CommitHook::on_rollback`** callback — synchronous, infallible, signal-only — as the failure-path counterpart to **`post_commit`**. It runs for every hook whose **`pre_commit`** already succeeded when **`commit()`** fails.
> 
> **`DbOp::commit`** now sequences failure handling explicitly: if a later hook’s **`pre_commit`** errors, the transaction is **rolled back first**, then earlier hooks get **`on_rollback`** (so compensating work does not fight the dying transaction’s locks). If **`COMMIT`** itself errors, **`on_rollback`** runs without a client rollback; side effects must be idempotent.
> 
> **`execute_pre`** no longer drops already-run hooks on error — it returns them with the error so **`PostCommitHooks::execute_rollback`** can notify in registration order. Docs and live-PG tests cover success/drop paths, ordering, default no-op, and advisory-lock proof that rollback lands before **`on_rollback`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a9a076129b58db89b8b30ebe5cb3ea00df580e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->