### PR TITLE
chore(ci): re-vendor for fuzz_job path fix (#21)

### DIFF
--- a/ci/vendir.lock.yml
+++ b/ci/vendir.lock.yml
@@ -8,8 +8,8 @@ directories:
   path: ../.github/workflows/vendor
 - contents:
   - git:
-      commitTitle: 'Merge pull request #20 from GaloyMoney/feat/fuzz-job...'
-      sha: 9184832cfd4d1cf5ce4ac750dbb73c7090e27576
+      commitTitle: 'Merge pull request #21 from GaloyMoney/fix/fuzz-script-path...'
+      sha: 4c9071ebc13e88282dc8c8924a52bc1c9d8b05cc
     path: .
   path: vendor
 kind: LockConfig

--- a/ci/vendir.yml
+++ b/ci/vendir.yml
@@ -21,7 +21,7 @@ directories:
   - path: .
     git:
       url: https://github.com/GaloyMoney/galoy-concourse-shared.git
-      ref: 9184832
+      ref: 4c9071e
     includePaths:
     - shared/ci/**/*
     excludePaths:

--- a/ci/vendor/pipeline-fragments.lib.yml
+++ b/ci/vendor/pipeline-fragments.lib.yml
@@ -567,7 +567,7 @@ plan:
           export CARGO_TARGET_DIR=$PWD/../cargo-target-dir
           export CORPUS_TARBALL_IN="../corpus/*.tgz"
           export CORPUS_TARBALL_OUT="../corpus-out/corpus-v$(date -u +%Y%m%d-%H%M%S).tgz"
-          bash pipeline-tasks/ci/vendor/tasks/fuzz.sh
+          bash ci/vendor/tasks/fuzz.sh
         '
     params:
       CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token


### PR DESCRIPTION
Bumps the ci/vendor vendir ref to 4c9071e to pick up galoy-concourse-shared#21, which fixes the fuzz_job script path (`bash ci/vendor/tasks/fuzz.sh`, repo-relative). Verified end-to-end: the fuzz job reaches the shared fuzz.sh and fuzzes at the configured 24h. (Schedule remains pinned Saturday 06:00 UTC.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI vendoring only; changes how the scheduled fuzz task resolves its script path with no auth, data, or runtime application logic impact.
> 
> **Overview**
> Re-vendors **galoy-concourse-shared** at `4c9071e` (via `ci/vendir.yml` and `ci/vendir.lock.yml`) to include the upstream fix for the Concourse fuzz job script path.
> 
> The vendored `pipeline-fragments.lib.yml` now invokes **`bash ci/vendor/tasks/fuzz.sh`** instead of the incorrect `pipeline-tasks/ci/vendor/tasks/fuzz.sh`, so the job can find the shared fuzz script after `cd repo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0905459508a0c2997f65b476c495f4bcb1fe4a38. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->