### PR TITLE
fix: run post-persist hooks when forgetting entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,9 +254,14 @@ pub enum CustomerEvent {
     },
 }
 
-// Repos marked `forgettable` generate a `forget` fn
-customers.forget(&mut customer).await?;
+// Repos marked `forgettable` generate a `forget` fn — it consumes the
+// entity and returns the rebuilt (forgotten) one, running any configured
+// `post_persist_hook` for staged events it persists.
+let customer = customers.forget(customer).await?;
 assert!(customer.name.is_forgotten());
+
+// And a storage-level check that the data is physically absent
+customers.verify_forgotten(customer.id).await?;
 ```
 
 See the [Forgettable Data](https://galoymoney.github.io/es-entity/forgettable.html) chapter in the book for details.

--- a/book/src/forgettable.md
+++ b/book/src/forgettable.md
@@ -197,22 +197,75 @@ pub struct Customers {
 }
 ```
 
-This generates a `forget` method on the repository that:
-1. Deletes all forgettable payloads for the entity from the database
-2. Sets any [forgettable index columns](#forgettable-index-columns) to `NULL`
-3. Rebuilds the entity in-place with forgotten fields set to `Forgettable::forgotten()`
+This generates a `forget` method (and `forget_in_op` for use inside an
+existing transaction) on the repository that:
+1. Persists any staged (unpersisted) events — consuming sequence numbers,
+   which is the concurrency fence against stale writers
+2. Deletes all forgettable payloads for the entity from the database
+3. Sets any [forgettable index columns](#forgettable-index-columns) to `NULL`
+4. Rebuilds and returns the entity with forgotten fields set to
+   `Forgettable::forgotten()`
 
 ```rust,ignore
 // Load the entity
-let mut customer = customers.find_by_id(id).await?;
+let customer = customers.find_by_id(id).await?;
 assert_eq!(customer.name.value().map(|v| v.clone()), Some("Alice".to_string()));
 
-// Forget personal data — updates `customer` in place
-customers.forget(&mut customer).await?;
+// Forget personal data — consumes the entity and returns the rebuilt,
+// forgotten one
+let customer = customers.forget(customer).await?;
 
 // The entity immediately reflects the forgotten state
 assert!(customer.name.is_forgotten());
 ```
+
+## Post-Persist Hooks and Forget
+
+If the repository configures a
+[`post_persist_hook`](repo-hooks.md) (e.g. an outbox
+publisher), `forget` runs it through the same channel as `create` and
+`update` — no separate publish path is needed for erasure events. The hook
+runs:
+
+- **exactly once**, for the staged events the forget persisted (by
+  convention, the domain erasure event — e.g. an empty `Forgot {}`);
+- **after** the payload delete and entity rebuild, so it observes the
+  forgotten representation — a raw payload being erased can never reach a
+  publisher;
+- **inside the erasure transaction**, so outbox-style publishers never
+  publish uncommitted data, and a failing hook rolls the entire erasure
+  back (the forget is retryable).
+
+If no staged events are persisted the hook is not invoked, matching
+`update`'s no-op semantics. A hook failure surfaces as
+`{Entity}ForgetError::PostPersistHookError`.
+
+## Verifying Erasure at the Storage Level
+
+Auditing an erasure by reloading the entity only proves the *hydrated* state
+reads back as forgotten. The generated `verify_forgotten` (and
+`verify_forgotten_in_op`) checks the **database** directly, so callers can
+trust physical absence without hand-maintaining a list of PII fields:
+
+1. no rows remain in the `_forgettable_payloads` table,
+2. all `Forgettable<..>` index columns are `NULL`, and
+3. no forgettable field holds a non-null value in the durable event JSON
+   (defense-in-depth: the framework always writes `null` there, so a hit
+   indicates out-of-band writes).
+
+```rust,ignore
+let customer = customers.forget(customer).await?;
+
+// Fails with `CustomerForgetError::NotForgotten(remnants)` if anything
+// forgettable is still physically present.
+customers.verify_forgotten(customer.id).await?;
+```
+
+The `NotForgotten` error carries a
+[`ForgettableRemnants`](https://docs.rs/es-entity) report describing exactly
+what survived (`payload_rows`, `live_index_columns`, `event_fields`),
+accessible via `err.not_forgotten_remnants()`. An id that was never persisted
+verifies trivially.
 
 ## Custom Queries with `es_query!`
 

--- a/book/src/repo-hooks.md
+++ b/book/src/repo-hooks.md
@@ -45,9 +45,13 @@ impl Users {
 }
 ```
 
+### Which operations run it
+
+The hook runs on every generated operation that persists events: `create`, `create_all`, `update`, `update_all`, soft `delete`, and — for [forgettable](forgettable.md) repos — `forget`. On `forget` it runs after the payload delete and entity rebuild, so it observes the forgotten representation; when an operation persists no events the hook is not invoked.
+
 ### Error propagation
 
-When the hook returns an error it is wrapped in the `PostPersistHookError` variant of `CreateError` or `ModifyError`:
+When the hook returns an error it is wrapped in the `PostPersistHookError` variant of `CreateError`, `ModifyError`, or `ForgetError`:
 
 ```rust,ignore
 match users.create(new_user).await {

--- a/es-entity-macros/src/event.rs
+++ b/es-entity-macros/src/event.rs
@@ -93,10 +93,28 @@ pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream
         })
         .collect();
 
+    // (serde tag value, forgettable field JSON key) pairs across all variants —
+    // consumed by the repo's generated `verify_forgotten` storage check.
+    let forgettable_json_fields: Vec<_> = forgettable_info
+        .variants
+        .iter()
+        .flat_map(|(_, tag_value, field_idents)| {
+            field_idents.iter().map(move |field_id| {
+                let field_name = field_id.to_string();
+                quote! { (#tag_value, #field_name) }
+            })
+        })
+        .collect();
+
     tokens.append_all(quote! {
         impl #ident {
             #[doc(hidden)]
             pub const HAS_FORGETTABLE_FIELDS: bool = #has_forgettable;
+
+            #[doc(hidden)]
+            pub const FORGETTABLE_JSON_FIELDS: &'static [(&'static str, &'static str)] = &[
+                #(#forgettable_json_fields),*
+            ];
 
             #[doc(hidden)]
             pub fn extract_forgettable_payloads(&self) -> Option<es_entity::prelude::serde_json::Value> {

--- a/es-entity-macros/src/repo/error_types.rs
+++ b/es-entity-macros/src/repo/error_types.rs
@@ -324,12 +324,29 @@ impl<'a> ErrorTypes<'a> {
         let forget_error = &self.forget_error;
         let entity_name = self.entity.to_string();
 
+        let (pp_variant, pp_display_arm, pp_source_arm) = if let Some(config) =
+            &self.post_persist_hook
+        {
+            let error_ty = &config.error;
+            (
+                quote! { PostPersistHookError(#error_ty), },
+                quote! { Self::PostPersistHookError(e) => write!(f, "{}ForgetError - PostPersistHookError: {}", #entity_name, e), },
+                quote! { Self::PostPersistHookError(e) => Some(e), },
+            )
+        } else {
+            (quote! {}, quote! {}, quote! {})
+        };
+
         quote! {
             #[derive(Debug)]
             pub enum #forget_error {
                 Sqlx(sqlx::Error),
                 HydrationError(es_entity::EntityHydrationError),
                 ConcurrentModification,
+                /// `verify_forgotten` found forgettable data still present at
+                /// the storage level.
+                NotForgotten(es_entity::ForgettableRemnants),
+                #pp_variant
             }
 
             impl std::fmt::Display for #forget_error {
@@ -338,6 +355,8 @@ impl<'a> ErrorTypes<'a> {
                         Self::Sqlx(e) => write!(f, "{}ForgetError - Sqlx: {}", #entity_name, e),
                         Self::HydrationError(e) => write!(f, "{}ForgetError - HydrationError: {}", #entity_name, e),
                         Self::ConcurrentModification => write!(f, "{}ForgetError - ConcurrentModification: another writer persisted events concurrently; reload the entity and re-forget", #entity_name),
+                        Self::NotForgotten(remnants) => write!(f, "{}ForgetError - NotForgotten: {}", #entity_name, remnants),
+                        #pp_display_arm
                     }
                 }
             }
@@ -348,6 +367,8 @@ impl<'a> ErrorTypes<'a> {
                         Self::Sqlx(e) => Some(e),
                         Self::HydrationError(e) => Some(e),
                         Self::ConcurrentModification => None,
+                        Self::NotForgotten(_) => None,
+                        #pp_source_arm
                     }
                 }
             }
@@ -367,6 +388,15 @@ impl<'a> ErrorTypes<'a> {
             impl #forget_error {
                 pub fn was_concurrent_modification(&self) -> bool {
                     matches!(self, Self::ConcurrentModification)
+                }
+
+                /// Returns the remnants report when `verify_forgotten` found
+                /// forgettable data still present at the storage level.
+                pub fn not_forgotten_remnants(&self) -> Option<&es_entity::ForgettableRemnants> {
+                    match self {
+                        Self::NotForgotten(remnants) => Some(remnants),
+                        _ => None,
+                    }
                 }
             }
         }

--- a/es-entity-macros/src/repo/forget_fn.rs
+++ b/es-entity-macros/src/repo/forget_fn.rs
@@ -10,8 +10,10 @@ pub struct ForgetFn<'a> {
     event: &'a syn::Ident,
     error: syn::Ident,
     table_name: &'a str,
+    events_table_name: &'a str,
     forgettable_table_name: &'a str,
     forgettable_columns: Vec<&'a syn::Ident>,
+    post_persist_error: Option<&'a syn::Type>,
 }
 
 impl<'a> ForgetFn<'a> {
@@ -22,10 +24,12 @@ impl<'a> ForgetFn<'a> {
             event: opts.event(),
             error: opts.forget_error(),
             table_name: opts.table_name(),
+            events_table_name: opts.events_table_name(),
             forgettable_table_name: opts
                 .forgettable_table_name()
                 .expect("forgettable must be enabled"),
             forgettable_columns: opts.columns.forgettable_column_names(),
+            post_persist_error: opts.post_persist_hook.as_ref().map(|h| &h.error),
         }
     }
 }
@@ -67,6 +71,45 @@ impl ToTokens for ForgetFn<'_> {
             }
         };
 
+        // Persist staged events, capturing how many were persisted so the
+        // post-persist hook can be handed exactly those events (in their
+        // forgotten, rebuilt form) after the payload delete.
+        let (persist_staged, post_persist_check) = if self.post_persist_error.is_some() {
+            (
+                quote! {
+                    let n_events = if entity.events().any_new() {
+                        Self::extract_concurrent_modification(
+                            self.persist_events(op, entity.events_mut()).await,
+                            #error::ConcurrentModification,
+                        )?
+                    } else {
+                        0
+                    };
+                },
+                quote! {
+                    if n_events > 0 {
+                        self.execute_post_persist_hook(
+                            op,
+                            &entity,
+                            entity.events().last_persisted(n_events)
+                        ).await.map_err(#error::PostPersistHookError)?;
+                    }
+                },
+            )
+        } else {
+            (
+                quote! {
+                    if entity.events().any_new() {
+                        Self::extract_concurrent_modification(
+                            self.persist_events(op, entity.events_mut()).await,
+                            #error::ConcurrentModification,
+                        )?;
+                    }
+                },
+                quote! {},
+            )
+        };
+
         tokens.append_all(quote! {
             /// Permanently forgets the entity's forgettable data. Consumes the
             /// entity and returns the rebuilt (forgotten) entity. On any error
@@ -105,6 +148,14 @@ impl ToTokens for ForgetFn<'_> {
             /// `forget` itself can fail with `ConcurrentModification` if
             /// another writer got there first — reload and re-forget (repeat
             /// forgets are legitimate).
+            ///
+            /// If the repository configures a `post_persist_hook`, it runs for
+            /// the staged events persisted by this call — exactly once, after
+            /// the payload delete and entity rebuild, so the hook observes the
+            /// forgotten representation (never the raw payloads being erased)
+            /// while still running inside the erasure transaction. When no
+            /// staged events are persisted the hook is not invoked, matching
+            /// `update`'s no-op semantics.
             pub async fn forget_in_op<OP>(
                 &self,
                 op: &mut OP,
@@ -113,12 +164,7 @@ impl ToTokens for ForgetFn<'_> {
             where
                 OP: es_entity::AtomicOperation
             {
-                if entity.events().any_new() {
-                    Self::extract_concurrent_modification(
-                        self.persist_events(op, entity.events_mut()).await,
-                        #error::ConcurrentModification,
-                    )?;
-                }
+                #persist_staged
                 {
                     let id = &entity.id;
                     sqlx::query!(
@@ -132,7 +178,149 @@ impl ToTokens for ForgetFn<'_> {
                 let events = entity.events_mut().forget_and_take(
                     #event_type::forget_forgettable_payloads
                 );
-                Ok(es_entity::TryFromEvents::try_from_events(events)?)
+                let entity: #entity_type = es_entity::TryFromEvents::try_from_events(events)?;
+                #post_persist_check
+                Ok(entity)
+            }
+        });
+
+        self.verify_forgotten_tokens(tokens);
+    }
+}
+
+impl ForgetFn<'_> {
+    /// Generates `verify_forgotten` / `verify_forgotten_in_op`: a storage-level
+    /// check that all configured forgettable data for an entity is physically
+    /// absent — payload rows deleted, `Forgettable<..>` index columns NULL, and
+    /// (defense-in-depth) no forgettable field holding a non-null value in the
+    /// durable event JSON.
+    fn verify_forgotten_tokens(&self, tokens: &mut TokenStream) {
+        let id_type = &self.id;
+        let event_type = self.event;
+        let error = &self.error;
+
+        let payload_count_query = format!(
+            "SELECT COUNT(*) AS \"count!\" FROM {} WHERE entity_id = $1",
+            self.forgettable_table_name
+        );
+
+        let event_fields_query = format!(
+            "SELECT DISTINCT e.event_type AS \"event_type!\", f.field AS \"field!\" \
+             FROM {} e \
+             JOIN (SELECT UNNEST($2::text[]) AS event_type, UNNEST($3::text[]) AS field) f \
+             ON e.event_type = f.event_type \
+             WHERE e.id = $1 \
+             AND e.event -> f.field IS NOT NULL \
+             AND e.event -> f.field != 'null'::jsonb",
+            self.events_table_name
+        );
+
+        let check_columns = if self.forgettable_columns.is_empty() {
+            quote! {}
+        } else {
+            let selects = self
+                .forgettable_columns
+                .iter()
+                .map(|c| format!("{c} IS NOT NULL AS \"{c}!\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let columns_query =
+                format!("SELECT {} FROM {} WHERE id = $1", selects, self.table_name);
+            let column_checks = self.forgettable_columns.iter().map(|c| {
+                let name = c.to_string();
+                quote! {
+                    if row.#c {
+                        remnants.live_index_columns.push(#name);
+                    }
+                }
+            });
+            quote! {
+                if let Some(row) = sqlx::query!(
+                    #columns_query,
+                    id as &#id_type
+                )
+                .fetch_optional(op.as_executor())
+                .await?
+                {
+                    #(#column_checks)*
+                }
+            }
+        };
+
+        tokens.append_all(quote! {
+            /// Verifies at the **storage level** that all configured
+            /// forgettable data for `id` is physically absent — i.e. that
+            /// `forget()` has fully taken effect. Unlike inspecting a hydrated
+            /// entity (which merely reads back as forgotten), this checks the
+            /// database directly:
+            ///
+            /// 1. no rows remain in the forgettable payloads table,
+            /// 2. all `Forgettable<..>` index columns are NULL, and
+            /// 3. no forgettable field holds a non-null value in the durable
+            ///    event JSON (defense-in-depth: the framework always writes
+            ///    `null` there, so a hit indicates out-of-band writes).
+            ///
+            /// Returns `Err(NotForgotten(remnants))` describing anything still
+            /// present. An entity that was never persisted verifies trivially.
+            pub async fn verify_forgotten(
+                &self,
+                id: impl std::borrow::Borrow<#id_type>
+            ) -> Result<(), #error> {
+                let mut op = self.begin_op().await?;
+                self.verify_forgotten_in_op(&mut op, id).await
+            }
+
+            /// Same as [`Self::verify_forgotten`] but runs on an existing
+            /// operation, so the check can share the erasure (or a follow-up)
+            /// transaction.
+            pub async fn verify_forgotten_in_op<OP>(
+                &self,
+                op: &mut OP,
+                id: impl std::borrow::Borrow<#id_type>
+            ) -> Result<(), #error>
+            where
+                OP: es_entity::AtomicOperation
+            {
+                let id = id.borrow();
+                let mut remnants = es_entity::ForgettableRemnants::default();
+
+                let payload_rows = sqlx::query!(
+                    #payload_count_query,
+                    id as &#id_type
+                )
+                .fetch_one(op.as_executor())
+                .await?
+                .count;
+                remnants.payload_rows = payload_rows as usize;
+
+                #check_columns
+
+                let event_types: Vec<String> = #event_type::FORGETTABLE_JSON_FIELDS
+                    .iter()
+                    .map(|(t, _)| t.to_string())
+                    .collect();
+                let fields: Vec<String> = #event_type::FORGETTABLE_JSON_FIELDS
+                    .iter()
+                    .map(|(_, f)| f.to_string())
+                    .collect();
+                let rows = sqlx::query!(
+                    #event_fields_query,
+                    id as &#id_type,
+                    &event_types[..],
+                    &fields[..]
+                )
+                .fetch_all(op.as_executor())
+                .await?;
+                remnants.event_fields = rows
+                    .into_iter()
+                    .map(|r| (r.event_type, r.field))
+                    .collect();
+
+                if remnants.is_empty() {
+                    Ok(())
+                } else {
+                    Err(#error::NotForgotten(remnants))
+                }
             }
         });
     }
@@ -157,8 +345,10 @@ mod tests {
             event: &event,
             error,
             table_name: "entities",
+            events_table_name: "entity_events",
             forgettable_table_name: "entities_forgettable_payloads",
             forgettable_columns: Vec::new(),
+            post_persist_error: None,
         };
 
         let mut tokens = TokenStream::new();
@@ -170,7 +360,10 @@ mod tests {
         assert!(output.contains("entity : Entity) -> Result < Entity , EntityForgetError >"));
         assert!(!output.contains("& mut Entity"));
         assert!(!output.contains("* entity ="));
-        assert!(output.contains("Ok (es_entity :: TryFromEvents :: try_from_events"));
+        assert!(output.contains("es_entity :: TryFromEvents :: try_from_events"));
+        assert!(output.contains("Ok (entity)"));
+        // No hook configured — no hook invocation is generated.
+        assert!(!output.contains("execute_post_persist_hook"));
         // Staged events are persisted (fencing + no laundering), BEFORE the
         // payload delete — assert the persist appears before the DELETE.
         let persist_at = output
@@ -201,8 +394,10 @@ mod tests {
             event: &event,
             error,
             table_name: "entities",
+            events_table_name: "entity_events",
             forgettable_table_name: "entities_forgettable_payloads",
             forgettable_columns: vec![&email],
+            post_persist_error: None,
         };
 
         let mut tokens = TokenStream::new();
@@ -210,5 +405,47 @@ mod tests {
 
         let output = tokens.to_string();
         assert!(output.contains("UPDATE entities SET email = NULL WHERE id = $1"));
+    }
+
+    #[test]
+    fn forget_fn_runs_post_persist_hook() {
+        let id = Ident::new("EntityId", Span::call_site());
+        let entity = Ident::new("Entity", Span::call_site());
+        let event = Ident::new("EntityEvent", Span::call_site());
+        let error = Ident::new("EntityForgetError", Span::call_site());
+        let hook_error: syn::Type = syn::parse_str("MyHookError").unwrap();
+
+        let forget_fn = ForgetFn {
+            id: &id,
+            entity: &entity,
+            event: &event,
+            error,
+            table_name: "entities",
+            events_table_name: "entity_events",
+            forgettable_table_name: "entities_forgettable_payloads",
+            forgettable_columns: Vec::new(),
+            post_persist_error: Some(&hook_error),
+        };
+
+        let mut tokens = TokenStream::new();
+        forget_fn.to_tokens(&mut tokens);
+
+        let output = tokens.to_string();
+        // The hook runs once, with the just-persisted staged events...
+        assert!(output.contains("if n_events > 0"));
+        assert!(
+            output.contains(
+                "self . execute_post_persist_hook (op , & entity , entity . events () . last_persisted (n_events))"
+            ),
+            "hook must receive exactly the just-persisted events: {output}"
+        );
+        assert!(output.contains("EntityForgetError :: PostPersistHookError"));
+        // ...AFTER the rebuild (hook observes the forgotten representation):
+        // the hook invocation must come after try_from_events.
+        let rebuild_at = output.find("try_from_events").expect("rebuild present");
+        let hook_at = output
+            .find("execute_post_persist_hook")
+            .expect("hook invocation present");
+        assert!(rebuild_at < hook_at, "hook must run on the rebuilt entity");
     }
 }

--- a/src/forgettable.rs
+++ b/src/forgettable.rs
@@ -225,6 +225,50 @@ pub fn inject_forgettable_payload(event_json: &mut serde_json::Value, payload: s
     }
 }
 
+/// Storage-level remnants of forgettable data found by a repository's
+/// generated `verify_forgotten` check.
+///
+/// `verify_forgotten` inspects the database directly — not hydrated entity
+/// state — and reports anything that should have been erased by `forget()`:
+///
+/// - `payload_rows`: rows still present in the `_forgettable_payloads` table
+/// - `live_index_columns`: `Forgettable<..>` index columns that are non-NULL
+///   in the lookup table
+/// - `event_fields`: `(event_type, field)` pairs of forgettable fields whose
+///   durable event JSON holds a non-null value (defense-in-depth — the
+///   framework always writes `null` there, so any hit indicates data written
+///   outside the framework's serialization path)
+///
+/// An empty report means all configured forgettable data is physically absent
+/// at the storage level.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ForgettableRemnants {
+    /// Number of rows remaining in the forgettable payloads table.
+    pub payload_rows: usize,
+    /// Names of `Forgettable<..>` index columns that are still non-NULL.
+    pub live_index_columns: Vec<&'static str>,
+    /// `(event_type, field)` pairs with non-null forgettable values in the
+    /// durable event JSON.
+    pub event_fields: Vec<(String, String)>,
+}
+
+impl ForgettableRemnants {
+    /// True when no forgettable data remains at the storage level.
+    pub fn is_empty(&self) -> bool {
+        self.payload_rows == 0 && self.live_index_columns.is_empty() && self.event_fields.is_empty()
+    }
+}
+
+impl fmt::Display for ForgettableRemnants {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "forgettable data still present at storage level: {} payload row(s), non-NULL index columns {:?}, non-null event fields {:?}",
+            self.payload_rows, self.live_index_columns, self.event_fields
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub use es_entity_macros::retry_on_concurrent_modification;
 #[doc(inline)]
 pub use events::*;
 #[doc(inline)]
-pub use forgettable::{Forgettable, ForgettableRef};
+pub use forgettable::{Forgettable, ForgettableRef, ForgettableRemnants};
 #[doc(inline)]
 pub use idempotent::*;
 #[doc(inline)]

--- a/tests/forgettable.rs
+++ b/tests/forgettable.rs
@@ -286,6 +286,96 @@ async fn forget_persists_staged_events_without_laundering() -> anyhow::Result<()
 }
 
 #[tokio::test]
+async fn verify_forgotten_reports_remnants_before_and_passes_after_forget() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = Customers::new(pool);
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Verify Vera")
+        .email("verify@example.com")
+        .build()
+        .unwrap();
+    let mut customer = customers.create(new_customer).await?;
+    let _ = customer.update_name("Vera Verified");
+    customers.update(&mut customer).await?;
+
+    // Live entity: the storage-level check reports the payload rows.
+    let err = customers
+        .verify_forgotten(id)
+        .await
+        .expect_err("live entity must not verify as forgotten");
+    let remnants = err
+        .not_forgotten_remnants()
+        .expect("expected NotForgotten error");
+    assert_eq!(remnants.payload_rows, 2);
+    assert!(remnants.live_index_columns.is_empty());
+    assert!(remnants.event_fields.is_empty());
+
+    // After forget: physically absent.
+    let mut customer = customers.find_by_id(id).await?;
+    customer.record_erasure();
+    customers.forget(customer).await?;
+    customers.verify_forgotten(id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn verify_forgotten_detects_out_of_band_event_json_writes() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = Customers::new(pool.clone());
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Tampered Tim")
+        .email("tampered@example.com")
+        .build()
+        .unwrap();
+    let mut customer = customers.create(new_customer).await?;
+    customer.record_erasure();
+    customers.forget(customer).await?;
+    customers.verify_forgotten(id).await?;
+
+    // Simulate an out-of-band write leaking a raw value into the durable
+    // event JSON (the framework itself always writes null there).
+    sqlx::query!(
+        r#"UPDATE customer_events
+           SET event = jsonb_set(event, '{name}', '"leaked"')
+           WHERE id = $1 AND event_type = 'initialized'"#,
+        id as CustomerId
+    )
+    .execute(&pool)
+    .await?;
+
+    let err = customers
+        .verify_forgotten(id)
+        .await
+        .expect_err("leaked event JSON must fail verification");
+    let remnants = err.not_forgotten_remnants().expect("NotForgotten");
+    assert_eq!(remnants.payload_rows, 0);
+    assert_eq!(
+        remnants.event_fields,
+        vec![("initialized".to_string(), "name".to_string())]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn verify_forgotten_passes_trivially_for_unknown_id() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = Customers::new(pool);
+
+    // An id that was never persisted has nothing to erase.
+    customers.verify_forgotten(CustomerId::new()).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn events_table_stores_null_for_live_forgettable_fields() -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;
     let customers = Customers::new(pool.clone());

--- a/tests/forgettable_columns.rs
+++ b/tests/forgettable_columns.rs
@@ -320,3 +320,30 @@ async fn soft_delete_auto_forgets_the_index_column() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn verify_forgotten_reports_live_index_columns() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let subscribers = Subscribers::new(pool);
+
+    let (mut subscriber, _email) = new_subscriber(&subscribers).await?;
+    let id = subscriber.id;
+
+    // Live entity: both the payload row and the materialised index column
+    // still hold the value.
+    let err = subscribers
+        .verify_forgotten(id)
+        .await
+        .expect_err("live entity must not verify as forgotten");
+    let remnants = err.not_forgotten_remnants().expect("NotForgotten");
+    assert_eq!(remnants.payload_rows, 1);
+    assert_eq!(remnants.live_index_columns, vec!["email"]);
+    assert!(remnants.event_fields.is_empty());
+
+    // After a fenced forget everything is physically absent.
+    subscriber.record_erasure();
+    subscribers.forget(subscriber).await?;
+    subscribers.verify_forgotten(id).await?;
+
+    Ok(())
+}

--- a/tests/forgettable_hooks.rs
+++ b/tests/forgettable_hooks.rs
@@ -1,0 +1,310 @@
+//! Post-persist hook execution on the generated `forget` / `forget_in_op`
+//! path.
+//!
+//! Forgetting an entity must run the same post-persist hook as normal
+//! persists — exactly once, after the payload delete and rebuild (so the hook
+//! observes the forgotten representation), and inside the erasure transaction
+//! (so a failing hook rolls the whole erasure back and outbox-style
+//! publishers never publish uncommitted data).
+
+mod entities;
+mod helpers;
+
+use sqlx::PgPool;
+
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use entities::customer::*;
+use es_entity::*;
+
+#[derive(Debug)]
+pub struct CustomerPublishError(String);
+
+impl std::fmt::Display for CustomerPublishError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "publish failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for CustomerPublishError {}
+
+/// One recorded hook invocation.
+#[derive(Debug, Clone)]
+pub struct HookCall {
+    /// Event types of the events handed to the hook, in order.
+    pub event_types: Vec<String>,
+    /// The entity's `name` as the hook observed it.
+    pub entity_name: String,
+    /// Whether any `NameUpdated` event handed to the hook still carried a
+    /// readable (non-forgotten) name value.
+    pub saw_raw_name: bool,
+    /// Payload rows present for the entity at hook time (queried through the
+    /// hook's own operation — i.e. inside the same transaction).
+    pub payload_rows_at_hook_time: i64,
+}
+
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "Customer",
+    forgettable,
+    columns(email(ty = "String")),
+    post_persist_hook(method = "publish", error = "CustomerPublishError")
+)]
+pub struct CustomersWithHook {
+    pool: PgPool,
+    calls: Mutex<Vec<HookCall>>,
+    fail_on_forgot: AtomicBool,
+}
+
+impl CustomersWithHook {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+            calls: Mutex::new(Vec::new()),
+            fail_on_forgot: AtomicBool::new(false),
+        }
+    }
+
+    pub fn calls(&self) -> Vec<HookCall> {
+        self.calls.lock().unwrap().clone()
+    }
+
+    async fn publish<OP: es_entity::AtomicOperation>(
+        &self,
+        op: &mut OP,
+        entity: &Customer,
+        new_events: es_entity::events::LastPersisted<'_, CustomerEvent>,
+    ) -> Result<(), CustomerPublishError> {
+        let events: Vec<_> = new_events.collect();
+        let event_types: Vec<String> = events
+            .iter()
+            .map(|e| match &e.event {
+                CustomerEvent::Initialized { .. } => "initialized".to_string(),
+                CustomerEvent::NameUpdated { .. } => "name_updated".to_string(),
+                CustomerEvent::EmailUpdated { .. } => "email_updated".to_string(),
+                CustomerEvent::Forgot { .. } => "forgot".to_string(),
+            })
+            .collect();
+        let saw_raw_name = events.iter().any(|e| match &e.event {
+            CustomerEvent::NameUpdated { name } => name.value().is_some(),
+            _ => false,
+        });
+        let id = entity.id;
+        let payload_rows_at_hook_time = sqlx::query!(
+            r#"SELECT COUNT(*) AS "count!" FROM customers_forgettable_payloads
+               WHERE entity_id = $1"#,
+            id as CustomerId
+        )
+        .fetch_one(op.as_executor())
+        .await
+        .map_err(|e| CustomerPublishError(e.to_string()))?
+        .count;
+
+        if self.fail_on_forgot.load(Ordering::SeqCst) && event_types.iter().any(|t| t == "forgot") {
+            return Err(CustomerPublishError(format!(
+                "publisher rejected forgot event for {id}"
+            )));
+        }
+
+        self.calls.lock().unwrap().push(HookCall {
+            event_types,
+            entity_name: entity.name.clone(),
+            saw_raw_name,
+            payload_rows_at_hook_time,
+        });
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn forget_runs_post_persist_hook_for_staged_erasure_event() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = CustomersWithHook::new(pool);
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Hooked Hannah")
+        .email("hooked@example.com")
+        .build()
+        .unwrap();
+    let mut customer = customers.create(new_customer).await?;
+    assert_eq!(customers.calls().len(), 1, "create fires the hook once");
+
+    customer.record_erasure();
+    customers.forget(customer).await?;
+
+    let calls = customers.calls();
+    assert_eq!(calls.len(), 2, "forget fires the hook exactly once more");
+    let forget_call = &calls[1];
+    assert_eq!(forget_call.event_types, vec!["forgot"]);
+    // The hook observes the rebuilt (forgotten) entity, not the raw one.
+    assert_eq!(forget_call.entity_name, "[forgotten]");
+    // ...and runs after the payload delete, inside the erasure transaction.
+    assert_eq!(forget_call.payload_rows_at_hook_time, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn forget_without_staged_events_does_not_run_hook() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = CustomersWithHook::new(pool);
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Quiet Quinn")
+        .email("quiet@example.com")
+        .build()
+        .unwrap();
+    let customer = customers.create(new_customer).await?;
+    assert_eq!(customers.calls().len(), 1);
+
+    // No staged events: nothing is persisted, so there is nothing to publish
+    // — mirroring `update`'s no-op semantics.
+    customers.forget(customer).await?;
+    assert_eq!(customers.calls().len(), 1, "hook must not fire");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn hook_sees_forgotten_payloads_for_staged_pii_events() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = CustomersWithHook::new(pool);
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Leaky Lou")
+        .email("leaky@example.com")
+        .build()
+        .unwrap();
+    let mut customer = customers.create(new_customer).await?;
+
+    // A staged-but-unpersisted PII event rides along with the erasure. The
+    // hook must receive it in its forgotten form — the raw value must never
+    // reach a publisher during an erasure.
+    let _ = customer.update_name("Unpersisted Raw Name");
+    customer.record_erasure();
+    customers.forget(customer).await?;
+
+    let calls = customers.calls();
+    assert_eq!(calls.len(), 2);
+    let forget_call = &calls[1];
+    assert_eq!(forget_call.event_types, vec!["name_updated", "forgot"]);
+    assert!(
+        !forget_call.saw_raw_name,
+        "hook must never observe raw PII during an erasure"
+    );
+    assert_eq!(forget_call.entity_name, "[forgotten]");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn hook_error_rolls_back_the_entire_erasure() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = CustomersWithHook::new(pool.clone());
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Rollback Rae")
+        .email("rollback@example.com")
+        .build()
+        .unwrap();
+    let mut customer = customers.create(new_customer).await?;
+
+    customers.fail_on_forgot.store(true, Ordering::SeqCst);
+    customer.record_erasure();
+    let err = match customers.forget(customer).await {
+        Err(e) => e,
+        Ok(_) => panic!("hook failure must fail the forget"),
+    };
+    match err {
+        CustomerForgetError::PostPersistHookError(inner) => {
+            assert!(inner.to_string().contains("rejected forgot event"));
+        }
+        e => panic!("expected PostPersistHookError, got: {e}"),
+    }
+
+    // The whole erasure rolled back: payloads still present, entity still
+    // live, no forgot event persisted.
+    let payloads = sqlx::query!(
+        r#"SELECT COUNT(*) AS "count!" FROM customers_forgettable_payloads
+           WHERE entity_id = $1"#,
+        id as CustomerId
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(payloads.count, 1);
+
+    let reloaded = customers.find_by_id(id).await?;
+    assert_eq!(reloaded.name, "Rollback Rae");
+    let forgot_events = sqlx::query!(
+        r#"SELECT COUNT(*) AS "count!" FROM customer_events
+           WHERE id = $1 AND event_type = 'forgot'"#,
+        id as CustomerId
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(forgot_events.count, 0);
+
+    // Retry after the publisher recovers: the erasure is retryable.
+    customers.fail_on_forgot.store(false, Ordering::SeqCst);
+    let mut customer = customers.find_by_id(id).await?;
+    customer.record_erasure();
+    let customer = customers.forget(customer).await?;
+    assert_eq!(customer.name, "[forgotten]");
+    customers.verify_forgotten(id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn stale_writer_pii_is_fenced_and_leaves_no_trace_after_forget() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = CustomersWithHook::new(pool.clone());
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Fenced Fran")
+        .email("fenced@example.com")
+        .build()
+        .unwrap();
+    customers.create(new_customer).await?;
+
+    let mut stale = customers.find_by_id(id).await?;
+    let mut fresh = customers.find_by_id(id).await?;
+
+    fresh.record_erasure();
+    customers.forget(fresh).await?;
+
+    // A stale instance trying to write PII after the concurrent forget is
+    // rejected by the sequence fence...
+    let _ = stale.update_name("Resurrected PII");
+    let err = customers
+        .update(&mut stale)
+        .await
+        .expect_err("stale PII write after forget must fail");
+    assert!(err.was_concurrent_modification());
+
+    // ...the rejected write publishes nothing...
+    let calls = customers.calls();
+    assert_eq!(
+        calls.len(),
+        2,
+        "create + forget only — no publish for the rejected write"
+    );
+
+    // ...and leaves no PII behind at the storage level.
+    customers.verify_forgotten(id).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## What

Route the generated `forget` / `forget_in_op` path through the repository's `post_persist_hook`, and add a generated storage-level erasure check (`verify_forgotten`).

## Why

Erasing an entity should be observable through the same channel as every other persist. Until now `forget_in_op` persisted staged events directly and bypassed the hook, so outbox-style publishers never saw the erasure event — downstream consumers (e.g. public erasure events, warehouse cleanup) had to bolt on custom publish calls next to `forget`.

Auditing an erasure by reloading the entity only proves the hydrated state reads back as forgotten. Consumers of `forget` need a way to trust that the data is *physically* gone without hand-maintaining a list of PII fields.

## How it behaves

**Hook on forget** — the hook runs exactly once, for the staged events the forget persists (by convention the domain erasure event):

- after the payload delete and entity rebuild, so it observes the forgotten representation — raw payloads being erased can never reach a publisher;
- inside the erasure transaction, so publishers never publish uncommitted data and a failing hook rolls the whole erasure back (the forget stays retryable);
- not at all when no staged events are persisted, matching `update`'s no-op semantics.

Failures surface as a new `{Entity}ForgetError::PostPersistHookError` variant. Atomicity, the stale-writer sequence fence, payload deletion, and index-column nulling are unchanged.

**`verify_forgotten` / `verify_forgotten_in_op`** — generated for every `forgettable` repo; checks the database directly and fails with `{Entity}ForgetError::NotForgotten(ForgettableRemnants)` if anything survives:

1. rows remaining in the `_forgettable_payloads` table
2. non-NULL `Forgettable<..>` index columns
3. non-null forgettable fields in the durable event JSON (defense-in-depth against out-of-band writes), driven by a new `FORGETTABLE_JSON_FIELDS` const the `EsEvent` derive emits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
