### PR TITLE
perf(repo): collapse index+events writes into one round trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,9 +254,14 @@ pub enum CustomerEvent {
     },
 }
 
-// Repos marked `forgettable` generate a `forget` fn
-customers.forget(&mut customer).await?;
+// Repos marked `forgettable` generate a `forget` fn — it consumes the
+// entity and returns the rebuilt (forgotten) one, running any configured
+// `post_persist_hook` for staged events it persists.
+let customer = customers.forget(customer).await?;
 assert!(customer.name.is_forgotten());
+
+// And a storage-level check that the data is physically absent
+customers.verify_forgotten(customer.id).await?;
 ```
 
 See the [Forgettable Data](https://galoymoney.github.io/es-entity/forgettable.html) chapter in the book for details.

--- a/book/src/forgettable.md
+++ b/book/src/forgettable.md
@@ -197,22 +197,75 @@ pub struct Customers {
 }
 ```
 
-This generates a `forget` method on the repository that:
-1. Deletes all forgettable payloads for the entity from the database
-2. Sets any [forgettable index columns](#forgettable-index-columns) to `NULL`
-3. Rebuilds the entity in-place with forgotten fields set to `Forgettable::forgotten()`
+This generates a `forget` method (and `forget_in_op` for use inside an
+existing transaction) on the repository that:
+1. Persists any staged (unpersisted) events — consuming sequence numbers,
+   which is the concurrency fence against stale writers
+2. Deletes all forgettable payloads for the entity from the database
+3. Sets any [forgettable index columns](#forgettable-index-columns) to `NULL`
+4. Rebuilds and returns the entity with forgotten fields set to
+   `Forgettable::forgotten()`
 
 ```rust,ignore
 // Load the entity
-let mut customer = customers.find_by_id(id).await?;
+let customer = customers.find_by_id(id).await?;
 assert_eq!(customer.name.value().map(|v| v.clone()), Some("Alice".to_string()));
 
-// Forget personal data — updates `customer` in place
-customers.forget(&mut customer).await?;
+// Forget personal data — consumes the entity and returns the rebuilt,
+// forgotten one
+let customer = customers.forget(customer).await?;
 
 // The entity immediately reflects the forgotten state
 assert!(customer.name.is_forgotten());
 ```
+
+## Post-Persist Hooks and Forget
+
+If the repository configures a
+[`post_persist_hook`](repo-hooks.md) (e.g. an outbox
+publisher), `forget` runs it through the same channel as `create` and
+`update` — no separate publish path is needed for erasure events. The hook
+runs:
+
+- **exactly once**, for the staged events the forget persisted (by
+  convention, the domain erasure event — e.g. an empty `Forgot {}`);
+- **after** the payload delete and entity rebuild, so it observes the
+  forgotten representation — a raw payload being erased can never reach a
+  publisher;
+- **inside the erasure transaction**, so outbox-style publishers never
+  publish uncommitted data, and a failing hook rolls the entire erasure
+  back (the forget is retryable).
+
+If no staged events are persisted the hook is not invoked, matching
+`update`'s no-op semantics. A hook failure surfaces as
+`{Entity}ForgetError::PostPersistHookError`.
+
+## Verifying Erasure at the Storage Level
+
+Auditing an erasure by reloading the entity only proves the *hydrated* state
+reads back as forgotten. The generated `verify_forgotten` (and
+`verify_forgotten_in_op`) checks the **database** directly, so callers can
+trust physical absence without hand-maintaining a list of PII fields:
+
+1. no rows remain in the `_forgettable_payloads` table,
+2. all `Forgettable<..>` index columns are `NULL`, and
+3. no forgettable field holds a non-null value in the durable event JSON
+   (defense-in-depth: the framework always writes `null` there, so a hit
+   indicates out-of-band writes).
+
+```rust,ignore
+let customer = customers.forget(customer).await?;
+
+// Fails with `CustomerForgetError::NotForgotten(remnants)` if anything
+// forgettable is still physically present.
+customers.verify_forgotten(customer.id).await?;
+```
+
+The `NotForgotten` error carries a
+[`ForgettableRemnants`](https://docs.rs/es-entity) report describing exactly
+what survived (`payload_rows`, `live_index_columns`, `event_fields`),
+accessible via `err.not_forgotten_remnants()`. An id that was never persisted
+verifies trivially.
 
 ## Custom Queries with `es_query!`
 

--- a/book/src/repo-hooks.md
+++ b/book/src/repo-hooks.md
@@ -45,9 +45,13 @@ impl Users {
 }
 ```
 
+### Which operations run it
+
+The hook runs on every generated operation that persists events: `create`, `create_all`, `update`, `update_all`, soft `delete`, and — for [forgettable](forgettable.md) repos — `forget`. On `forget` it runs after the payload delete and entity rebuild, so it observes the forgotten representation; when an operation persists no events the hook is not invoked.
+
 ### Error propagation
 
-When the hook returns an error it is wrapped in the `PostPersistHookError` variant of `CreateError` or `ModifyError`:
+When the hook returns an error it is wrapped in the `PostPersistHookError` variant of `CreateError`, `ModifyError`, or `ForgetError`:
 
 ```rust,ignore
 match users.create(new_user).await {

--- a/es-entity-macros/src/event.rs
+++ b/es-entity-macros/src/event.rs
@@ -17,7 +17,7 @@ pub struct EsEvent {
 struct ForgettableInfo {
     /// Whether any variant has forgettable fields.
     has_forgettable: bool,
-    /// Per-variant: (variant_ident, serde_tag_value, list_of_forgettable_field_idents)
+    /// Per-variant: (variant_ident, event_type_value, list_of_forgettable_field_idents)
     variants: Vec<(syn::Ident, String, Vec<syn::Ident>)>,
 }
 
@@ -93,15 +93,16 @@ pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream
         })
         .collect();
 
-    // (serde tag value, forgettable field JSON key) pairs across all variants —
-    // consumed by the repo's generated `verify_forgotten` storage check.
+    // (event_type column value, forgettable field JSON key) pairs across all
+    // variants — consumed by the repo's generated `verify_forgotten` storage
+    // check, which joins the first element against the `event_type` column.
     let forgettable_json_fields: Vec<_> = forgettable_info
         .variants
         .iter()
-        .flat_map(|(_, tag_value, field_idents)| {
+        .flat_map(|(_, event_type_value, field_idents)| {
             field_idents.iter().map(move |field_id| {
                 let field_name = field_id.to_string();
-                quote! { (#tag_value, #field_name) }
+                quote! { (#event_type_value, #field_name) }
             })
         })
         .collect();
@@ -135,17 +136,26 @@ pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream
     Ok(tokens)
 }
 
+/// The value written to the `event_type` column for a variant.
+///
+/// Deliberately the snake-cased *ident*, not the serde tag: the column is
+/// populated from the generated `EsEvent::event_type`, which knows nothing
+/// about serde renames, so anything matching against that column has to agree
+/// with it. Both emission sites go through here — the `event_type` arms and
+/// `FORGETTABLE_JSON_FIELDS` — so the two cannot drift apart.
+fn event_type_value(variant_ident: &syn::Ident) -> String {
+    variant_ident.to_string().to_case(Case::Snake)
+}
+
 /// Extract forgettable field information from the enum definition.
 fn extract_forgettable_info(ast: &syn::DeriveInput) -> ForgettableInfo {
-    let rename_rule = parse_serde_rename_all(ast);
-
     let variants = match &ast.data {
         syn::Data::Enum(data) => data
             .variants
             .iter()
             .map(|variant| {
                 let variant_ident = variant.ident.clone();
-                let tag_value = serde_variant_name(variant, &rename_rule);
+                let event_type_value = event_type_value(&variant_ident);
                 let forgettable_fields = variant
                     .fields
                     .iter()
@@ -157,7 +167,7 @@ fn extract_forgettable_info(ast: &syn::DeriveInput) -> ForgettableInfo {
                         }
                     })
                     .collect::<Vec<_>>();
-                (variant_ident, tag_value, forgettable_fields)
+                (variant_ident, event_type_value, forgettable_fields)
             })
             .collect(),
         _ => Vec::new(),
@@ -181,79 +191,6 @@ fn is_forgettable_type(ty: &syn::Type) -> bool {
     false
 }
 
-/// Parse the `rename_all` value from `#[serde(tag = "type", rename_all = "...")]`.
-fn parse_serde_rename_all(ast: &syn::DeriveInput) -> Option<String> {
-    for attr in &ast.attrs {
-        if !attr.path().is_ident("serde") {
-            continue;
-        }
-        let mut rename_all_str = None;
-        let _ = attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident("rename_all") {
-                let value = meta.value()?;
-                let lit: syn::LitStr = value.parse()?;
-                rename_all_str = Some(lit.value());
-            } else {
-                // Consume any value so parse_nested_meta can continue to the next item
-                let _ = meta.value().and_then(|v| v.parse::<syn::LitStr>());
-            }
-            Ok(())
-        });
-        if rename_all_str.is_some() {
-            return rename_all_str;
-        }
-    }
-    None
-}
-
-/// Convert a serde rename_all string to a convert_case::Case.
-fn serde_rename_to_case(s: &str) -> Option<Case<'static>> {
-    match s {
-        "lowercase" => Some(Case::Lower),
-        "UPPERCASE" => Some(Case::Upper),
-        "PascalCase" => Some(Case::Pascal),
-        "camelCase" => Some(Case::Camel),
-        "snake_case" => Some(Case::Snake),
-        "SCREAMING_SNAKE_CASE" => Some(Case::Constant),
-        "kebab-case" => Some(Case::Kebab),
-        "SCREAMING-KEBAB-CASE" => Some(Case::Cobol),
-        _ => None,
-    }
-}
-
-/// Get the serde tag name for a variant, considering rename_all and per-variant rename.
-fn serde_variant_name(variant: &syn::Variant, rename_rule: &Option<String>) -> String {
-    // Check for explicit #[serde(rename = "...")]
-    for attr in &variant.attrs {
-        if !attr.path().is_ident("serde") {
-            continue;
-        }
-        let mut explicit_rename = None;
-        let _ = attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident("rename") {
-                let value = meta.value()?;
-                let lit: syn::LitStr = value.parse()?;
-                explicit_rename = Some(lit.value());
-            }
-            Ok(())
-        });
-        if let Some(name) = explicit_rename {
-            return name;
-        }
-    }
-
-    let ident = variant.ident.to_string();
-    if let Some(rule) = rename_rule {
-        if let Some(case) = serde_rename_to_case(rule) {
-            ident.to_case(case)
-        } else {
-            ident
-        }
-    } else {
-        ident
-    }
-}
-
 impl ToTokens for EsEvent {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let ident = &self.ident;
@@ -275,9 +212,9 @@ impl ToTokens for EsEvent {
                     .iter()
                     .map(|v| {
                         let variant_ident = &v.ident;
-                        let snake_name = variant_ident.to_string().to_case(Case::Snake);
+                        let type_value = event_type_value(variant_ident);
                         quote! {
-                            Self::#variant_ident { .. } => #snake_name,
+                            Self::#variant_ident { .. } => #type_value,
                         }
                     })
                     .collect();
@@ -343,5 +280,40 @@ mod tests {
         };
 
         assert_eq!(tokens.to_string(), expected.to_string());
+    }
+
+    /// `verify_forgotten` joins `FORGETTABLE_JSON_FIELDS` against the
+    /// `event_type` column, which is written from `event_type()` — the
+    /// snake-cased ident, which knows nothing about serde renames. Keying
+    /// the const on the serde tag instead would make the join match nothing
+    /// and silently report a forgotten entity as clean. Every entity in this
+    /// repo happens to use `rename_all = "snake_case"`, where the two agree,
+    /// so this pins the case where they do not.
+    #[test]
+    fn forgettable_json_fields_key_on_the_event_type_column_not_the_serde_tag() {
+        let input: syn::DeriveInput = syn::parse_quote! {
+            #[es_event(id = "SubscriberId")]
+            #[serde(tag = "type", rename_all = "camelCase")]
+            enum SubscriberEvent {
+                #[serde(rename = "totally_custom")]
+                Initialized { id: SubscriberId, email: Forgettable<String> },
+                EmailChanged { email: Forgettable<String> },
+            }
+        };
+
+        let out = derive(input).unwrap().to_string();
+
+        // Both variants keyed by the snake_case ident, matching `event_type()`.
+        assert!(
+            out.contains(r#"("initialized" , "email")"#),
+            "expected snake_case ident key, got: {out}"
+        );
+        assert!(
+            out.contains(r#"("email_changed" , "email")"#),
+            "expected snake_case ident key, got: {out}"
+        );
+        // Never the serde tag or the rename_all casing.
+        assert!(!out.contains(r#""totally_custom""#));
+        assert!(!out.contains(r#""emailChanged""#));
     }
 }

--- a/es-entity-macros/src/event.rs
+++ b/es-entity-macros/src/event.rs
@@ -93,10 +93,28 @@ pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream
         })
         .collect();
 
+    // (serde tag value, forgettable field JSON key) pairs across all variants —
+    // consumed by the repo's generated `verify_forgotten` storage check.
+    let forgettable_json_fields: Vec<_> = forgettable_info
+        .variants
+        .iter()
+        .flat_map(|(_, tag_value, field_idents)| {
+            field_idents.iter().map(move |field_id| {
+                let field_name = field_id.to_string();
+                quote! { (#tag_value, #field_name) }
+            })
+        })
+        .collect();
+
     tokens.append_all(quote! {
         impl #ident {
             #[doc(hidden)]
             pub const HAS_FORGETTABLE_FIELDS: bool = #has_forgettable;
+
+            #[doc(hidden)]
+            pub const FORGETTABLE_JSON_FIELDS: &'static [(&'static str, &'static str)] = &[
+                #(#forgettable_json_fields),*
+            ];
 
             #[doc(hidden)]
             pub fn extract_forgettable_payloads(&self) -> Option<es_entity::prelude::serde_json::Value> {

--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -2,11 +2,16 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::options::*;
+use super::{error_classifier::write_error_classifier, options::*};
 
 pub struct CreateAllFn<'a> {
     entity: &'a syn::Ident,
+    id: &'a syn::Ident,
+    event: &'a syn::Ident,
     table_name: &'a str,
+    events_table_name: &'a str,
+    event_ctx: bool,
+    forgettable_table_name: Option<&'a str>,
     columns: &'a Columns,
     create_error: syn::Ident,
     nested_fn_names: Vec<syn::Ident>,
@@ -21,6 +26,11 @@ impl<'a> From<&'a RepositoryOptions> for CreateAllFn<'a> {
         Self {
             table_name: opts.table_name(),
             entity: opts.entity(),
+            id: opts.id(),
+            event: opts.event(),
+            events_table_name: opts.events_table_name(),
+            event_ctx: opts.event_context_enabled(),
+            forgettable_table_name: opts.forgettable_table_name(),
             create_error: opts.create_error(),
             nested_fn_names: opts
                 .all_nested()
@@ -55,21 +65,123 @@ impl ToTokens for CreateAllFn<'_> {
 
         let column_names = self.columns.insert_column_names();
         let placeholders = self.columns.insert_placeholders(1);
-        let (arg_collection, bindings) = self
+        let (arg_collection, arg_adds) = self
             .columns
             .create_all_arg_collection(syn::parse_quote! { new_entity });
 
+        let ids_p = column_names.len() + 2;
+        let sequences_p = ids_p + 1;
+        let types_p = ids_p + 2;
+        let events_p = ids_p + 3;
+        let ctx_p = ids_p + 4;
+
+        // Both inserts in one statement. The events insert joins the `new_rows`
+        // CTE, which forces the index rows to be written first — so a duplicate
+        // id surfaces as the index constraint violation rather than as a unique
+        // violation on the events table.
         let query = format!(
-            "INSERT INTO {} (created_at, {}) \
+            "WITH new_rows AS (INSERT INTO {} (created_at, {}) \
             SELECT COALESCE($1, NOW()), unnested.{} \
             FROM UNNEST({}) \
-            AS unnested({})",
+            AS unnested({}) RETURNING id) \
+            INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
+            SELECT unnested.id, COALESCE($1, NOW()), unnested.sequence, unnested.event_type, unnested.event{} \
+            FROM UNNEST(${}, ${}::INT[], ${}::TEXT[], ${}::JSONB[]{}) \
+            AS unnested(id, sequence, event_type, event{}) \
+            JOIN new_rows ON new_rows.id = unnested.id \
+            RETURNING recorded_at",
             table_name,
             column_names.join(", "),
             column_names.join(", unnested."),
             placeholders,
             column_names.join(", "),
+            self.events_table_name,
+            if self.event_ctx { ", context" } else { "" },
+            if self.event_ctx {
+                ", unnested.context"
+            } else {
+                ""
+            },
+            ids_p,
+            sequences_p,
+            types_p,
+            events_p,
+            if self.event_ctx {
+                format!(", ${ctx_p}::JSONB[]")
+            } else {
+                String::new()
+            },
+            if self.event_ctx { ", context" } else { "" },
         );
+
+        let classifier = write_error_classifier(create_error, self.events_table_name);
+
+        let id_type = self.id;
+        let event_type = self.event;
+
+        let (ctx_var, ctx_extend, ctx_add) = if self.event_ctx {
+            (
+                quote! {
+                    let mut all_contexts: Vec<es_entity::ContextData> = Vec::new();
+                },
+                quote! {
+                    if let Some(contexts) = events.serialize_new_event_contexts() {
+                        all_contexts.extend(contexts);
+                    }
+                },
+                quote! {
+                    __query_args.add(if all_contexts.is_empty() {
+                        None
+                    } else {
+                        Some(&all_contexts)
+                    }).map_err(sqlx::Error::Encode)?;
+                },
+            )
+        } else {
+            (quote! {}, quote! {}, quote! {})
+        };
+
+        let (forgettable_vars, forgettable_extract, forgettable_insert) = if let Some(
+            forgettable_tbl,
+        ) =
+            self.forgettable_table_name
+        {
+            let payload_insert_query = format!(
+                "INSERT INTO {} (entity_id, sequence, payload) SELECT unnested.entity_id, unnested.sequence, unnested.payload FROM UNNEST($1, $2::INT[], $3::JSONB[]) AS unnested(entity_id, sequence, payload)",
+                forgettable_tbl
+            );
+            (
+                quote! {
+                    let mut payload_ids: Vec<&#id_type> = Vec::new();
+                    let mut payload_sequences: Vec<i32> = Vec::new();
+                    let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
+                },
+                quote! {
+                    for (idx, event_with_ctx) in events.iter_new_events().enumerate() {
+                        if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
+                            payload_ids.push(id);
+                            payload_sequences.push((offset + idx) as i32);
+                            payload_values.push(payload);
+                        }
+                    }
+                },
+                quote! {
+                    if !payload_sequences.is_empty() {
+                        Self::extract_concurrent_modification(
+                            sqlx::query(#payload_insert_query)
+                                .bind(&payload_ids)
+                                .bind(&payload_sequences)
+                                .bind(&payload_values)
+                                .execute(op.as_executor())
+                                .await,
+                            #create_error::ConcurrentModification,
+                        )?;
+                    }
+                },
+            )
+        } else {
+            (quote! {}, quote! {}, quote! {})
+        };
 
         #[cfg(feature = "instrument")]
         let (instrument_attr, error_recording) = {
@@ -129,39 +241,79 @@ impl ToTokens for CreateAllFn<'_> {
                 OP: es_entity::AtomicOperation
             {
                 let __result: Result<Vec<#entity>, #create_error> = async {
+                    use es_entity::prelude::sqlx::{Arguments, Row};
+
                     let mut res = Vec::new();
                     if new_entities.is_empty() {
                         return Ok(res);
                     }
 
+                    let mut __query_args = sqlx::postgres::PgArguments::default();
+                    __query_args.add(op.maybe_now()).map_err(sqlx::Error::Encode)?;
+
+                    // The index columns are encoded first so that the borrows
+                    // they hold on `new_entities` end here, freeing it to be
+                    // consumed into the event stream below.
                     #arg_collection
-
-                    let now = op.maybe_now();
-                    sqlx::query(#query)
-                       .bind(now)
-                       #(#bindings)*
-                       .fetch_all(op.as_executor())
-                       .await
-                       .map_err(|e| match &e {
-                           sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
-                               #create_error::ConstraintViolation {
-                                   column: Self::map_constraint_column(db_err.constraint()),
-                                   value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                   inner: e,
-                               }
-                           }
-                           _ => #create_error::Sqlx(e),
-                       })?;
-
+                    #(#arg_adds)*
 
                     let mut all_events: Vec<es_entity::EntityEvents<<#entity as es_entity::EsEntity>::Event>> = new_entities.into_iter().map(Self::convert_new).collect();
-                    let mut n_persisted = Self::extract_concurrent_modification(
-                        self.persist_events_batch(op, &mut all_events).await,
-                        #create_error::ConcurrentModification,
-                    )?;
 
-                    for events in all_events.into_iter() {
-                        let n_events = n_persisted.remove(events.id()).expect("n_events exists");
+                    let mut all_ids: Vec<&#id_type> = Vec::new();
+                    let mut all_sequences: Vec<i32> = Vec::new();
+                    let mut all_types = Vec::new();
+                    let mut all_serialized = Vec::new();
+                    let mut n_persisted: Vec<usize> = Vec::new();
+                    #ctx_var
+                    #forgettable_vars
+
+                    for events in all_events.iter() {
+                        let id = events.id();
+                        let offset = events.len_persisted() + 1;
+                        let types = events.new_event_types();
+                        let serialized = events.serialize_new_events();
+                        #ctx_extend
+                        #forgettable_extract
+
+                        let n_events = serialized.len();
+                        all_types.extend(types);
+                        all_serialized.extend(serialized);
+                        all_ids.extend(std::iter::repeat(id).take(n_events));
+                        all_sequences.extend((offset..).take(n_events).map(|i| i as i32));
+                        n_persisted.push(n_events);
+                    }
+
+                    __query_args.add(&all_ids).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(&all_sequences).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(&all_types).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(&all_serialized).map_err(sqlx::Error::Encode)?;
+                    #ctx_add
+
+                    let expected_events = all_ids.len();
+                    let rows = sqlx::query_with(#query, __query_args)
+                        .fetch_all(op.as_executor())
+                        .await
+                        .map_err(#classifier)?;
+
+                    #forgettable_insert
+
+                    if expected_events > 0 {
+                        // Every event row joins an index row this same statement
+                        // inserted, so a short count means the join dropped rows.
+                        if rows.len() != expected_events {
+                            return Err(#create_error::ConcurrentModification);
+                        }
+
+                        let recorded_at = rows
+                            .first()
+                            .ok_or(sqlx::Error::RowNotFound)
+                            .and_then(|row| row.try_get("recorded_at"))?;
+                        for events in all_events.iter_mut() {
+                            events.mark_new_events_persisted_at(recorded_at);
+                        }
+                    }
+
+                    for (events, n_events) in all_events.into_iter().zip(n_persisted) {
                         let #maybe_mut_entity = Self::hydrate_entity(events)?;
 
                         #(#nested)*
@@ -191,15 +343,22 @@ mod tests {
     fn create_all_fn() {
         let entity = Ident::new("Entity", Span::call_site());
         let create_error = syn::Ident::new("EntityCreateError", Span::call_site());
+        let id = Ident::new("EntityId", Span::call_site());
+        let event = Ident::new("EntityEvent", Span::call_site());
 
         use darling::FromMeta;
         let input: syn::Meta = syn::parse_quote!(columns(name = "String",));
         let mut columns = Columns::from_meta(&input).expect("Failed to parse Fields");
-        columns.set_id_column(&Ident::new("EntityId", Span::call_site()));
+        columns.set_id_column(&id);
 
         let create_fn = CreateAllFn {
             table_name: "entities",
             entity: &entity,
+            id: &id,
+            event: &event,
+            events_table_name: "entity_events",
+            event_ctx: false,
+            forgettable_table_name: None,
             create_error,
             columns: &columns,
             nested_fn_names: Vec::new(),
@@ -208,9 +367,6 @@ mod tests {
             #[cfg(feature = "instrument")]
             repo_name_snake: "test_repo".to_string(),
         };
-
-        let mut tokens = TokenStream::new();
-        create_fn.to_tokens(&mut tokens);
 
         let mut tokens = TokenStream::new();
         create_fn.to_tokens(&mut tokens);
@@ -235,10 +391,15 @@ mod tests {
                 OP: es_entity::AtomicOperation
             {
                 let __result: Result<Vec<Entity>, EntityCreateError> = async {
+                    use es_entity::prelude::sqlx::{Arguments, Row};
+
                     let mut res = Vec::new();
                     if new_entities.is_empty() {
                         return Ok(res);
                     }
+
+                    let mut __query_args = sqlx::postgres::PgArguments::default();
+                    __query_args.add(op.maybe_now()).map_err(sqlx::Error::Encode)?;
 
                     let mut id_collection = Vec::new();
                     let mut name_collection = Vec::new();
@@ -251,16 +412,54 @@ mod tests {
                         name_collection.push(name);
                     }
 
-                    let now = op.maybe_now();
-                    sqlx::query(
-                        "INSERT INTO entities (created_at, id, name) SELECT COALESCE($1, NOW()), unnested.id, unnested.name FROM UNNEST($2, $3) AS unnested(id, name)")
-                        .bind(now)
-                        .bind(id_collection)
-                        .bind(name_collection)
+                    __query_args.add(id_collection).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(name_collection).map_err(sqlx::Error::Encode)?;
+
+                    let mut all_events: Vec<es_entity::EntityEvents<<Entity as es_entity::EsEntity>::Event>> = new_entities.into_iter().map(Self::convert_new).collect();
+
+                    let mut all_ids: Vec<&EntityId> = Vec::new();
+                    let mut all_sequences: Vec<i32> = Vec::new();
+                    let mut all_types = Vec::new();
+                    let mut all_serialized = Vec::new();
+                    let mut n_persisted: Vec<usize> = Vec::new();
+
+                    for events in all_events.iter() {
+                        let id = events.id();
+                        let offset = events.len_persisted() + 1;
+                        let types = events.new_event_types();
+                        let serialized = events.serialize_new_events();
+
+                        let n_events = serialized.len();
+                        all_types.extend(types);
+                        all_serialized.extend(serialized);
+                        all_ids.extend(std::iter::repeat(id).take(n_events));
+                        all_sequences.extend((offset..).take(n_events).map(|i| i as i32));
+                        n_persisted.push(n_events);
+                    }
+
+                    __query_args.add(&all_ids).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(&all_sequences).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(&all_types).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(&all_serialized).map_err(sqlx::Error::Encode)?;
+
+                    let expected_events = all_ids.len();
+                    let rows = sqlx::query_with(
+                        "WITH new_rows AS (INSERT INTO entities (created_at, id, name) SELECT COALESCE($1, NOW()), unnested.id, unnested.name FROM UNNEST($2, $3) AS unnested(id, name) RETURNING id) INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, COALESCE($1, NOW()), unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($4, $5::INT[], $6::TEXT[], $7::JSONB[]) AS unnested(id, sequence, event_type, event) JOIN new_rows ON new_rows.id = unnested.id RETURNING recorded_at",
+                        __query_args
+                    )
                         .fetch_all(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
+                            sqlx::Error::Database(db_err)
+                                if db_err.is_unique_violation()
+                                    && db_err.table() == Some("entity_events") =>
+                            {
+                                EntityCreateError::ConcurrentModification
+                            }
+                            sqlx::Error::Database(db_err)
+                                if db_err.table() != Some("entity_events")
+                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+                            {
                                 EntityCreateError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -270,15 +469,21 @@ mod tests {
                             _ => EntityCreateError::Sqlx(e),
                         })?;
 
+                    if expected_events > 0 {
+                        if rows.len() != expected_events {
+                            return Err(EntityCreateError::ConcurrentModification);
+                        }
 
-                    let mut all_events: Vec<es_entity::EntityEvents<<#entity as es_entity::EsEntity>::Event>> = new_entities.into_iter().map(Self::convert_new).collect();
-                    let mut n_persisted = Self::extract_concurrent_modification(
-                        self.persist_events_batch(op, &mut all_events).await,
-                        EntityCreateError::ConcurrentModification,
-                    )?;
+                        let recorded_at = rows
+                            .first()
+                            .ok_or(sqlx::Error::RowNotFound)
+                            .and_then(|row| row.try_get("recorded_at"))?;
+                        for events in all_events.iter_mut() {
+                            events.mark_new_events_persisted_at(recorded_at);
+                        }
+                    }
 
-                    for events in all_events.into_iter() {
-                        let n_events = n_persisted.remove(events.id()).expect("n_events exists");
+                    for (events, n_events) in all_events.into_iter().zip(n_persisted) {
                         let entity = Self::hydrate_entity(events)?;
 
                         res.push(entity);

--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::write_error_classifier, options::*};
+use super::{
+    error_classifier::write_error_classifier,
+    events_write::{EventSource, EventsInsert, ForgettablePayloads},
+    options::*,
+};
 
 pub struct CreateAllFn<'a> {
     entity: &'a syn::Ident,
@@ -69,119 +73,59 @@ impl ToTokens for CreateAllFn<'_> {
             .columns
             .create_all_arg_collection(syn::parse_quote! { new_entity });
 
-        let ids_p = column_names.len() + 2;
-        let sequences_p = ids_p + 1;
-        let types_p = ids_p + 2;
-        let events_p = ids_p + 3;
-        let ctx_p = ids_p + 4;
-
         // Both inserts in one statement. The events insert joins the `new_rows`
         // CTE, which forces the index rows to be written first — so a duplicate
         // id surfaces as the index constraint violation rather than as a unique
         // violation on the events table.
+        let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+        let source = EventSource::BatchCte { cte: "new_rows" };
         let query = format!(
             "WITH new_rows AS (INSERT INTO {} (created_at, {}) \
             SELECT COALESCE($1, NOW()), unnested.{} \
             FROM UNNEST({}) \
-            AS unnested({}) RETURNING id) \
-            INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-            SELECT unnested.id, COALESCE($1, NOW()), unnested.sequence, unnested.event_type, unnested.event{} \
-            FROM UNNEST(${}, ${}::INT[], ${}::TEXT[], ${}::JSONB[]{}) \
-            AS unnested(id, sequence, event_type, event{}) \
-            JOIN new_rows ON new_rows.id = unnested.id \
-            RETURNING recorded_at",
+            AS unnested({}) RETURNING id) {}",
             table_name,
             column_names.join(", "),
             column_names.join(", unnested."),
             placeholders,
             column_names.join(", "),
-            self.events_table_name,
-            if self.event_ctx { ", context" } else { "" },
-            if self.event_ctx {
-                ", unnested.context"
-            } else {
-                ""
-            },
-            ids_p,
-            sequences_p,
-            types_p,
-            events_p,
-            if self.event_ctx {
-                format!(", ${ctx_p}::JSONB[]")
-            } else {
-                String::new()
-            },
-            if self.event_ctx { ", context" } else { "" },
+            events_insert.sql(&source, 1, column_names.len() + 2),
         );
 
         let classifier = write_error_classifier(create_error, self.events_table_name);
 
         let id_type = self.id;
-        let event_type = self.event;
 
-        let (ctx_var, ctx_extend, ctx_add) = if self.event_ctx {
-            (
-                quote! {
-                    let mut all_contexts: Vec<es_entity::ContextData> = Vec::new();
-                },
-                quote! {
-                    if let Some(contexts) = events.serialize_new_event_contexts() {
-                        all_contexts.extend(contexts);
-                    }
-                },
-                quote! {
-                    __query_args.add(if all_contexts.is_empty() {
-                        None
-                    } else {
-                        Some(&all_contexts)
-                    }).map_err(sqlx::Error::Encode)?;
-                },
-            )
-        } else {
-            (quote! {}, quote! {}, quote! {})
-        };
+        let batch_declarations = events_insert.batch_declarations(id_type);
+        let gather = events_insert.gather_batch(quote! { events }, quote! { id });
+        // The index columns are encoded first (their borrows on the new
+        // entities must end before those are consumed), so the event arrays
+        // follow — hence skipping the shared `now` argument here.
+        let event_arg_adds = events_insert
+            .arg_exprs(&source)
+            .into_iter()
+            .skip(1)
+            .map(|expr| quote! { __query_args.add(#expr).map_err(sqlx::Error::Encode)?; });
 
-        let (forgettable_vars, forgettable_extract, forgettable_insert) = if let Some(
-            forgettable_tbl,
-        ) =
-            self.forgettable_table_name
-        {
-            let payload_insert_query = format!(
-                "INSERT INTO {} (entity_id, sequence, payload) SELECT unnested.entity_id, unnested.sequence, unnested.payload FROM UNNEST($1, $2::INT[], $3::JSONB[]) AS unnested(entity_id, sequence, payload)",
-                forgettable_tbl
-            );
-            (
-                quote! {
-                    let mut payload_ids: Vec<&#id_type> = Vec::new();
-                    let mut payload_sequences: Vec<i32> = Vec::new();
-                    let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
-                },
-                quote! {
-                    for (idx, event_with_ctx) in events.iter_new_events().enumerate() {
-                        if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
-                            payload_ids.push(id);
-                            payload_sequences.push((offset + idx) as i32);
-                            payload_values.push(payload);
-                        }
-                    }
-                },
-                quote! {
-                    if !payload_sequences.is_empty() {
-                        Self::extract_concurrent_modification(
-                            sqlx::query(#payload_insert_query)
-                                .bind(&payload_ids)
-                                .bind(&payload_sequences)
-                                .bind(&payload_values)
-                                .execute(op.as_executor())
-                                .await,
-                            #create_error::ConcurrentModification,
-                        )?;
-                    }
-                },
-            )
-        } else {
-            (quote! {}, quote! {}, quote! {})
-        };
+        let payloads = self
+            .forgettable_table_name
+            .map(|table| ForgettablePayloads {
+                table,
+                id_type,
+                event_type: self.event,
+            });
+        let forgettable_vars = payloads
+            .as_ref()
+            .map(|p| p.batch_declarations())
+            .unwrap_or_default();
+        let forgettable_extract = payloads
+            .as_ref()
+            .map(|p| p.gather_batch(quote! { events }, quote! { id }))
+            .unwrap_or_default();
+        let forgettable_insert = payloads
+            .as_ref()
+            .map(|p| p.insert_batch(create_error))
+            .unwrap_or_default();
 
         #[cfg(feature = "instrument")]
         let (instrument_attr, error_recording) = {
@@ -259,35 +203,18 @@ impl ToTokens for CreateAllFn<'_> {
 
                     let mut all_events: Vec<es_entity::EntityEvents<<#entity as es_entity::EsEntity>::Event>> = new_entities.into_iter().map(Self::convert_new).collect();
 
-                    let mut all_ids: Vec<&#id_type> = Vec::new();
-                    let mut all_sequences: Vec<i32> = Vec::new();
-                    let mut all_types = Vec::new();
-                    let mut all_serialized = Vec::new();
+                    #batch_declarations
                     let mut n_persisted: Vec<usize> = Vec::new();
-                    #ctx_var
                     #forgettable_vars
 
                     for events in all_events.iter() {
                         let id = events.id();
-                        let offset = events.len_persisted() + 1;
-                        let types = events.new_event_types();
-                        let serialized = events.serialize_new_events();
-                        #ctx_extend
+                        #gather
                         #forgettable_extract
-
-                        let n_events = serialized.len();
-                        all_types.extend(types);
-                        all_serialized.extend(serialized);
-                        all_ids.extend(std::iter::repeat(id).take(n_events));
-                        all_sequences.extend((offset..).take(n_events).map(|i| i as i32));
-                        n_persisted.push(n_events);
+                        n_persisted.push(n_new);
                     }
 
-                    __query_args.add(&all_ids).map_err(sqlx::Error::Encode)?;
-                    __query_args.add(&all_sequences).map_err(sqlx::Error::Encode)?;
-                    __query_args.add(&all_types).map_err(sqlx::Error::Encode)?;
-                    __query_args.add(&all_serialized).map_err(sqlx::Error::Encode)?;
-                    #ctx_add
+                    #(#event_arg_adds)*
 
                     let expected_events = all_ids.len();
                     let rows = sqlx::query_with(#query, __query_args)
@@ -429,12 +356,12 @@ mod tests {
                         let types = events.new_event_types();
                         let serialized = events.serialize_new_events();
 
-                        let n_events = serialized.len();
+                        let n_new = serialized.len();
                         all_types.extend(types);
                         all_serialized.extend(serialized);
-                        all_ids.extend(std::iter::repeat(id).take(n_events));
-                        all_sequences.extend((offset..).take(n_events).map(|i| i as i32));
-                        n_persisted.push(n_events);
+                        all_ids.extend(std::iter::repeat(id).take(n_new));
+                        all_sequences.extend((offset..).take(n_new).map(|i| i as i32));
+                        n_persisted.push(n_new);
                     }
 
                     __query_args.add(&all_ids).map_err(sqlx::Error::Encode)?;

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -2,11 +2,16 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::options::*;
+use super::{error_classifier::write_error_classifier, options::*};
 
 pub struct CreateFn<'a> {
     entity: &'a syn::Ident,
+    id: &'a syn::Ident,
+    event: &'a syn::Ident,
     table_name: &'a str,
+    events_table_name: &'a str,
+    event_ctx: bool,
+    forgettable_table_name: Option<&'a str>,
     columns: &'a Columns,
     create_error: syn::Ident,
     nested_fn_names: Vec<syn::Ident>,
@@ -21,6 +26,11 @@ impl<'a> From<&'a RepositoryOptions> for CreateFn<'a> {
         Self {
             table_name: opts.table_name(),
             entity: opts.entity(),
+            id: opts.id(),
+            event: opts.event(),
+            events_table_name: opts.events_table_name(),
+            event_ctx: opts.event_context_enabled(),
+            forgettable_table_name: opts.forgettable_table_name(),
             create_error: opts.create_error(),
             nested_fn_names: opts
                 .all_nested()
@@ -58,15 +68,91 @@ impl ToTokens for CreateFn<'_> {
 
         let column_names = self.columns.insert_column_names();
         let placeholders = self.columns.insert_placeholders(0);
-        let args = self.columns.create_query_args();
+        let now_p = column_names.len() + 1;
+        let types_p = now_p + 1;
+        let events_p = now_p + 2;
+        let ctx_p = now_p + 3;
+        let arg_adds = self.columns.create_query_arg_adds();
 
+        // Index insert and events insert combined into one statement. The
+        // outer insert reads from the CTE, which forces the index row to be
+        // written first — preserving error precedence (a duplicate id
+        // surfaces as the index pkey violation, not as a unique violation on
+        // the events table) and providing the id without a second bind.
         let query = format!(
-            "INSERT INTO {} ({}, created_at) VALUES ({}, COALESCE(${}, NOW()))",
+            "WITH new_row AS (INSERT INTO {} ({}, created_at) VALUES ({}, COALESCE(${}, NOW())) RETURNING id) \
+            INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
+            SELECT new_row.id, COALESCE(${}, NOW()), ROW_NUMBER() OVER (), unnested.event_type, unnested.event{} \
+            FROM new_row CROSS JOIN UNNEST(${}::TEXT[], ${}::JSONB[]{}) AS unnested(event_type, event{}) \
+            RETURNING recorded_at",
             table_name,
             column_names.join(", "),
             placeholders,
-            column_names.len() + 1,
+            now_p,
+            self.events_table_name,
+            if self.event_ctx { ", context" } else { "" },
+            now_p,
+            if self.event_ctx {
+                ", unnested.context"
+            } else {
+                ""
+            },
+            types_p,
+            events_p,
+            if self.event_ctx {
+                format!(", ${ctx_p}::JSONB[]")
+            } else {
+                String::new()
+            },
+            if self.event_ctx { ", context" } else { "" },
         );
+
+        let classifier = write_error_classifier(create_error, self.events_table_name);
+
+        let ctx_add = if self.event_ctx {
+            quote! {
+                let contexts = events.serialize_new_event_contexts();
+                __query_args.add(contexts.as_deref() as Option<&[es_entity::ContextData]>).map_err(sqlx::Error::Encode)?;
+            }
+        } else {
+            quote! {}
+        };
+
+        let forgettable_code = if let Some(forgettable_tbl) = self.forgettable_table_name {
+            let id_type = &self.id;
+            let event_type = &self.event;
+            let payload_insert_query = format!(
+                "INSERT INTO {} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)",
+                forgettable_tbl
+            );
+            quote! {
+                let mut payload_sequences: Vec<i32> = Vec::new();
+                let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
+                let offset = events.len_persisted();
+                for (idx, event_with_ctx) in events.iter_new_events().enumerate() {
+                    if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
+                        payload_sequences.push((offset + 1 + idx) as i32);
+                        payload_values.push(payload);
+                    }
+                }
+                if !payload_sequences.is_empty() {
+                    let id = events.id();
+                    Self::extract_concurrent_modification(
+                        sqlx::query!(
+                            #payload_insert_query,
+                            id as &#id_type,
+                            &payload_sequences,
+                            &payload_values,
+                        )
+                        .execute(op.as_executor())
+                        .await,
+                        #create_error::ConcurrentModification,
+                    )?;
+                }
+            }
+        } else {
+            quote! {}
+        };
 
         #[cfg(feature = "instrument")]
         let (instrument_attr, record_id, error_recording) = {
@@ -147,32 +233,34 @@ impl ToTokens for CreateFn<'_> {
                 OP: es_entity::AtomicOperation
             {
                 let __result: Result<#entity, #create_error> = async {
+                    use es_entity::prelude::sqlx::{Arguments, Row};
+
                     #assignments
                     #record_id
 
-                     sqlx::query!(
-                         #query,
-                         #(#args)*
-                         op.maybe_now()
-                    )
-                    .execute(op.as_executor())
-                    .await
-                    .map_err(|e| match &e {
-                        sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
-                            #create_error::ConstraintViolation {
-                                column: Self::map_constraint_column(db_err.constraint()),
-                                value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                inner: e,
-                            }
-                        }
-                        _ => #create_error::Sqlx(e),
-                    })?;
+                    let mut __query_args = sqlx::postgres::PgArguments::default();
+                    #(#arg_adds)*
+                    __query_args.add(op.maybe_now()).map_err(sqlx::Error::Encode)?;
 
                     let mut events = Self::convert_new(new_entity);
-                    let n_events = Self::extract_concurrent_modification(
-                        self.persist_events(op, &mut events).await,
-                        #create_error::ConcurrentModification,
-                    )?;
+                    let events_types = events.new_event_types();
+                    let serialized_events = events.serialize_new_events();
+                    __query_args.add(&events_types).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(&serialized_events).map_err(sqlx::Error::Encode)?;
+                    #ctx_add
+
+                    let rows = sqlx::query_with(#query, __query_args)
+                        .fetch_all(op.as_executor())
+                        .await
+                        .map_err(#classifier)?;
+
+                    #forgettable_code
+
+                    let recorded_at = rows
+                        .first()
+                        .ok_or(sqlx::Error::RowNotFound)
+                        .and_then(|row| row.try_get("recorded_at"))?;
+                    let n_events = events.mark_new_events_persisted_at(recorded_at);
                     let #maybe_mut_entity = Self::hydrate_entity(events)?;
 
                     #(#nested)*
@@ -200,12 +288,18 @@ mod tests {
         let entity = Ident::new("Entity", Span::call_site());
         let create_error = syn::Ident::new("EntityCreateError", Span::call_site());
         let id = Ident::new("EntityId", Span::call_site());
+        let event = Ident::new("EntityEvent", Span::call_site());
         let mut columns = Columns::default();
         columns.set_id_column(&id);
 
         let create_fn = CreateFn {
             table_name: "entities",
             entity: &entity,
+            id: &id,
+            event: &event,
+            events_table_name: "entity_events",
+            event_ctx: false,
+            forgettable_table_name: None,
             create_error,
             columns: &columns,
             nested_fn_names: Vec::new(),
@@ -256,30 +350,51 @@ mod tests {
                 OP: es_entity::AtomicOperation
             {
                 let __result: Result<Entity, EntityCreateError> = async {
+                    use es_entity::prelude::sqlx::{Arguments, Row};
+
                     let id = &new_entity.id;
 
-                    sqlx::query!("INSERT INTO entities (id, created_at) VALUES ($1, COALESCE($2, NOW()))",
-                        id as &EntityId,
-                        op.maybe_now()
-                    )
-                    .execute(op.as_executor())
-                    .await
-                    .map_err(|e| match &e {
-                        sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
-                            EntityCreateError::ConstraintViolation {
-                                column: Self::map_constraint_column(db_err.constraint()),
-                                value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                inner: e,
-                            }
-                        }
-                        _ => EntityCreateError::Sqlx(e),
-                    })?;
+                    let mut __query_args = sqlx::postgres::PgArguments::default();
+                    __query_args.add(id as &EntityId).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(op.maybe_now()).map_err(sqlx::Error::Encode)?;
 
                     let mut events = Self::convert_new(new_entity);
-                    let n_events = Self::extract_concurrent_modification(
-                        self.persist_events(op, &mut events).await,
-                        EntityCreateError::ConcurrentModification,
-                    )?;
+                    let events_types = events.new_event_types();
+                    let serialized_events = events.serialize_new_events();
+                    __query_args.add(&events_types).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(&serialized_events).map_err(sqlx::Error::Encode)?;
+
+                    let rows = sqlx::query_with(
+                        "WITH new_row AS (INSERT INTO entities (id, created_at) VALUES ($1, COALESCE($2, NOW())) RETURNING id) INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) SELECT new_row.id, COALESCE($2, NOW()), ROW_NUMBER() OVER (), unnested.event_type, unnested.event FROM new_row CROSS JOIN UNNEST($3::TEXT[], $4::JSONB[]) AS unnested(event_type, event) RETURNING recorded_at",
+                        __query_args
+                    )
+                        .fetch_all(op.as_executor())
+                        .await
+                        .map_err(|e| match &e {
+                            sqlx::Error::Database(db_err)
+                                if db_err.is_unique_violation()
+                                    && db_err.table() == Some("entity_events") =>
+                            {
+                                EntityCreateError::ConcurrentModification
+                            }
+                            sqlx::Error::Database(db_err)
+                                if db_err.table() != Some("entity_events")
+                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+                            {
+                                EntityCreateError::ConstraintViolation {
+                                    column: Self::map_constraint_column(db_err.constraint()),
+                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
+                                    inner: e,
+                                }
+                            }
+                            _ => EntityCreateError::Sqlx(e),
+                        })?;
+
+                    let recorded_at = rows
+                        .first()
+                        .ok_or(sqlx::Error::RowNotFound)
+                        .and_then(|row| row.try_get("recorded_at"))?;
+                    let n_events = events.mark_new_events_persisted_at(recorded_at);
                     let entity = Self::hydrate_entity(events)?;
 
                     Ok(entity)
@@ -296,16 +411,23 @@ mod tests {
     fn create_fn_with_columns() {
         let entity = Ident::new("Entity", Span::call_site());
         let create_error = syn::Ident::new("EntityCreateError", Span::call_site());
+        let id = Ident::new("EntityId", Span::call_site());
+        let event = Ident::new("EntityEvent", Span::call_site());
 
         use darling::FromMeta;
         let input: syn::Meta =
             syn::parse_quote!(columns(name(ty = "String", create(accessor = "name()"))));
         let mut columns = Columns::from_meta(&input).expect("Failed to parse Fields");
-        columns.set_id_column(&Ident::new("EntityId", Span::call_site()));
+        columns.set_id_column(&id);
 
         let create_fn = CreateFn {
             table_name: "entities",
             entity: &entity,
+            id: &id,
+            event: &event,
+            events_table_name: "entity_events",
+            event_ctx: false,
+            forgettable_table_name: None,
             create_error,
             columns: &columns,
             nested_fn_names: Vec::new(),
@@ -356,32 +478,53 @@ mod tests {
                 OP: es_entity::AtomicOperation
             {
                 let __result: Result<Entity, EntityCreateError> = async {
+                    use es_entity::prelude::sqlx::{Arguments, Row};
+
                     let id = &new_entity.id;
                     let name = &new_entity.name();
 
-                    sqlx::query!("INSERT INTO entities (id, name, created_at) VALUES ($1, $2, COALESCE($3, NOW()))",
-                        id as &EntityId,
-                        name as &String,
-                        op.maybe_now()
-                    )
-                    .execute(op.as_executor())
-                    .await
-                    .map_err(|e| match &e {
-                        sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
-                            EntityCreateError::ConstraintViolation {
-                                column: Self::map_constraint_column(db_err.constraint()),
-                                value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                inner: e,
-                            }
-                        }
-                        _ => EntityCreateError::Sqlx(e),
-                    })?;
+                    let mut __query_args = sqlx::postgres::PgArguments::default();
+                    __query_args.add(id as &EntityId).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(name as &String).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(op.maybe_now()).map_err(sqlx::Error::Encode)?;
 
                     let mut events = Self::convert_new(new_entity);
-                    let n_events = Self::extract_concurrent_modification(
-                        self.persist_events(op, &mut events).await,
-                        EntityCreateError::ConcurrentModification,
-                    )?;
+                    let events_types = events.new_event_types();
+                    let serialized_events = events.serialize_new_events();
+                    __query_args.add(&events_types).map_err(sqlx::Error::Encode)?;
+                    __query_args.add(&serialized_events).map_err(sqlx::Error::Encode)?;
+
+                    let rows = sqlx::query_with(
+                        "WITH new_row AS (INSERT INTO entities (id, name, created_at) VALUES ($1, $2, COALESCE($3, NOW())) RETURNING id) INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) SELECT new_row.id, COALESCE($3, NOW()), ROW_NUMBER() OVER (), unnested.event_type, unnested.event FROM new_row CROSS JOIN UNNEST($4::TEXT[], $5::JSONB[]) AS unnested(event_type, event) RETURNING recorded_at",
+                        __query_args
+                    )
+                        .fetch_all(op.as_executor())
+                        .await
+                        .map_err(|e| match &e {
+                            sqlx::Error::Database(db_err)
+                                if db_err.is_unique_violation()
+                                    && db_err.table() == Some("entity_events") =>
+                            {
+                                EntityCreateError::ConcurrentModification
+                            }
+                            sqlx::Error::Database(db_err)
+                                if db_err.table() != Some("entity_events")
+                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+                            {
+                                EntityCreateError::ConstraintViolation {
+                                    column: Self::map_constraint_column(db_err.constraint()),
+                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
+                                    inner: e,
+                                }
+                            }
+                            _ => EntityCreateError::Sqlx(e),
+                        })?;
+
+                    let recorded_at = rows
+                        .first()
+                        .ok_or(sqlx::Error::RowNotFound)
+                        .and_then(|row| row.try_get("recorded_at"))?;
+                    let n_events = events.mark_new_events_persisted_at(recorded_at);
                     let entity = Self::hydrate_entity(events)?;
 
                     Ok(entity)

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::write_error_classifier, options::*};
+use super::{
+    error_classifier::write_error_classifier,
+    events_write::{EventSource, EventsInsert, ForgettablePayloads},
+    options::*,
+};
 
 pub struct CreateFn<'a> {
     entity: &'a syn::Ident,
@@ -68,10 +72,6 @@ impl ToTokens for CreateFn<'_> {
 
         let column_names = self.columns.insert_column_names();
         let placeholders = self.columns.insert_placeholders(0);
-        let now_p = column_names.len() + 1;
-        let types_p = now_p + 1;
-        let events_p = now_p + 2;
-        let ctx_p = now_p + 3;
         let arg_adds = self.columns.create_query_arg_adds();
 
         // Index insert and events insert combined into one statement. The
@@ -79,79 +79,54 @@ impl ToTokens for CreateFn<'_> {
         // written first — preserving error precedence (a duplicate id
         // surfaces as the index pkey violation, not as a unique violation on
         // the events table) and providing the id without a second bind.
+        //
+        // A brand-new entity has no persisted events, so sequences start at 1
+        // and no offset parameter is needed.
+        let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+        let now_p = column_names.len() + 1;
+        let source = EventSource::PerEntityCte {
+            cte: "new_row",
+            offset_param: None,
+        };
         let query = format!(
-            "WITH new_row AS (INSERT INTO {} ({}, created_at) VALUES ({}, COALESCE(${}, NOW())) RETURNING id) \
-            INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-            SELECT new_row.id, COALESCE(${}, NOW()), ROW_NUMBER() OVER (), unnested.event_type, unnested.event{} \
-            FROM new_row CROSS JOIN UNNEST(${}::TEXT[], ${}::JSONB[]{}) AS unnested(event_type, event{}) \
-            RETURNING recorded_at",
+            "WITH new_row AS (INSERT INTO {} ({}, created_at) VALUES ({}, COALESCE(${}, NOW())) RETURNING id) {}",
             table_name,
             column_names.join(", "),
             placeholders,
             now_p,
-            self.events_table_name,
-            if self.event_ctx { ", context" } else { "" },
-            now_p,
-            if self.event_ctx {
-                ", unnested.context"
-            } else {
-                ""
-            },
-            types_p,
-            events_p,
-            if self.event_ctx {
-                format!(", ${ctx_p}::JSONB[]")
-            } else {
-                String::new()
-            },
-            if self.event_ctx { ", context" } else { "" },
+            events_insert.sql(&source, now_p, now_p + 1),
         );
 
         let classifier = write_error_classifier(create_error, self.events_table_name);
 
-        let ctx_add = if self.event_ctx {
-            quote! {
-                let contexts = events.serialize_new_event_contexts();
-                __query_args.add(contexts.as_deref() as Option<&[es_entity::ContextData]>).map_err(sqlx::Error::Encode)?;
-            }
+        // The event arrays are encoded after the index columns, whose borrows
+        // on the new entity must end before it is consumed into events.
+        let event_arg_adds = events_insert
+            .arg_exprs(&source)
+            .into_iter()
+            .skip(1)
+            .map(|expr| quote! { __query_args.add(#expr).map_err(sqlx::Error::Encode)?; });
+        let ctx_var = if self.event_ctx {
+            quote! { let contexts = events.serialize_new_event_contexts(); }
         } else {
             quote! {}
         };
 
-        let forgettable_code = if let Some(forgettable_tbl) = self.forgettable_table_name {
-            let id_type = &self.id;
-            let event_type = &self.event;
-            let payload_insert_query = format!(
-                "INSERT INTO {} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)",
-                forgettable_tbl
-            );
-            quote! {
-                let mut payload_sequences: Vec<i32> = Vec::new();
-                let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
-                let offset = events.len_persisted();
-                for (idx, event_with_ctx) in events.iter_new_events().enumerate() {
-                    if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
-                        payload_sequences.push((offset + 1 + idx) as i32);
-                        payload_values.push(payload);
-                    }
+        let forgettable_code = match self.forgettable_table_name {
+            Some(table) => {
+                let payloads = ForgettablePayloads {
+                    table,
+                    id_type: self.id,
+                    event_type: self.event,
                 }
-                if !payload_sequences.is_empty() {
+                .insert_per_entity(quote! { events }, create_error);
+                quote! {
+                    let offset = events.len_persisted();
                     let id = events.id();
-                    Self::extract_concurrent_modification(
-                        sqlx::query!(
-                            #payload_insert_query,
-                            id as &#id_type,
-                            &payload_sequences,
-                            &payload_values,
-                        )
-                        .execute(op.as_executor())
-                        .await,
-                        #create_error::ConcurrentModification,
-                    )?;
+                    #payloads
                 }
             }
-        } else {
-            quote! {}
+            None => quote! {},
         };
 
         #[cfg(feature = "instrument")]
@@ -245,9 +220,8 @@ impl ToTokens for CreateFn<'_> {
                     let mut events = Self::convert_new(new_entity);
                     let events_types = events.new_event_types();
                     let serialized_events = events.serialize_new_events();
-                    __query_args.add(&events_types).map_err(sqlx::Error::Encode)?;
-                    __query_args.add(&serialized_events).map_err(sqlx::Error::Encode)?;
-                    #ctx_add
+                    #ctx_var
+                    #(#event_arg_adds)*
 
                     let rows = sqlx::query_with(#query, __query_args)
                         .fetch_all(op.as_executor())

--- a/es-entity-macros/src/repo/delete_fn.rs
+++ b/es-entity-macros/src/repo/delete_fn.rs
@@ -2,13 +2,16 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::options::*;
+use super::{error_classifier::write_error_classifier, options::*};
 
 pub struct DeleteFn<'a> {
     id: &'a syn::Ident,
+    event: &'a syn::Ident,
     modify_error: syn::Ident,
     entity: &'a syn::Ident,
     table_name: &'a str,
+    events_table_name: &'a str,
+    event_ctx: bool,
     columns: &'a Columns,
     delete_option: &'a DeleteOption,
     nested_delete_fn_names: Vec<syn::Ident>,
@@ -22,10 +25,13 @@ impl<'a> DeleteFn<'a> {
     pub fn from(opts: &'a RepositoryOptions) -> Self {
         Self {
             id: opts.id(),
+            event: opts.event(),
             entity: opts.entity(),
             modify_error: opts.modify_error(),
             columns: &opts.columns,
             table_name: opts.table_name(),
+            events_table_name: opts.events_table_name(),
+            event_ctx: opts.event_context_enabled(),
             delete_option: &opts.delete,
             nested_delete_fn_names: opts
                 .all_nested()
@@ -60,13 +66,58 @@ impl ToTokens for DeleteFn<'_> {
             .columns
             .variable_assignments_for_delete(syn::parse_quote! { entity });
         let column_updates = self.columns.sql_updates_for_delete();
+        let args = self.columns.update_query_args_for_delete();
+
+        let now_p = args.len() + 1;
+        let offset_p = now_p + 1;
+        let types_p = now_p + 2;
+        let events_p = now_p + 3;
+        let ctx_p = now_p + 4;
+
+        // The soft-delete flag and the entity's staged events go out as one
+        // statement; the events insert reads from the CTE so the index write
+        // is ordered first. `delete` may have no staged events at all, in
+        // which case the UNNEST is empty and only the CTE does work.
         let query = format!(
-            "UPDATE {} SET {}{}deleted = TRUE WHERE id = $1",
+            "WITH updated AS (UPDATE {} SET {}{}deleted = TRUE WHERE id = $1 RETURNING id) \
+            INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
+            SELECT updated.id, COALESCE(${}, NOW()), ROW_NUMBER() OVER () + ${}, unnested.event_type, unnested.event{} \
+            FROM updated CROSS JOIN UNNEST(${}::TEXT[], ${}::JSONB[]{}) AS unnested(event_type, event{}) \
+            RETURNING recorded_at",
             self.table_name,
             column_updates,
-            if column_updates.is_empty() { "" } else { ", " }
+            if column_updates.is_empty() { "" } else { ", " },
+            self.events_table_name,
+            if self.event_ctx { ", context" } else { "" },
+            now_p,
+            offset_p,
+            if self.event_ctx {
+                ", unnested.context"
+            } else {
+                ""
+            },
+            types_p,
+            events_p,
+            if self.event_ctx {
+                format!(", ${ctx_p}::JSONB[]")
+            } else {
+                String::new()
+            },
+            if self.event_ctx { ", context" } else { "" },
         );
-        let args = self.columns.update_query_args_for_delete();
+
+        let classifier = write_error_classifier(modify_error, self.events_table_name);
+
+        let (ctx_var, ctx_arg) = if self.event_ctx {
+            (
+                quote! { let contexts = entity.events().serialize_new_event_contexts(); },
+                quote! {
+                    , contexts.as_deref() as Option<&[es_entity::ContextData]>
+                },
+            )
+        } else {
+            (quote! {}, quote! {})
+        };
 
         #[cfg(feature = "instrument")]
         let (instrument_attr, record_id, error_recording) = {
@@ -101,6 +152,10 @@ impl ToTokens for DeleteFn<'_> {
         };
 
         let id_type = self.id;
+        let event_type = self.event;
+        // The payload purge runs *before* the combined statement: staged
+        // events are persisted after it, so — as before — a payload staged but
+        // not yet persisted at delete time survives the delete.
         let forget_payloads = if let Some(forgettable_tbl) = self.forgettable_table_name {
             let forget_query = format!("DELETE FROM {} WHERE entity_id = $1", forgettable_tbl);
             quote! {
@@ -110,6 +165,38 @@ impl ToTokens for DeleteFn<'_> {
                 )
                 .execute(op.as_executor())
                 .await?;
+            }
+        } else {
+            quote! {}
+        };
+
+        let staged_payload_insert = if let Some(forgettable_tbl) = self.forgettable_table_name {
+            let payload_insert_query = format!(
+                "INSERT INTO {} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)",
+                forgettable_tbl
+            );
+            quote! {
+                let mut payload_sequences: Vec<i32> = Vec::new();
+                let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
+                for (idx, event_with_ctx) in entity.events().iter_new_events().enumerate() {
+                    if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
+                        payload_sequences.push((offset + 1 + idx) as i32);
+                        payload_values.push(payload);
+                    }
+                }
+                if !payload_sequences.is_empty() {
+                    Self::extract_concurrent_modification(
+                        sqlx::query!(
+                            #payload_insert_query,
+                            id as &#id_type,
+                            &payload_sequences,
+                            &payload_values,
+                        )
+                        .execute(op.as_executor())
+                        .await,
+                        #modify_error::ConcurrentModification,
+                    )?;
+                }
             }
         } else {
             quote! {}
@@ -139,38 +226,39 @@ impl ToTokens for DeleteFn<'_> {
                     #assignments
                     #record_id
 
-                    sqlx::query!(
-                        #query,
-                        #(#args),*
-                    )
-                        .execute(op.as_executor())
-                        .await
-                        .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
-                                #modify_error::ConstraintViolation {
-                                    column: Self::map_constraint_column(db_err.constraint()),
-                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            _ => #modify_error::Sqlx(e),
-                        })?;
-
                     #forget_payloads
 
-                    let new_events = {
-                        let events = Self::extract_events(&mut entity);
-                        events.any_new()
-                    };
+                    let new_events = entity.events().any_new();
+                    let offset = entity.events().len_persisted();
+                    let events_types = entity.events().new_event_types();
+                    let serialized_events = entity.events().serialize_new_events();
+                    #ctx_var
+
+                    let rows = sqlx::query!(
+                        #query,
+                        #(#args,)*
+                        op.maybe_now(),
+                        offset as i32,
+                        &events_types,
+                        &serialized_events
+                        #ctx_arg
+                    )
+                        .fetch_all(op.as_executor())
+                        .await
+                        .map_err(#classifier)?;
+
+                    #staged_payload_insert
 
                     if new_events {
-                        let n_events = {
-                            let events = Self::extract_events(&mut entity);
-                            Self::extract_concurrent_modification(
-                                self.persist_events(op, events).await,
-                                #modify_error::ConcurrentModification,
-                            )?
-                        };
+                        // No row means the CTE's UPDATE matched nothing — the
+                        // entity was hard-deleted underneath us. That is a lost
+                        // race, not an internal error.
+                        let recorded_at = rows
+                            .first()
+                            .map(|row| row.recorded_at)
+                            .ok_or(#modify_error::ConcurrentModification)?;
+                        let n_events = Self::extract_events(&mut entity)
+                            .mark_new_events_persisted_at(recorded_at);
 
                         #post_persist_check
                     }
@@ -198,11 +286,15 @@ mod tests {
         let mut columns = Columns::default();
         columns.set_id_column(&id);
 
+        let event = Ident::new("EntityEvent", Span::call_site());
         let delete_fn = DeleteFn {
             id: &id,
+            event: &event,
             entity: &entity,
             modify_error: syn::Ident::new("EntityModifyError", Span::call_site()),
             table_name: "entities",
+            events_table_name: "entity_events",
+            event_ctx: false,
             columns: &columns,
             delete_option: &DeleteOption::Soft,
             nested_delete_fn_names: Vec::new(),
@@ -237,14 +329,32 @@ mod tests {
                 let __result: Result<(), EntityModifyError> = async {
                     let id = &entity.id;
 
-                    sqlx::query!(
-                        "UPDATE entities SET deleted = TRUE WHERE id = $1",
-                        id as &EntityId
+                    let new_events = entity.events().any_new();
+                    let offset = entity.events().len_persisted();
+                    let events_types = entity.events().new_event_types();
+                    let serialized_events = entity.events().serialize_new_events();
+
+                    let rows = sqlx::query!(
+                        "WITH updated AS (UPDATE entities SET deleted = TRUE WHERE id = $1 RETURNING id) INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) SELECT updated.id, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM updated CROSS JOIN UNNEST($4::TEXT[], $5::JSONB[]) AS unnested(event_type, event) RETURNING recorded_at",
+                        id as &EntityId,
+                        op.maybe_now(),
+                        offset as i32,
+                        &events_types,
+                        &serialized_events
                     )
-                        .execute(op.as_executor())
+                        .fetch_all(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
+                            sqlx::Error::Database(db_err)
+                                if db_err.is_unique_violation()
+                                    && db_err.table() == Some("entity_events") =>
+                            {
+                                EntityModifyError::ConcurrentModification
+                            }
+                            sqlx::Error::Database(db_err)
+                                if db_err.table() != Some("entity_events")
+                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+                            {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -254,19 +364,13 @@ mod tests {
                             _ => EntityModifyError::Sqlx(e),
                         })?;
 
-                    let new_events = {
-                        let events = Self::extract_events(&mut entity);
-                        events.any_new()
-                    };
-
                     if new_events {
-                        let n_events = {
-                            let events = Self::extract_events(&mut entity);
-                            Self::extract_concurrent_modification(
-                                self.persist_events(op, events).await,
-                                EntityModifyError::ConcurrentModification,
-                            )?
-                        };
+                        let recorded_at = rows
+                            .first()
+                            .map(|row| row.recorded_at)
+                            .ok_or(EntityModifyError::ConcurrentModification)?;
+                        let n_events = Self::extract_events(&mut entity)
+                            .mark_new_events_persisted_at(recorded_at);
                     }
 
                     Ok(())
@@ -292,11 +396,15 @@ mod tests {
             )],
         );
 
+        let event = Ident::new("EntityEvent", Span::call_site());
         let delete_fn = DeleteFn {
             id: &id,
+            event: &event,
             entity: &entity,
             modify_error: syn::Ident::new("EntityModifyError", Span::call_site()),
             table_name: "entities",
+            events_table_name: "entity_events",
+            event_ctx: false,
             columns: &columns,
             delete_option: &DeleteOption::Soft,
             nested_delete_fn_names: Vec::new(),
@@ -332,15 +440,33 @@ mod tests {
                     let id = &entity.id;
                     let name = &entity.name;
 
-                    sqlx::query!(
-                        "UPDATE entities SET name = $2, deleted = TRUE WHERE id = $1",
+                    let new_events = entity.events().any_new();
+                    let offset = entity.events().len_persisted();
+                    let events_types = entity.events().new_event_types();
+                    let serialized_events = entity.events().serialize_new_events();
+
+                    let rows = sqlx::query!(
+                        "WITH updated AS (UPDATE entities SET name = $2, deleted = TRUE WHERE id = $1 RETURNING id) INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) SELECT updated.id, COALESCE($3, NOW()), ROW_NUMBER() OVER () + $4, unnested.event_type, unnested.event FROM updated CROSS JOIN UNNEST($5::TEXT[], $6::JSONB[]) AS unnested(event_type, event) RETURNING recorded_at",
                         id as &EntityId,
-                        name as &String
+                        name as &String,
+                        op.maybe_now(),
+                        offset as i32,
+                        &events_types,
+                        &serialized_events
                     )
-                        .execute(op.as_executor())
+                        .fetch_all(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
+                            sqlx::Error::Database(db_err)
+                                if db_err.is_unique_violation()
+                                    && db_err.table() == Some("entity_events") =>
+                            {
+                                EntityModifyError::ConcurrentModification
+                            }
+                            sqlx::Error::Database(db_err)
+                                if db_err.table() != Some("entity_events")
+                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+                            {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -350,19 +476,13 @@ mod tests {
                             _ => EntityModifyError::Sqlx(e),
                         })?;
 
-                    let new_events = {
-                        let events = Self::extract_events(&mut entity);
-                        events.any_new()
-                    };
-
                     if new_events {
-                        let n_events = {
-                            let events = Self::extract_events(&mut entity);
-                            Self::extract_concurrent_modification(
-                                self.persist_events(op, events).await,
-                                EntityModifyError::ConcurrentModification,
-                            )?
-                        };
+                        let recorded_at = rows
+                            .first()
+                            .map(|row| row.recorded_at)
+                            .ok_or(EntityModifyError::ConcurrentModification)?;
+                        let n_events = Self::extract_events(&mut entity)
+                            .mark_new_events_persisted_at(recorded_at);
                     }
 
                     Ok(())
@@ -382,11 +502,15 @@ mod tests {
         let mut columns = Columns::default();
         columns.set_id_column(&id);
 
+        let event = Ident::new("EntityEvent", Span::call_site());
         let delete_fn = DeleteFn {
             id: &id,
+            event: &event,
             entity: &entity,
             modify_error: syn::Ident::new("EntityModifyError", Span::call_site()),
             table_name: "entities",
+            events_table_name: "entity_events",
+            event_ctx: false,
             columns: &columns,
             delete_option: &DeleteOption::Soft,
             nested_delete_fn_names: Vec::new(),
@@ -422,13 +546,38 @@ mod tests {
                     let id = &entity.id;
 
                     sqlx::query!(
-                        "UPDATE entities SET deleted = TRUE WHERE id = $1",
+                        "DELETE FROM entities_forgettable_payloads WHERE entity_id = $1",
                         id as &EntityId
                     )
-                        .execute(op.as_executor())
+                    .execute(op.as_executor())
+                    .await?;
+
+                    let new_events = entity.events().any_new();
+                    let offset = entity.events().len_persisted();
+                    let events_types = entity.events().new_event_types();
+                    let serialized_events = entity.events().serialize_new_events();
+
+                    let rows = sqlx::query!(
+                        "WITH updated AS (UPDATE entities SET deleted = TRUE WHERE id = $1 RETURNING id) INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) SELECT updated.id, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM updated CROSS JOIN UNNEST($4::TEXT[], $5::JSONB[]) AS unnested(event_type, event) RETURNING recorded_at",
+                        id as &EntityId,
+                        op.maybe_now(),
+                        offset as i32,
+                        &events_types,
+                        &serialized_events
+                    )
+                        .fetch_all(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
+                            sqlx::Error::Database(db_err)
+                                if db_err.is_unique_violation()
+                                    && db_err.table() == Some("entity_events") =>
+                            {
+                                EntityModifyError::ConcurrentModification
+                            }
+                            sqlx::Error::Database(db_err)
+                                if db_err.table() != Some("entity_events")
+                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+                            {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -438,26 +587,35 @@ mod tests {
                             _ => EntityModifyError::Sqlx(e),
                         })?;
 
-                    sqlx::query!(
-                        "DELETE FROM entities_forgettable_payloads WHERE entity_id = $1",
-                        id as &EntityId
-                    )
-                    .execute(op.as_executor())
-                    .await?;
-
-                    let new_events = {
-                        let events = Self::extract_events(&mut entity);
-                        events.any_new()
-                    };
+                    let mut payload_sequences: Vec<i32> = Vec::new();
+                    let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
+                    for (idx, event_with_ctx) in entity.events().iter_new_events().enumerate() {
+                        if let Some(payload) = EntityEvent::extract_forgettable_payloads(&event_with_ctx.event) {
+                            payload_sequences.push((offset + 1 + idx) as i32);
+                            payload_values.push(payload);
+                        }
+                    }
+                    if !payload_sequences.is_empty() {
+                        Self::extract_concurrent_modification(
+                            sqlx::query!(
+                                "INSERT INTO entities_forgettable_payloads (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)",
+                                id as &EntityId,
+                                &payload_sequences,
+                                &payload_values,
+                            )
+                            .execute(op.as_executor())
+                            .await,
+                            EntityModifyError::ConcurrentModification,
+                        )?;
+                    }
 
                     if new_events {
-                        let n_events = {
-                            let events = Self::extract_events(&mut entity);
-                            Self::extract_concurrent_modification(
-                                self.persist_events(op, events).await,
-                                EntityModifyError::ConcurrentModification,
-                            )?
-                        };
+                        let recorded_at = rows
+                            .first()
+                            .map(|row| row.recorded_at)
+                            .ok_or(EntityModifyError::ConcurrentModification)?;
+                        let n_events = Self::extract_events(&mut entity)
+                            .mark_new_events_persisted_at(recorded_at);
                     }
 
                     Ok(())

--- a/es-entity-macros/src/repo/delete_fn.rs
+++ b/es-entity-macros/src/repo/delete_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::write_error_classifier, options::*};
+use super::{
+    error_classifier::write_error_classifier,
+    events_write::{EventSource, EventsInsert, ForgettablePayloads},
+    options::*,
+};
 
 pub struct DeleteFn<'a> {
     id: &'a syn::Ident,
@@ -68,56 +72,27 @@ impl ToTokens for DeleteFn<'_> {
         let column_updates = self.columns.sql_updates_for_delete();
         let args = self.columns.update_query_args_for_delete();
 
-        let now_p = args.len() + 1;
-        let offset_p = now_p + 1;
-        let types_p = now_p + 2;
-        let events_p = now_p + 3;
-        let ctx_p = now_p + 4;
-
         // The soft-delete flag and the entity's staged events go out as one
         // statement; the events insert reads from the CTE so the index write
         // is ordered first. `delete` may have no staged events at all, in
         // which case the UNNEST is empty and only the CTE does work.
+        let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+        let now_p = args.len() + 1;
+        let source = EventSource::PerEntityCte {
+            cte: "updated",
+            offset_param: Some(now_p + 1),
+        };
         let query = format!(
-            "WITH updated AS (UPDATE {} SET {}{}deleted = TRUE WHERE id = $1 RETURNING id) \
-            INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-            SELECT updated.id, COALESCE(${}, NOW()), ROW_NUMBER() OVER () + ${}, unnested.event_type, unnested.event{} \
-            FROM updated CROSS JOIN UNNEST(${}::TEXT[], ${}::JSONB[]{}) AS unnested(event_type, event{}) \
-            RETURNING recorded_at",
+            "WITH updated AS (UPDATE {} SET {}{}deleted = TRUE WHERE id = $1 RETURNING id) {}",
             self.table_name,
             column_updates,
             if column_updates.is_empty() { "" } else { ", " },
-            self.events_table_name,
-            if self.event_ctx { ", context" } else { "" },
-            now_p,
-            offset_p,
-            if self.event_ctx {
-                ", unnested.context"
-            } else {
-                ""
-            },
-            types_p,
-            events_p,
-            if self.event_ctx {
-                format!(", ${ctx_p}::JSONB[]")
-            } else {
-                String::new()
-            },
-            if self.event_ctx { ", context" } else { "" },
+            events_insert.sql(&source, now_p, now_p + 2),
         );
 
         let classifier = write_error_classifier(modify_error, self.events_table_name);
-
-        let (ctx_var, ctx_arg) = if self.event_ctx {
-            (
-                quote! { let contexts = entity.events().serialize_new_event_contexts(); },
-                quote! {
-                    , contexts.as_deref() as Option<&[es_entity::ContextData]>
-                },
-            )
-        } else {
-            (quote! {}, quote! {})
-        };
+        let gather = events_insert.gather_per_entity(quote! { entity.events() });
+        let event_args = events_insert.arg_exprs(&source);
 
         #[cfg(feature = "instrument")]
         let (instrument_attr, record_id, error_recording) = {
@@ -170,36 +145,14 @@ impl ToTokens for DeleteFn<'_> {
             quote! {}
         };
 
-        let staged_payload_insert = if let Some(forgettable_tbl) = self.forgettable_table_name {
-            let payload_insert_query = format!(
-                "INSERT INTO {} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)",
-                forgettable_tbl
-            );
-            quote! {
-                let mut payload_sequences: Vec<i32> = Vec::new();
-                let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
-                for (idx, event_with_ctx) in entity.events().iter_new_events().enumerate() {
-                    if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
-                        payload_sequences.push((offset + 1 + idx) as i32);
-                        payload_values.push(payload);
-                    }
-                }
-                if !payload_sequences.is_empty() {
-                    Self::extract_concurrent_modification(
-                        sqlx::query!(
-                            #payload_insert_query,
-                            id as &#id_type,
-                            &payload_sequences,
-                            &payload_values,
-                        )
-                        .execute(op.as_executor())
-                        .await,
-                        #modify_error::ConcurrentModification,
-                    )?;
-                }
+        let staged_payload_insert = match self.forgettable_table_name {
+            Some(table) => ForgettablePayloads {
+                table,
+                id_type,
+                event_type,
             }
-        } else {
-            quote! {}
+            .insert_per_entity(quote! { entity.events() }, modify_error),
+            None => quote! {},
         };
 
         tokens.append_all(quote! {
@@ -229,19 +182,12 @@ impl ToTokens for DeleteFn<'_> {
                     #forget_payloads
 
                     let new_events = entity.events().any_new();
-                    let offset = entity.events().len_persisted();
-                    let events_types = entity.events().new_event_types();
-                    let serialized_events = entity.events().serialize_new_events();
-                    #ctx_var
+                    #gather
 
                     let rows = sqlx::query!(
                         #query,
                         #(#args,)*
-                        op.maybe_now(),
-                        offset as i32,
-                        &events_types,
-                        &serialized_events
-                        #ctx_arg
+                        #(#event_args),*
                     )
                         .fetch_all(op.as_executor())
                         .await

--- a/es-entity-macros/src/repo/error_classifier.rs
+++ b/es-entity-macros/src/repo/error_classifier.rs
@@ -1,0 +1,42 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// The `map_err` closure for a combined index+events write statement.
+///
+/// A single statement can fail from either table, so classification switches
+/// on `DatabaseError::table()` instead of on which statement failed:
+///
+/// - unique violation on the events table → `ConcurrentModification`
+/// - classified violation elsewhere (the index table) → `ConstraintViolation`
+/// - anything else (including events-table FK violations) → `Sqlx`
+///
+/// The events table name may be schema-qualified in the repo options;
+/// Postgres reports the bare table name in errors, so only the last path
+/// component is compared.
+pub fn write_error_classifier(error: &syn::Ident, events_table_name: &str) -> TokenStream {
+    let events_table = events_table_name
+        .rsplit('.')
+        .next()
+        .expect("rsplit yields at least one element");
+    quote! {
+        |e| match &e {
+            sqlx::Error::Database(db_err)
+                if db_err.is_unique_violation()
+                    && db_err.table() == Some(#events_table) =>
+            {
+                #error::ConcurrentModification
+            }
+            sqlx::Error::Database(db_err)
+                if db_err.table() != Some(#events_table)
+                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+            {
+                #error::ConstraintViolation {
+                    column: Self::map_constraint_column(db_err.constraint()),
+                    value: es_entity::extract_constraint_value(db_err.as_ref()),
+                    inner: e,
+                }
+            }
+            _ => #error::Sqlx(e),
+        }
+    }
+}

--- a/es-entity-macros/src/repo/error_classifier.rs
+++ b/es-entity-macros/src/repo/error_classifier.rs
@@ -1,5 +1,62 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{TokenStreamExt, quote};
+
+/// Postgres reports the bare table name in errors, so a schema-qualified
+/// events table from the repo options is reduced to its last path component
+/// before being compared.
+fn bare_table_name(events_table_name: &str) -> &str {
+    events_table_name
+        .rsplit('.')
+        .next()
+        .expect("rsplit yields at least one element")
+}
+
+/// The `extract_concurrent_modification` helper, which turns a unique
+/// violation into the caller's `ConcurrentModification` variant.
+///
+/// It is emitted separately from `persist_events` because the combined write
+/// statements classify their own errors, yet the follow-up forgettable
+/// payload inserts (which are plain statements) still need it.
+pub fn extract_concurrent_modification_fn() -> TokenStream {
+    let mut tokens = TokenStream::new();
+    tokens.append_all(quote! {
+        fn extract_concurrent_modification<T, __EsErr: From<sqlx::Error>>(
+            res: Result<T, sqlx::Error>,
+            concurrent_modification: __EsErr,
+        ) -> Result<T, __EsErr> {
+            match res {
+                Ok(v) => Ok(v),
+                Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
+                    Err(concurrent_modification)
+                }
+                Err(e) => Err(__EsErr::from(e)),
+            }
+        }
+    });
+    tokens
+}
+
+/// The `map_err` closure for a combined write statement whose error type has
+/// no `ConstraintViolation` variant (e.g. the generated `{Entity}ForgetError`).
+/// Only the events-table unique violation is distinguished; everything else
+/// stays `Sqlx`.
+pub fn concurrent_modification_classifier(
+    error: &syn::Ident,
+    events_table_name: &str,
+) -> TokenStream {
+    let events_table = bare_table_name(events_table_name);
+    quote! {
+        |e| match &e {
+            sqlx::Error::Database(db_err)
+                if db_err.is_unique_violation()
+                    && db_err.table() == Some(#events_table) =>
+            {
+                #error::ConcurrentModification
+            }
+            _ => #error::Sqlx(e),
+        }
+    }
+}
 
 /// The `map_err` closure for a combined index+events write statement.
 ///
@@ -14,10 +71,7 @@ use quote::quote;
 /// Postgres reports the bare table name in errors, so only the last path
 /// component is compared.
 pub fn write_error_classifier(error: &syn::Ident, events_table_name: &str) -> TokenStream {
-    let events_table = events_table_name
-        .rsplit('.')
-        .next()
-        .expect("rsplit yields at least one element");
+    let events_table = bare_table_name(events_table_name);
     quote! {
         |e| match &e {
             sqlx::Error::Database(db_err)

--- a/es-entity-macros/src/repo/error_types.rs
+++ b/es-entity-macros/src/repo/error_types.rs
@@ -324,12 +324,29 @@ impl<'a> ErrorTypes<'a> {
         let forget_error = &self.forget_error;
         let entity_name = self.entity.to_string();
 
+        let (pp_variant, pp_display_arm, pp_source_arm) = if let Some(config) =
+            &self.post_persist_hook
+        {
+            let error_ty = &config.error;
+            (
+                quote! { PostPersistHookError(#error_ty), },
+                quote! { Self::PostPersistHookError(e) => write!(f, "{}ForgetError - PostPersistHookError: {}", #entity_name, e), },
+                quote! { Self::PostPersistHookError(e) => Some(e), },
+            )
+        } else {
+            (quote! {}, quote! {}, quote! {})
+        };
+
         quote! {
             #[derive(Debug)]
             pub enum #forget_error {
                 Sqlx(sqlx::Error),
                 HydrationError(es_entity::EntityHydrationError),
                 ConcurrentModification,
+                /// `verify_forgotten` found forgettable data still present at
+                /// the storage level.
+                NotForgotten(es_entity::ForgettableRemnants),
+                #pp_variant
             }
 
             impl std::fmt::Display for #forget_error {
@@ -338,6 +355,8 @@ impl<'a> ErrorTypes<'a> {
                         Self::Sqlx(e) => write!(f, "{}ForgetError - Sqlx: {}", #entity_name, e),
                         Self::HydrationError(e) => write!(f, "{}ForgetError - HydrationError: {}", #entity_name, e),
                         Self::ConcurrentModification => write!(f, "{}ForgetError - ConcurrentModification: another writer persisted events concurrently; reload the entity and re-forget", #entity_name),
+                        Self::NotForgotten(remnants) => write!(f, "{}ForgetError - NotForgotten: {}", #entity_name, remnants),
+                        #pp_display_arm
                     }
                 }
             }
@@ -348,6 +367,8 @@ impl<'a> ErrorTypes<'a> {
                         Self::Sqlx(e) => Some(e),
                         Self::HydrationError(e) => Some(e),
                         Self::ConcurrentModification => None,
+                        Self::NotForgotten(_) => None,
+                        #pp_source_arm
                     }
                 }
             }
@@ -367,6 +388,15 @@ impl<'a> ErrorTypes<'a> {
             impl #forget_error {
                 pub fn was_concurrent_modification(&self) -> bool {
                     matches!(self, Self::ConcurrentModification)
+                }
+
+                /// Returns the remnants report when `verify_forgotten` found
+                /// forgettable data still present at the storage level.
+                pub fn not_forgotten_remnants(&self) -> Option<&es_entity::ForgettableRemnants> {
+                    match self {
+                        Self::NotForgotten(remnants) => Some(remnants),
+                        _ => None,
+                    }
                 }
             }
         }

--- a/es-entity-macros/src/repo/events_write.rs
+++ b/es-entity-macros/src/repo/events_write.rs
@@ -1,0 +1,430 @@
+//! Shared pieces of the combined index+events write statements.
+//!
+//! Every write path (`create`, `create_all`, `update`, `update_all`, `delete`,
+//! `forget`) emits the same tail: an `INSERT INTO {events_table} … SELECT …
+//! FROM UNNEST(…) RETURNING recorded_at` fed by arrays of serialized events.
+//! Only the *head* — the data-modifying CTE that writes the index row — is
+//! genuinely per-path. This module owns the tail, the preamble that gathers
+//! the arrays, and the follow-up forgettable payload insert, so the
+//! `event_context` branching and the `$n` placeholder arithmetic each exist
+//! once instead of six times.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Where the event rows' ids and sequences come from.
+///
+/// Two orthogonal axes: whether one entity's events or many are being written
+/// (which decides what the arrays carry), and whether the id comes from a
+/// data-modifying CTE in the same statement or is supplied directly (the
+/// standalone `persist_events` helpers, used where there is no index write to
+/// fold into).
+pub enum EventSource<'a> {
+    /// One entity, id bound directly — the standalone `persist_events`.
+    PerEntityStandalone {
+        id_param: usize,
+        offset_param: usize,
+    },
+    /// One entity, id taken from a CTE the same statement writes. The event
+    /// arrays are crossed with the single CTE row and the sequence comes from
+    /// `ROW_NUMBER()`. `offset_param` is `None` where the entity is brand new
+    /// and sequences therefore start at 1 (`create`).
+    PerEntityCte {
+        cte: &'a str,
+        offset_param: Option<usize>,
+    },
+    /// Many entities, ids and sequences in the arrays — the standalone
+    /// `persist_events_batch`.
+    BatchStandalone,
+    /// Many entities, joined back to a CTE the same statement writes, which
+    /// both orders the writes and reveals index rows that vanished (a short
+    /// `RETURNING` count).
+    BatchCte { cte: &'a str },
+}
+
+impl EventSource<'_> {
+    fn is_batch(&self) -> bool {
+        matches!(self, Self::BatchStandalone | Self::BatchCte { .. })
+    }
+}
+
+/// Emitter for the events-table half of a combined write statement.
+pub struct EventsInsert<'a> {
+    pub events_table: &'a str,
+    pub event_ctx: bool,
+}
+
+impl<'a> EventsInsert<'a> {
+    pub fn new(events_table: &'a str, event_ctx: bool) -> Self {
+        Self {
+            events_table,
+            event_ctx,
+        }
+    }
+
+    /// The `INSERT INTO {events} … RETURNING recorded_at` tail.
+    ///
+    /// `now_param` is the placeholder holding `op.maybe_now()` (shared with
+    /// the head, which uses it for `created_at`); `first_array_param` is the
+    /// first placeholder this tail owns.
+    pub fn sql(
+        &self,
+        source: &EventSource<'_>,
+        now_param: usize,
+        first_array_param: usize,
+    ) -> String {
+        let ctx_col = if self.event_ctx { ", context" } else { "" };
+        let ctx_sel = if self.event_ctx {
+            ", unnested.context"
+        } else {
+            ""
+        };
+        let p = first_array_param;
+
+        let (id_expr, sequence_expr, from_clause) = match source {
+            EventSource::PerEntityStandalone {
+                id_param,
+                offset_param,
+            } => (
+                format!("${id_param}"),
+                format!("ROW_NUMBER() OVER () + ${offset_param}"),
+                self.per_entity_unnest(p, None),
+            ),
+            EventSource::PerEntityCte { cte, offset_param } => {
+                let sequence_expr = match offset_param {
+                    Some(offset) => format!("ROW_NUMBER() OVER () + ${offset}"),
+                    None => "ROW_NUMBER() OVER ()".to_string(),
+                };
+                (
+                    format!("{cte}.id"),
+                    sequence_expr,
+                    self.per_entity_unnest(p, Some(cte)),
+                )
+            }
+            EventSource::BatchStandalone => (
+                "unnested.id".to_string(),
+                "unnested.sequence".to_string(),
+                self.batch_unnest(p, None),
+            ),
+            EventSource::BatchCte { cte } => (
+                "unnested.id".to_string(),
+                "unnested.sequence".to_string(),
+                self.batch_unnest(p, Some(cte)),
+            ),
+        };
+
+        format!(
+            "INSERT INTO {} (id, recorded_at, sequence, event_type, event{ctx_col}) \
+             SELECT {id_expr}, COALESCE(${now_param}, NOW()), {sequence_expr}, unnested.event_type, unnested.event{ctx_sel} \
+             {from_clause} \
+             RETURNING recorded_at",
+            self.events_table,
+        )
+    }
+
+    /// `FROM` clause for the one-entity shapes: the arrays carry only the
+    /// event type and body, optionally crossed with a CTE row supplying the id.
+    fn per_entity_unnest(&self, p: usize, cte: Option<&str>) -> String {
+        let ctx_col = if self.event_ctx { ", context" } else { "" };
+        let ctx_unnest = if self.event_ctx {
+            format!(", ${}::JSONB[]", p + 2)
+        } else {
+            String::new()
+        };
+        let cross_join = match cte {
+            Some(cte) => format!("{cte} CROSS JOIN "),
+            None => String::new(),
+        };
+        format!(
+            "FROM {cross_join}UNNEST(${}::TEXT[], ${}::JSONB[]{ctx_unnest}) AS unnested(event_type, event{ctx_col})",
+            p,
+            p + 1,
+        )
+    }
+
+    /// `FROM` clause for the many-entity shapes: the arrays also carry ids and
+    /// sequences, optionally joined back to a CTE.
+    fn batch_unnest(&self, p: usize, cte: Option<&str>) -> String {
+        let ctx_col = if self.event_ctx { ", context" } else { "" };
+        let ctx_unnest = if self.event_ctx {
+            format!(", ${}::JSONB[]", p + 4)
+        } else {
+            String::new()
+        };
+        let join = match cte {
+            Some(cte) => format!(" JOIN {cte} ON {cte}.id = unnested.id"),
+            None => String::new(),
+        };
+        format!(
+            "FROM UNNEST(${}, ${}::INT[], ${}::TEXT[], ${}::JSONB[]{ctx_unnest}) AS unnested(id, sequence, event_type, event{ctx_col}){join}",
+            p,
+            p + 1,
+            p + 2,
+            p + 3,
+        )
+    }
+
+    /// Statements that gather the serialized events for one entity into the
+    /// locals the tail's arguments name. `events` is an expression evaluating
+    /// to `&EntityEvents<_>`.
+    pub fn gather_per_entity(&self, events: TokenStream) -> TokenStream {
+        let ctx_var = if self.event_ctx {
+            quote! { let contexts = #events.serialize_new_event_contexts(); }
+        } else {
+            quote! {}
+        };
+        quote! {
+            let offset = #events.len_persisted();
+            let events_types = #events.new_event_types();
+            let serialized_events = #events.serialize_new_events();
+            #ctx_var
+        }
+    }
+
+    /// Declarations for the batch gather accumulators.
+    pub fn batch_declarations(&self, id_type: &syn::Ident) -> TokenStream {
+        let ctx_var = if self.event_ctx {
+            quote! { let mut all_contexts: Vec<es_entity::ContextData> = Vec::new(); }
+        } else {
+            quote! {}
+        };
+        quote! {
+            let mut all_ids: Vec<&#id_type> = Vec::new();
+            let mut all_sequences: Vec<i32> = Vec::new();
+            let mut all_types = Vec::new();
+            let mut all_serialized = Vec::new();
+            #ctx_var
+        }
+    }
+
+    /// Per-entity body of the batch gather loop. `events` evaluates to
+    /// `&EntityEvents<_>` and `id` to `&{IdType}`; both are re-read rather
+    /// than threaded so callers keep their own borrow shapes.
+    pub fn gather_batch(&self, events: TokenStream, id: TokenStream) -> TokenStream {
+        let ctx_extend = if self.event_ctx {
+            quote! {
+                if let Some(contexts) = #events.serialize_new_event_contexts() {
+                    all_contexts.extend(contexts);
+                }
+            }
+        } else {
+            quote! {}
+        };
+        quote! {
+            let offset = #events.len_persisted() + 1;
+            let types = #events.new_event_types();
+            let serialized = #events.serialize_new_events();
+            #ctx_extend
+
+            let n_new = serialized.len();
+            all_types.extend(types);
+            all_serialized.extend(serialized);
+            all_ids.extend(std::iter::repeat(#id).take(n_new));
+            all_sequences.extend((offset..).take(n_new).map(|i| i as i32));
+        }
+    }
+
+    /// The argument expressions the tail binds, in placeholder order, starting
+    /// with `op.maybe_now()`. Callers wrap them for their own call style —
+    /// positional `query!` arguments, `PgArguments::add`, or `.bind`.
+    pub fn arg_exprs(&self, source: &EventSource<'_>) -> Vec<TokenStream> {
+        let mut args = vec![quote! { op.maybe_now() }];
+        if source.is_batch() {
+            args.push(quote! { &all_ids });
+            args.push(quote! { &all_sequences });
+            args.push(quote! { &all_types });
+            args.push(quote! { &all_serialized });
+            if self.event_ctx {
+                args.push(quote! {
+                    &if all_contexts.is_empty() {
+                        None
+                    } else {
+                        Some(all_contexts)
+                    }
+                });
+            }
+        } else {
+            let has_offset = !matches!(
+                source,
+                EventSource::PerEntityCte {
+                    offset_param: None,
+                    ..
+                }
+            );
+            if has_offset {
+                args.push(quote! { offset as i32 });
+            }
+            args.push(quote! { &events_types });
+            args.push(quote! { &serialized_events });
+            if self.event_ctx {
+                args.push(quote! { contexts.as_deref() as Option<&[es_entity::ContextData]> });
+            }
+        }
+        args
+    }
+}
+
+/// Emitter for the follow-up forgettable payload insert.
+///
+/// Payloads live in a third table, so they cannot join the combined statement:
+/// sub-statements of a data-modifying CTE do not see each other's writes, and
+/// `forget`'s payload delete has to be able to see them.
+pub struct ForgettablePayloads<'a> {
+    pub table: &'a str,
+    pub id_type: &'a syn::Ident,
+    pub event_type: &'a syn::Ident,
+}
+
+impl ForgettablePayloads<'_> {
+    /// Collects and inserts the payloads of one entity's new events.
+    /// Requires `offset` (the pre-persist `len_persisted`) and `id` in scope.
+    pub fn insert_per_entity(&self, events: TokenStream, error: &syn::Ident) -> TokenStream {
+        let Self {
+            table,
+            id_type,
+            event_type,
+        } = self;
+        let query = format!(
+            "INSERT INTO {table} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)"
+        );
+        quote! {
+            let mut payload_sequences: Vec<i32> = Vec::new();
+            let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
+            for (idx, event_with_ctx) in #events.iter_new_events().enumerate() {
+                if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
+                    payload_sequences.push((offset + 1 + idx) as i32);
+                    payload_values.push(payload);
+                }
+            }
+            if !payload_sequences.is_empty() {
+                Self::extract_concurrent_modification(
+                    sqlx::query!(
+                        #query,
+                        id as &#id_type,
+                        &payload_sequences,
+                        &payload_values,
+                    )
+                    .execute(op.as_executor())
+                    .await,
+                    #error::ConcurrentModification,
+                )?;
+            }
+        }
+    }
+
+    /// Declarations for the batch payload accumulators.
+    pub fn batch_declarations(&self) -> TokenStream {
+        let id_type = self.id_type;
+        quote! {
+            let mut payload_ids: Vec<&#id_type> = Vec::new();
+            let mut payload_sequences: Vec<i32> = Vec::new();
+            let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
+        }
+    }
+
+    /// Per-entity body of the batch payload gather. Requires `offset` (the
+    /// 1-based first sequence for this entity) in scope.
+    pub fn gather_batch(&self, events: TokenStream, id: TokenStream) -> TokenStream {
+        let event_type = self.event_type;
+        quote! {
+            for (idx, event_with_ctx) in #events.iter_new_events().enumerate() {
+                if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
+                    payload_ids.push(#id);
+                    payload_sequences.push((offset + idx) as i32);
+                    payload_values.push(payload);
+                }
+            }
+        }
+    }
+
+    /// The batch payload insert.
+    pub fn insert_batch(&self, error: &syn::Ident) -> TokenStream {
+        let query = format!(
+            "INSERT INTO {} (entity_id, sequence, payload) SELECT unnested.entity_id, unnested.sequence, unnested.payload FROM UNNEST($1, $2::INT[], $3::JSONB[]) AS unnested(entity_id, sequence, payload)",
+            self.table
+        );
+        quote! {
+            if !payload_sequences.is_empty() {
+                Self::extract_concurrent_modification(
+                    sqlx::query(#query)
+                        .bind(&payload_ids)
+                        .bind(&payload_sequences)
+                        .bind(&payload_values)
+                        .execute(op.as_executor())
+                        .await,
+                    #error::ConcurrentModification,
+                )?;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn per_entity_sql_without_offset_matches_create() {
+        let insert = EventsInsert::new("entity_events", false);
+        let source = EventSource::PerEntityCte {
+            cte: "new_row",
+            offset_param: None,
+        };
+        assert_eq!(
+            insert.sql(&source, 2, 3),
+            "INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) \
+             SELECT new_row.id, COALESCE($2, NOW()), ROW_NUMBER() OVER (), unnested.event_type, unnested.event \
+             FROM new_row CROSS JOIN UNNEST($3::TEXT[], $4::JSONB[]) AS unnested(event_type, event) \
+             RETURNING recorded_at"
+        );
+    }
+
+    #[test]
+    fn per_entity_sql_with_offset_and_context() {
+        let insert = EventsInsert::new("entity_events", true);
+        let source = EventSource::PerEntityCte {
+            cte: "updated",
+            offset_param: Some(4),
+        };
+        assert_eq!(
+            insert.sql(&source, 3, 5),
+            "INSERT INTO entity_events (id, recorded_at, sequence, event_type, event, context) \
+             SELECT updated.id, COALESCE($3, NOW()), ROW_NUMBER() OVER () + $4, unnested.event_type, unnested.event, unnested.context \
+             FROM updated CROSS JOIN UNNEST($5::TEXT[], $6::JSONB[], $7::JSONB[]) AS unnested(event_type, event, context) \
+             RETURNING recorded_at"
+        );
+    }
+
+    #[test]
+    fn batch_sql_joins_the_cte() {
+        let insert = EventsInsert::new("entity_events", false);
+        let source = EventSource::BatchCte { cte: "new_rows" };
+        assert_eq!(
+            insert.sql(&source, 1, 4),
+            "INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) \
+             SELECT unnested.id, COALESCE($1, NOW()), unnested.sequence, unnested.event_type, unnested.event \
+             FROM UNNEST($4, $5::INT[], $6::TEXT[], $7::JSONB[]) AS unnested(id, sequence, event_type, event) \
+             JOIN new_rows ON new_rows.id = unnested.id \
+             RETURNING recorded_at"
+        );
+    }
+
+    #[test]
+    fn arg_exprs_follow_placeholder_order() {
+        let insert = EventsInsert::new("entity_events", false);
+        let per_entity = insert.arg_exprs(&EventSource::PerEntityCte {
+            cte: "updated",
+            offset_param: Some(3),
+        });
+        let rendered: Vec<_> = per_entity.iter().map(|t| t.to_string()).collect();
+        assert_eq!(
+            rendered,
+            vec![
+                "op . maybe_now ()",
+                "offset as i32",
+                "& events_types",
+                "& serialized_events"
+            ]
+        );
+    }
+}

--- a/es-entity-macros/src/repo/forget_fn.rs
+++ b/es-entity-macros/src/repo/forget_fn.rs
@@ -338,7 +338,9 @@ impl ForgetFn<'_> {
                 id: impl std::borrow::Borrow<#id_type>
             ) -> Result<(), #error> {
                 let mut op = self.begin_op().await?;
-                self.verify_forgotten_in_op(&mut op, id).await
+                let res = self.verify_forgotten_in_op(&mut op, id).await?;
+                op.commit().await?;
+                Ok(res)
             }
 
             /// Same as [`Self::verify_forgotten`] but runs on an existing

--- a/es-entity-macros/src/repo/forget_fn.rs
+++ b/es-entity-macros/src/repo/forget_fn.rs
@@ -10,8 +10,10 @@ pub struct ForgetFn<'a> {
     event: &'a syn::Ident,
     error: syn::Ident,
     table_name: &'a str,
+    events_table_name: &'a str,
     forgettable_table_name: &'a str,
     forgettable_columns: Vec<&'a syn::Ident>,
+    post_persist_error: Option<&'a syn::Type>,
 }
 
 impl<'a> ForgetFn<'a> {
@@ -22,10 +24,12 @@ impl<'a> ForgetFn<'a> {
             event: opts.event(),
             error: opts.forget_error(),
             table_name: opts.table_name(),
+            events_table_name: opts.events_table_name(),
             forgettable_table_name: opts
                 .forgettable_table_name()
                 .expect("forgettable must be enabled"),
             forgettable_columns: opts.columns.forgettable_column_names(),
+            post_persist_error: opts.post_persist_hook.as_ref().map(|h| &h.error),
         }
     }
 }
@@ -67,6 +71,45 @@ impl ToTokens for ForgetFn<'_> {
             }
         };
 
+        // Persist staged events, capturing how many were persisted so the
+        // post-persist hook can be handed exactly those events (in their
+        // forgotten, rebuilt form) after the payload delete.
+        let (persist_staged, post_persist_check) = if self.post_persist_error.is_some() {
+            (
+                quote! {
+                    let n_events = if entity.events().any_new() {
+                        Self::extract_concurrent_modification(
+                            self.persist_events(op, entity.events_mut()).await,
+                            #error::ConcurrentModification,
+                        )?
+                    } else {
+                        0
+                    };
+                },
+                quote! {
+                    if n_events > 0 {
+                        self.execute_post_persist_hook(
+                            op,
+                            &entity,
+                            entity.events().last_persisted(n_events)
+                        ).await.map_err(#error::PostPersistHookError)?;
+                    }
+                },
+            )
+        } else {
+            (
+                quote! {
+                    if entity.events().any_new() {
+                        Self::extract_concurrent_modification(
+                            self.persist_events(op, entity.events_mut()).await,
+                            #error::ConcurrentModification,
+                        )?;
+                    }
+                },
+                quote! {},
+            )
+        };
+
         tokens.append_all(quote! {
             /// Permanently forgets the entity's forgettable data. Consumes the
             /// entity and returns the rebuilt (forgotten) entity. On any error
@@ -105,6 +148,14 @@ impl ToTokens for ForgetFn<'_> {
             /// `forget` itself can fail with `ConcurrentModification` if
             /// another writer got there first — reload and re-forget (repeat
             /// forgets are legitimate).
+            ///
+            /// If the repository configures a `post_persist_hook`, it runs for
+            /// the staged events persisted by this call — exactly once, after
+            /// the payload delete and entity rebuild, so the hook observes the
+            /// forgotten representation (never the raw payloads being erased)
+            /// while still running inside the erasure transaction. When no
+            /// staged events are persisted the hook is not invoked, matching
+            /// `update`'s no-op semantics.
             pub async fn forget_in_op<OP>(
                 &self,
                 op: &mut OP,
@@ -113,12 +164,7 @@ impl ToTokens for ForgetFn<'_> {
             where
                 OP: es_entity::AtomicOperation
             {
-                if entity.events().any_new() {
-                    Self::extract_concurrent_modification(
-                        self.persist_events(op, entity.events_mut()).await,
-                        #error::ConcurrentModification,
-                    )?;
-                }
+                #persist_staged
                 {
                     let id = &entity.id;
                     sqlx::query!(
@@ -132,7 +178,149 @@ impl ToTokens for ForgetFn<'_> {
                 let events = entity.events_mut().forget_and_take(
                     #event_type::forget_forgettable_payloads
                 );
-                Ok(es_entity::TryFromEvents::try_from_events(events)?)
+                let entity: #entity_type = es_entity::TryFromEvents::try_from_events(events)?;
+                #post_persist_check
+                Ok(entity)
+            }
+        });
+
+        self.verify_forgotten_tokens(tokens);
+    }
+}
+
+impl ForgetFn<'_> {
+    /// Generates `verify_forgotten` / `verify_forgotten_in_op`: a storage-level
+    /// check that all configured forgettable data for an entity is physically
+    /// absent — payload rows deleted, `Forgettable<..>` index columns NULL, and
+    /// (defense-in-depth) no forgettable field holding a non-null value in the
+    /// durable event JSON.
+    fn verify_forgotten_tokens(&self, tokens: &mut TokenStream) {
+        let id_type = &self.id;
+        let event_type = self.event;
+        let error = &self.error;
+
+        let payload_count_query = format!(
+            "SELECT COUNT(*) AS \"count!\" FROM {} WHERE entity_id = $1",
+            self.forgettable_table_name
+        );
+
+        let event_fields_query = format!(
+            "SELECT DISTINCT e.event_type AS \"event_type!\", f.field AS \"field!\" \
+             FROM {} e \
+             JOIN (SELECT UNNEST($2::text[]) AS event_type, UNNEST($3::text[]) AS field) f \
+             ON e.event_type = f.event_type \
+             WHERE e.id = $1 \
+             AND e.event -> f.field IS NOT NULL \
+             AND e.event -> f.field != 'null'::jsonb",
+            self.events_table_name
+        );
+
+        let check_columns = if self.forgettable_columns.is_empty() {
+            quote! {}
+        } else {
+            let selects = self
+                .forgettable_columns
+                .iter()
+                .map(|c| format!("{c} IS NOT NULL AS \"{c}!\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let columns_query =
+                format!("SELECT {} FROM {} WHERE id = $1", selects, self.table_name);
+            let column_checks = self.forgettable_columns.iter().map(|c| {
+                let name = c.to_string();
+                quote! {
+                    if row.#c {
+                        remnants.live_index_columns.push(#name);
+                    }
+                }
+            });
+            quote! {
+                if let Some(row) = sqlx::query!(
+                    #columns_query,
+                    id as &#id_type
+                )
+                .fetch_optional(op.as_executor())
+                .await?
+                {
+                    #(#column_checks)*
+                }
+            }
+        };
+
+        tokens.append_all(quote! {
+            /// Verifies at the **storage level** that all configured
+            /// forgettable data for `id` is physically absent — i.e. that
+            /// `forget()` has fully taken effect. Unlike inspecting a hydrated
+            /// entity (which merely reads back as forgotten), this checks the
+            /// database directly:
+            ///
+            /// 1. no rows remain in the forgettable payloads table,
+            /// 2. all `Forgettable<..>` index columns are NULL, and
+            /// 3. no forgettable field holds a non-null value in the durable
+            ///    event JSON (defense-in-depth: the framework always writes
+            ///    `null` there, so a hit indicates out-of-band writes).
+            ///
+            /// Returns `Err(NotForgotten(remnants))` describing anything still
+            /// present. An entity that was never persisted verifies trivially.
+            pub async fn verify_forgotten(
+                &self,
+                id: impl std::borrow::Borrow<#id_type>
+            ) -> Result<(), #error> {
+                let mut op = self.begin_op().await?;
+                self.verify_forgotten_in_op(&mut op, id).await
+            }
+
+            /// Same as [`Self::verify_forgotten`] but runs on an existing
+            /// operation, so the check can share the erasure (or a follow-up)
+            /// transaction.
+            pub async fn verify_forgotten_in_op<OP>(
+                &self,
+                op: &mut OP,
+                id: impl std::borrow::Borrow<#id_type>
+            ) -> Result<(), #error>
+            where
+                OP: es_entity::AtomicOperation
+            {
+                let id = id.borrow();
+                let mut remnants = es_entity::ForgettableRemnants::default();
+
+                let payload_rows = sqlx::query!(
+                    #payload_count_query,
+                    id as &#id_type
+                )
+                .fetch_one(op.as_executor())
+                .await?
+                .count;
+                remnants.payload_rows = payload_rows as usize;
+
+                #check_columns
+
+                let event_types: Vec<String> = #event_type::FORGETTABLE_JSON_FIELDS
+                    .iter()
+                    .map(|(t, _)| t.to_string())
+                    .collect();
+                let fields: Vec<String> = #event_type::FORGETTABLE_JSON_FIELDS
+                    .iter()
+                    .map(|(_, f)| f.to_string())
+                    .collect();
+                let rows = sqlx::query!(
+                    #event_fields_query,
+                    id as &#id_type,
+                    &event_types[..],
+                    &fields[..]
+                )
+                .fetch_all(op.as_executor())
+                .await?;
+                remnants.event_fields = rows
+                    .into_iter()
+                    .map(|r| (r.event_type, r.field))
+                    .collect();
+
+                if remnants.is_empty() {
+                    Ok(())
+                } else {
+                    Err(#error::NotForgotten(remnants))
+                }
             }
         });
     }
@@ -157,8 +345,10 @@ mod tests {
             event: &event,
             error,
             table_name: "entities",
+            events_table_name: "entity_events",
             forgettable_table_name: "entities_forgettable_payloads",
             forgettable_columns: Vec::new(),
+            post_persist_error: None,
         };
 
         let mut tokens = TokenStream::new();
@@ -170,7 +360,10 @@ mod tests {
         assert!(output.contains("entity : Entity) -> Result < Entity , EntityForgetError >"));
         assert!(!output.contains("& mut Entity"));
         assert!(!output.contains("* entity ="));
-        assert!(output.contains("Ok (es_entity :: TryFromEvents :: try_from_events"));
+        assert!(output.contains("es_entity :: TryFromEvents :: try_from_events"));
+        assert!(output.contains("Ok (entity)"));
+        // No hook configured — no hook invocation is generated.
+        assert!(!output.contains("execute_post_persist_hook"));
         // Staged events are persisted (fencing + no laundering), BEFORE the
         // payload delete — assert the persist appears before the DELETE.
         let persist_at = output
@@ -201,8 +394,10 @@ mod tests {
             event: &event,
             error,
             table_name: "entities",
+            events_table_name: "entity_events",
             forgettable_table_name: "entities_forgettable_payloads",
             forgettable_columns: vec![&email],
+            post_persist_error: None,
         };
 
         let mut tokens = TokenStream::new();
@@ -210,5 +405,47 @@ mod tests {
 
         let output = tokens.to_string();
         assert!(output.contains("UPDATE entities SET email = NULL WHERE id = $1"));
+    }
+
+    #[test]
+    fn forget_fn_runs_post_persist_hook() {
+        let id = Ident::new("EntityId", Span::call_site());
+        let entity = Ident::new("Entity", Span::call_site());
+        let event = Ident::new("EntityEvent", Span::call_site());
+        let error = Ident::new("EntityForgetError", Span::call_site());
+        let hook_error: syn::Type = syn::parse_str("MyHookError").unwrap();
+
+        let forget_fn = ForgetFn {
+            id: &id,
+            entity: &entity,
+            event: &event,
+            error,
+            table_name: "entities",
+            events_table_name: "entity_events",
+            forgettable_table_name: "entities_forgettable_payloads",
+            forgettable_columns: Vec::new(),
+            post_persist_error: Some(&hook_error),
+        };
+
+        let mut tokens = TokenStream::new();
+        forget_fn.to_tokens(&mut tokens);
+
+        let output = tokens.to_string();
+        // The hook runs once, with the just-persisted staged events...
+        assert!(output.contains("if n_events > 0"));
+        assert!(
+            output.contains(
+                "self . execute_post_persist_hook (op , & entity , entity . events () . last_persisted (n_events))"
+            ),
+            "hook must receive exactly the just-persisted events: {output}"
+        );
+        assert!(output.contains("EntityForgetError :: PostPersistHookError"));
+        // ...AFTER the rebuild (hook observes the forgotten representation):
+        // the hook invocation must come after try_from_events.
+        let rebuild_at = output.find("try_from_events").expect("rebuild present");
+        let hook_at = output
+            .find("execute_post_persist_hook")
+            .expect("hook invocation present");
+        assert!(rebuild_at < hook_at, "hook must run on the rebuilt entity");
     }
 }

--- a/es-entity-macros/src/repo/forget_fn.rs
+++ b/es-entity-macros/src/repo/forget_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::concurrent_modification_classifier, options::*};
+use super::{
+    error_classifier::concurrent_modification_classifier,
+    events_write::{EventSource, EventsInsert},
+    options::*,
+};
 
 pub struct ForgetFn<'a> {
     id: &'a syn::Ident,
@@ -100,55 +104,32 @@ impl ToTokens for ForgetFn<'_> {
                 .map(|c| format!("{} = NULL", c))
                 .collect::<Vec<_>>()
                 .join(", ");
+            let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+            let source = EventSource::PerEntityCte {
+                cte: "updated",
+                offset_param: Some(3),
+            };
             let combined_query = format!(
-                "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) \
-                INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-                SELECT updated.id, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event{} \
-                FROM updated CROSS JOIN UNNEST($4::TEXT[], $5::JSONB[]{}) AS unnested(event_type, event{}) \
-                RETURNING recorded_at",
+                "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) {}",
                 self.table_name,
                 set_clause,
-                self.events_table_name,
-                if self.event_ctx { ", context" } else { "" },
-                if self.event_ctx {
-                    ", unnested.context"
-                } else {
-                    ""
-                },
-                if self.event_ctx { ", $6::JSONB[]" } else { "" },
-                if self.event_ctx { ", context" } else { "" },
+                events_insert.sql(&source, 2, 4),
             );
 
             let classifier = concurrent_modification_classifier(error, self.events_table_name);
-
-            let (ctx_var, ctx_arg) = if self.event_ctx {
-                (
-                    quote! { let contexts = entity.events().serialize_new_event_contexts(); },
-                    quote! {
-                        , contexts.as_deref() as Option<&[es_entity::ContextData]>
-                    },
-                )
-            } else {
-                (quote! {}, quote! {})
-            };
+            let gather = events_insert.gather_per_entity(quote! { entity.events() });
+            let event_args = events_insert.arg_exprs(&source);
 
             let persist = quote! {
                 let has_new_events = entity.events().any_new();
-                let offset = entity.events().len_persisted();
-                let events_types = entity.events().new_event_types();
-                let serialized_events = entity.events().serialize_new_events();
-                #ctx_var
+                #gather
 
                 let rows = {
                     let id = &entity.id;
                     sqlx::query!(
                         #combined_query,
                         id as &#id_type,
-                        op.maybe_now(),
-                        offset as i32,
-                        &events_types,
-                        &serialized_events
-                        #ctx_arg
+                        #(#event_args),*
                     )
                     .fetch_all(op.as_executor())
                     .await

--- a/es-entity-macros/src/repo/forget_fn.rs
+++ b/es-entity-macros/src/repo/forget_fn.rs
@@ -2,7 +2,7 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::options::*;
+use super::{error_classifier::concurrent_modification_classifier, options::*};
 
 pub struct ForgetFn<'a> {
     id: &'a syn::Ident,
@@ -10,6 +10,8 @@ pub struct ForgetFn<'a> {
     event: &'a syn::Ident,
     error: syn::Ident,
     table_name: &'a str,
+    events_table_name: &'a str,
+    event_ctx: bool,
     forgettable_table_name: &'a str,
     forgettable_columns: Vec<&'a syn::Ident>,
 }
@@ -22,6 +24,8 @@ impl<'a> ForgetFn<'a> {
             event: opts.event(),
             error: opts.forget_error(),
             table_name: opts.table_name(),
+            events_table_name: opts.events_table_name(),
+            event_ctx: opts.event_context_enabled(),
             forgettable_table_name: opts
                 .forgettable_table_name()
                 .expect("forgettable must be enabled"),
@@ -43,9 +47,27 @@ impl ToTokens for ForgetFn<'_> {
         );
 
         // Also NULL any `Forgettable<..>` index columns so the materialised
-        // lookup table stops exposing the forgotten value.
-        let forget_columns = if self.forgettable_columns.is_empty() {
-            quote! {}
+        // lookup table stops exposing the forgotten value. When there are such
+        // columns, that UPDATE and the staged-event insert go out as one
+        // statement; otherwise there is nothing to combine and the shared
+        // `persist_events` is used.
+        //
+        // The payload delete deliberately stays a *separate, later* statement:
+        // sub-statements of a data-modifying CTE cannot see each other's
+        // writes, so folding it in would let payload rows written by the same
+        // statement survive the erasure. Combining also makes the staged
+        // payload insert unnecessary — inserting rows the delete would remove
+        // in the same transaction is unobservable — so the combined path skips
+        // it, and a staged event still cannot smuggle a value past erasure.
+        let persist_and_forget_columns = if self.forgettable_columns.is_empty() {
+            quote! {
+                if entity.events().any_new() {
+                    Self::extract_concurrent_modification(
+                        self.persist_events(op, entity.events_mut()).await,
+                        #error::ConcurrentModification,
+                    )?;
+                }
+            }
         } else {
             let set_clause = self
                 .forgettable_columns
@@ -53,17 +75,79 @@ impl ToTokens for ForgetFn<'_> {
                 .map(|c| format!("{} = NULL", c))
                 .collect::<Vec<_>>()
                 .join(", ");
-            let columns_query = format!(
-                "UPDATE {} SET {} WHERE id = $1",
-                self.table_name, set_clause
+            let combined_query = format!(
+                "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) \
+                INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
+                SELECT updated.id, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event{} \
+                FROM updated CROSS JOIN UNNEST($4::TEXT[], $5::JSONB[]{}) AS unnested(event_type, event{}) \
+                RETURNING recorded_at",
+                self.table_name,
+                set_clause,
+                self.events_table_name,
+                if self.event_ctx { ", context" } else { "" },
+                if self.event_ctx {
+                    ", unnested.context"
+                } else {
+                    ""
+                },
+                if self.event_ctx { ", $6::JSONB[]" } else { "" },
+                if self.event_ctx { ", context" } else { "" },
             );
-            quote! {
-                sqlx::query!(
-                    #columns_query,
-                    id as &#id_type
+
+            let classifier = concurrent_modification_classifier(error, self.events_table_name);
+
+            let (ctx_var, ctx_arg) = if self.event_ctx {
+                (
+                    quote! { let contexts = entity.events().serialize_new_event_contexts(); },
+                    quote! {
+                        , contexts.as_deref() as Option<&[es_entity::ContextData]>
+                    },
                 )
-                .execute(op.as_executor())
-                .await?;
+            } else {
+                (quote! {}, quote! {})
+            };
+
+            quote! {
+                let has_new_events = entity.events().any_new();
+                let offset = entity.events().len_persisted();
+                let events_types = entity.events().new_event_types();
+                let serialized_events = entity.events().serialize_new_events();
+                #ctx_var
+
+                let rows = {
+                    let id = &entity.id;
+                    sqlx::query!(
+                        #combined_query,
+                        id as &#id_type,
+                        op.maybe_now(),
+                        offset as i32,
+                        &events_types,
+                        &serialized_events
+                        #ctx_arg
+                    )
+                    .fetch_all(op.as_executor())
+                    .await
+                    .map_err(#classifier)?
+                };
+            }
+        };
+
+        // Marking has to wait until the payload delete has had its turn with
+        // `&entity.id`, since it needs the events mutably.
+        let mark_persisted = if self.forgettable_columns.is_empty() {
+            quote! {}
+        } else {
+            quote! {
+                if has_new_events {
+                    // No row means the CTE's UPDATE matched nothing — the
+                    // entity was hard-deleted underneath us. Report the lost
+                    // race rather than an internal error.
+                    let recorded_at = rows
+                        .first()
+                        .map(|row| row.recorded_at)
+                        .ok_or(#error::ConcurrentModification)?;
+                    entity.events_mut().mark_new_events_persisted_at(recorded_at);
+                }
             }
         };
 
@@ -113,12 +197,7 @@ impl ToTokens for ForgetFn<'_> {
             where
                 OP: es_entity::AtomicOperation
             {
-                if entity.events().any_new() {
-                    Self::extract_concurrent_modification(
-                        self.persist_events(op, entity.events_mut()).await,
-                        #error::ConcurrentModification,
-                    )?;
-                }
+                #persist_and_forget_columns
                 {
                     let id = &entity.id;
                     sqlx::query!(
@@ -127,8 +206,8 @@ impl ToTokens for ForgetFn<'_> {
                     )
                     .execute(op.as_executor())
                     .await?;
-                    #forget_columns
                 }
+                #mark_persisted
                 let events = entity.events_mut().forget_and_take(
                     #event_type::forget_forgettable_payloads
                 );
@@ -157,6 +236,8 @@ mod tests {
             event: &event,
             error,
             table_name: "entities",
+            events_table_name: "entity_events",
+            event_ctx: false,
             forgettable_table_name: "entities_forgettable_payloads",
             forgettable_columns: Vec::new(),
         };
@@ -201,6 +282,8 @@ mod tests {
             event: &event,
             error,
             table_name: "entities",
+            events_table_name: "entity_events",
+            event_ctx: false,
             forgettable_table_name: "entities_forgettable_payloads",
             forgettable_columns: vec![&email],
         };
@@ -209,6 +292,23 @@ mod tests {
         forget_fn.to_tokens(&mut tokens);
 
         let output = tokens.to_string();
-        assert!(output.contains("UPDATE entities SET email = NULL WHERE id = $1"));
+        // The index-column NULLing is now the CTE of the combined statement
+        // that also inserts any staged events.
+        assert!(output.contains(
+            "WITH updated AS (UPDATE entities SET email = NULL WHERE id = $1 RETURNING id) INSERT INTO entity_events"
+        ));
+        // No laundering: the payload delete must still come after the statement
+        // that persists staged events, and must not be folded into it (CTE
+        // sub-statements cannot see each other's writes).
+        let insert_at = output
+            .find("INSERT INTO entity_events")
+            .expect("staged events must be persisted");
+        let delete_at = output
+            .find("DELETE FROM entities_forgettable_payloads WHERE entity_id = $1")
+            .expect("payload delete present");
+        assert!(insert_at < delete_at, "must persist BEFORE payload delete");
+        // The combined path skips the staged payload insert entirely — the
+        // delete would remove those rows in the same transaction anyway.
+        assert!(!output.contains("INSERT INTO entities_forgettable_payloads"));
     }
 }

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -43,6 +43,7 @@ pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream
 pub struct EsRepo<'a> {
     repo: &'a syn::Ident,
     generics: &'a syn::Generics,
+    extract_concurrent_modification_fn: Option<TokenStream>,
     persist_events_fn: Option<persist_events_fn::PersistEventsFn<'a>>,
     persist_events_batch_fn: Option<persist_events_batch_fn::PersistEventsBatchFn<'a>>,
     update_fn: update_fn::UpdateFn<'a>,
@@ -112,22 +113,26 @@ impl<'a> From<&'a RepositoryOptions> for EsRepo<'a> {
             None
         };
 
-        // `create`/`update` (and their `_all` forms) write the index row and
-        // the events in one statement, so they no longer route through the
-        // shared persist helpers. Emitting a helper nothing calls would be
-        // dead code in consumers that build with `-D warnings`, so each is
-        // emitted only for the paths that still need it: `persist_events` for
-        // soft delete, forget, and column-less updates; `persist_events_batch`
-        // for column-less bulk updates. `extract_concurrent_modification`
-        // rides along with `persist_events`, which covers the remaining
-        // callers (the forgettable payload inserts in `create`/`create_all`).
-        let needs_persist_events =
-            !opts.columns.updates_needed() || opts.delete.is_soft() || opts.forgettable_enabled();
+        // Every write path now folds its index write and its event insert into
+        // one statement, so the shared persist helpers are only reachable
+        // where there is no index write to fold into. Emitting a helper
+        // nothing calls would be dead code in consumers that build with
+        // `-D warnings`, so each is gated to its remaining callers:
+        // `persist_events` for column-less updates and for `forget` on repos
+        // with no forgettable index columns; `persist_events_batch` for
+        // column-less bulk updates. `extract_concurrent_modification` outlives
+        // both — the follow-up forgettable payload inserts still use it.
+        let needs_persist_events = !opts.columns.updates_needed()
+            || (opts.forgettable_enabled() && opts.columns.forgettable_column_names().is_empty());
         let needs_persist_events_batch = !opts.columns.updates_needed();
+        let extract_concurrent_modification_fn = (!opts.columns.updates_needed()
+            || opts.forgettable_enabled())
+        .then(error_classifier::extract_concurrent_modification_fn);
 
         Self {
             repo: &opts.ident,
             generics: &opts.generics,
+            extract_concurrent_modification_fn,
             persist_events_fn: needs_persist_events
                 .then(|| persist_events_fn::PersistEventsFn::from(opts)),
             persist_events_batch_fn: needs_persist_events_batch
@@ -158,6 +163,7 @@ impl<'a> From<&'a RepositoryOptions> for EsRepo<'a> {
 impl ToTokens for EsRepo<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let repo = &self.repo;
+        let extract_concurrent_modification_fn = &self.extract_concurrent_modification_fn;
         let persist_events_fn = &self.persist_events_fn;
         let persist_events_batch_fn = &self.persist_events_batch_fn;
         let update_fn = &self.update_fn;
@@ -368,6 +374,7 @@ impl ToTokens for EsRepo<'_> {
                 #begin
                 #post_hydrate_hook
                 #post_persist_hook
+                #extract_concurrent_modification_fn
                 #persist_events_fn
                 #persist_events_batch_fn
                 #create_fn

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -5,6 +5,7 @@ mod create_fn;
 mod delete_fn;
 mod error_classifier;
 mod error_types;
+mod events_write;
 mod find_all_fn;
 mod find_by_fn;
 mod forget_fn;

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -3,6 +3,7 @@ mod combo_cursor;
 mod create_all_fn;
 mod create_fn;
 mod delete_fn;
+mod error_classifier;
 mod error_types;
 mod find_all_fn;
 mod find_by_fn;
@@ -42,8 +43,8 @@ pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream
 pub struct EsRepo<'a> {
     repo: &'a syn::Ident,
     generics: &'a syn::Generics,
-    persist_events_fn: persist_events_fn::PersistEventsFn<'a>,
-    persist_events_batch_fn: persist_events_batch_fn::PersistEventsBatchFn<'a>,
+    persist_events_fn: Option<persist_events_fn::PersistEventsFn<'a>>,
+    persist_events_batch_fn: Option<persist_events_batch_fn::PersistEventsBatchFn<'a>>,
     update_fn: update_fn::UpdateFn<'a>,
     update_all_fn: update_all_fn::UpdateAllFn<'a>,
     create_fn: create_fn::CreateFn<'a>,
@@ -111,11 +112,26 @@ impl<'a> From<&'a RepositoryOptions> for EsRepo<'a> {
             None
         };
 
+        // `create`/`update` (and their `_all` forms) write the index row and
+        // the events in one statement, so they no longer route through the
+        // shared persist helpers. Emitting a helper nothing calls would be
+        // dead code in consumers that build with `-D warnings`, so each is
+        // emitted only for the paths that still need it: `persist_events` for
+        // soft delete, forget, and column-less updates; `persist_events_batch`
+        // for column-less bulk updates. `extract_concurrent_modification`
+        // rides along with `persist_events`, which covers the remaining
+        // callers (the forgettable payload inserts in `create`/`create_all`).
+        let needs_persist_events =
+            !opts.columns.updates_needed() || opts.delete.is_soft() || opts.forgettable_enabled();
+        let needs_persist_events_batch = !opts.columns.updates_needed();
+
         Self {
             repo: &opts.ident,
             generics: &opts.generics,
-            persist_events_fn: persist_events_fn::PersistEventsFn::from(opts),
-            persist_events_batch_fn: persist_events_batch_fn::PersistEventsBatchFn::from(opts),
+            persist_events_fn: needs_persist_events
+                .then(|| persist_events_fn::PersistEventsFn::from(opts)),
+            persist_events_batch_fn: needs_persist_events_batch
+                .then(|| persist_events_batch_fn::PersistEventsBatchFn::from(opts)),
             update_fn: update_fn::UpdateFn::from(opts),
             update_all_fn: update_all_fn::UpdateAllFn::from(opts),
             create_fn: create_fn::CreateFn::from(opts),

--- a/es-entity-macros/src/repo/options/columns.rs
+++ b/es-entity-macros/src/repo/options/columns.rs
@@ -174,7 +174,11 @@ impl Columns {
         }
     }
 
-    pub fn create_query_args(&self) -> Vec<proc_macro2::TokenStream> {
+    /// Eager-encoding `add` statements for the create columns, targeting a
+    /// `__query_args: PgArguments`. Used by the combined index+events insert,
+    /// where the event arrays require consuming the new entity before query
+    /// construction — the index args are encoded first, ending their borrows.
+    pub fn create_query_arg_adds(&self) -> Vec<proc_macro2::TokenStream> {
         self.all
             .iter()
             .filter(|c| c.opts.persist_on_create())
@@ -182,12 +186,17 @@ impl Columns {
                 let ident = &column.name;
                 let ty = &column.opts.ty;
                 quote! {
-                    #ident as &#ty,
+                    __query_args.add(#ident as &#ty).map_err(sqlx::Error::Encode)?;
                 }
             })
             .collect()
     }
 
+    /// Per-column collection vectors for the bulk create, plus the eager
+    /// `add` statements that encode them into a `__query_args: PgArguments`.
+    /// Encoding eagerly (rather than binding lazily) ends the collections'
+    /// borrows of the new entities, so the caller can consume them into the
+    /// event stream for the same statement.
     pub fn create_all_arg_collection(
         &self,
         ident: syn::Ident,
@@ -211,7 +220,7 @@ impl Columns {
                         #vec_ident.push(#ident);
                     },
                     quote! {
-                        .bind(#vec_ident)
+                        __query_args.add(#vec_ident).map_err(sqlx::Error::Encode)?;
                     },
                 )
             })

--- a/es-entity-macros/src/repo/persist_events_batch_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_batch_fn.rs
@@ -2,7 +2,10 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::options::*;
+use super::{
+    events_write::{EventSource, EventsInsert},
+    options::*,
+};
 
 pub struct PersistEventsBatchFn<'a> {
     id: &'a syn::Ident,
@@ -29,20 +32,12 @@ impl ToTokens for PersistEventsBatchFn<'_> {
         let id_type = &self.id;
         let event_type = &self.event;
 
-        let query = format!(
-            "INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-             SELECT unnested.id, COALESCE($1, NOW()), unnested.sequence, unnested.event_type, unnested.event{} \
-             FROM UNNEST($2, $3::INT[], $4::TEXT[], $5::JSONB[]{}) \
-             AS unnested(id, sequence, event_type, event{}) RETURNING recorded_at",
-            self.events_table_name,
-            if self.event_ctx { ", context" } else { "" },
-            if self.event_ctx {
-                ", unnested.context"
-            } else {
-                ""
-            },
-            if self.event_ctx { ", $6::JSONB[]" } else { "" },
-            if self.event_ctx { ", context" } else { "" }
+        // Same events-table tail as the combined bulk write statements, just
+        // without a CTE to join back to.
+        let query = EventsInsert::new(self.events_table_name, self.event_ctx).sql(
+            &EventSource::BatchStandalone,
+            1,
+            2,
         );
 
         let (ctx_var, ctx_extend, ctx_bind) = if self.event_ctx {

--- a/es-entity-macros/src/repo/persist_events_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_fn.rs
@@ -85,19 +85,6 @@ impl ToTokens for PersistEventsFn<'_> {
         };
 
         tokens.append_all(quote! {
-            fn extract_concurrent_modification<T, __EsErr: From<sqlx::Error>>(
-                res: Result<T, sqlx::Error>,
-                concurrent_modification: __EsErr,
-            ) -> Result<T, __EsErr> {
-                match res {
-                    Ok(v) => Ok(v),
-                    Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
-                        Err(concurrent_modification)
-                    }
-                    Err(e) => Err(__EsErr::from(e)),
-                }
-            }
-
             async fn persist_events<OP>(
                 &self,
                 op: &mut OP,
@@ -159,19 +146,6 @@ mod tests {
         persist_fn.to_tokens(&mut tokens);
 
         let expected = quote! {
-            fn extract_concurrent_modification<T, __EsErr: From<sqlx::Error>>(
-                res: Result<T, sqlx::Error>,
-                concurrent_modification: __EsErr,
-            ) -> Result<T, __EsErr> {
-                match res {
-                    Ok(v) => Ok(v),
-                    Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
-                        Err(concurrent_modification)
-                    }
-                    Err(e) => Err(__EsErr::from(e)),
-                }
-            }
-
             async fn persist_events<OP>(
                 &self,
                 op: &mut OP,
@@ -229,19 +203,6 @@ mod tests {
         persist_fn.to_tokens(&mut tokens);
 
         let expected = quote! {
-            fn extract_concurrent_modification<T, __EsErr: From<sqlx::Error>>(
-                res: Result<T, sqlx::Error>,
-                concurrent_modification: __EsErr,
-            ) -> Result<T, __EsErr> {
-                match res {
-                    Ok(v) => Ok(v),
-                    Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
-                        Err(concurrent_modification)
-                    }
-                    Err(e) => Err(__EsErr::from(e)),
-                }
-            }
-
             async fn persist_events<OP>(
                 &self,
                 op: &mut OP,

--- a/es-entity-macros/src/repo/persist_events_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_fn.rs
@@ -2,7 +2,10 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::options::*;
+use super::{
+    events_write::{EventSource, EventsInsert},
+    options::*,
+};
 
 pub struct PersistEventsFn<'a> {
     id: &'a syn::Ident,
@@ -26,18 +29,14 @@ impl<'a> From<&'a RepositoryOptions> for PersistEventsFn<'a> {
 
 impl ToTokens for PersistEventsFn<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let query = format!(
-            "INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) SELECT $1, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event{} FROM UNNEST($4::TEXT[], $5::JSONB[]{}) AS unnested(event_type, event{}) RETURNING recorded_at",
-            self.events_table_name,
-            if self.event_ctx { ", context" } else { "" },
-            if self.event_ctx {
-                ", unnested.context"
-            } else {
-                ""
-            },
-            if self.event_ctx { ", $6::JSONB[]" } else { "" },
-            if self.event_ctx { ", context" } else { "" }
-        );
+        // Same events-table tail as the combined write statements, just with
+        // the id bound directly instead of read from a CTE.
+        let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+        let source = EventSource::PerEntityStandalone {
+            id_param: 1,
+            offset_param: 3,
+        };
+        let query = events_insert.sql(&source, 2, 4);
 
         let (ctx_var, ctx_arg) = if self.event_ctx {
             (

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::write_error_classifier, options::*};
+use super::{
+    error_classifier::write_error_classifier,
+    events_write::{EventSource, EventsInsert, ForgettablePayloads},
+    options::*,
+};
 
 pub struct UpdateAllFn<'a> {
     entity: &'a syn::Ident,
@@ -66,71 +70,28 @@ impl ToTokens for UpdateAllFn<'_> {
         };
 
         let id_type = self.id;
-        let event_type = self.event;
 
-        let (forgettable_vars, forgettable_extract, forgettable_insert) = if let Some(
-            forgettable_tbl,
-        ) =
-            self.forgettable_table_name
-        {
-            let payload_insert_query = format!(
-                "INSERT INTO {} (entity_id, sequence, payload) SELECT unnested.entity_id, unnested.sequence, unnested.payload FROM UNNEST($1, $2::INT[], $3::JSONB[]) AS unnested(entity_id, sequence, payload)",
-                forgettable_tbl
-            );
-            (
-                quote! {
-                    let mut payload_ids: Vec<&#id_type> = Vec::new();
-                    let mut payload_sequences: Vec<i32> = Vec::new();
-                    let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
-                },
-                quote! {
-                    for (idx, event_with_ctx) in entity.events().iter_new_events().enumerate() {
-                        if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
-                            payload_ids.push(&entity.id);
-                            payload_sequences.push((offset + idx) as i32);
-                            payload_values.push(payload);
-                        }
-                    }
-                },
-                quote! {
-                    if !payload_sequences.is_empty() {
-                        Self::extract_concurrent_modification(
-                            sqlx::query(#payload_insert_query)
-                                .bind(&payload_ids)
-                                .bind(&payload_sequences)
-                                .bind(&payload_values)
-                                .execute(op.as_executor())
-                                .await,
-                            #modify_error::ConcurrentModification,
-                        )?;
-                    }
-                },
-            )
-        } else {
-            (quote! {}, quote! {}, quote! {})
-        };
+        let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
 
-        let (ctx_var, ctx_extend, ctx_bind) = if self.event_ctx {
-            (
-                quote! {
-                    let mut all_contexts: Vec<es_entity::ContextData> = Vec::new();
-                },
-                quote! {
-                    if let Some(contexts) = entity.events().serialize_new_event_contexts() {
-                        all_contexts.extend(contexts);
-                    }
-                },
-                quote! {
-                    .bind(&if all_contexts.is_empty() {
-                        None
-                    } else {
-                        Some(all_contexts)
-                    })
-                },
-            )
-        } else {
-            (quote! {}, quote! {}, quote! {})
-        };
+        let payloads = self
+            .forgettable_table_name
+            .map(|table| ForgettablePayloads {
+                table,
+                id_type,
+                event_type: self.event,
+            });
+        let forgettable_vars = payloads
+            .as_ref()
+            .map(|p| p.batch_declarations())
+            .unwrap_or_default();
+        let forgettable_extract = payloads
+            .as_ref()
+            .map(|p| p.gather_batch(quote! { entity.events() }, quote! { &entity.id }))
+            .unwrap_or_default();
+        let forgettable_insert = payloads
+            .as_ref()
+            .map(|p| p.insert_batch(modify_error))
+            .unwrap_or_default();
 
         // Every entity in the batch is only borrowed here, so the index columns
         // and the event arrays can be gathered in the same pass and written by
@@ -152,38 +113,20 @@ impl ToTokens for UpdateAllFn<'_> {
             let table_name = self.table_name;
 
             let now_p = n_columns + 1;
-            let ids_p = now_p + 1;
-            let sequences_p = now_p + 2;
-            let types_p = now_p + 3;
-            let events_p = now_p + 4;
-            let ctx_p = now_p + 5;
-
+            let source = EventSource::BatchCte { cte: "updated" };
             let query = format!(
                 "WITH updated AS (UPDATE {table_name} SET {set_clause} \
                      FROM UNNEST({placeholders}) \
                      AS unnested({column_list}) \
-                     WHERE {table_name}.id = unnested.id RETURNING {table_name}.id) \
-                     INSERT INTO {events_table} (id, recorded_at, sequence, event_type, event{ctx_col}) \
-                     SELECT unnested.id, COALESCE(${now_p}, NOW()), unnested.sequence, unnested.event_type, unnested.event{ctx_sel} \
-                     FROM UNNEST(${ids_p}, ${sequences_p}::INT[], ${types_p}::TEXT[], ${events_p}::JSONB[]{ctx_unnest}) \
-                     AS unnested(id, sequence, event_type, event{ctx_col}) \
-                     JOIN updated ON updated.id = unnested.id \
-                     RETURNING recorded_at",
-                events_table = self.events_table_name,
-                ctx_col = if self.event_ctx { ", context" } else { "" },
-                ctx_sel = if self.event_ctx {
-                    ", unnested.context"
-                } else {
-                    ""
-                },
-                ctx_unnest = if self.event_ctx {
-                    format!(", ${ctx_p}::JSONB[]")
-                } else {
-                    String::new()
-                },
+                     WHERE {table_name}.id = unnested.id RETURNING {table_name}.id) {}",
+                events_insert.sql(&source, now_p, now_p + 1),
             );
 
             let classifier = write_error_classifier(modify_error, self.events_table_name);
+            let event_binds = events_insert
+                .arg_exprs(&source)
+                .into_iter()
+                .map(|expr| quote! { .bind(#expr) });
 
             (
                 Some(vecs),
@@ -192,12 +135,7 @@ impl ToTokens for UpdateAllFn<'_> {
                     let expected_events = all_ids.len();
                     let rows = sqlx::query(#query)
                         #(#bind_tokens)*
-                        .bind(op.maybe_now())
-                        .bind(&all_ids)
-                        .bind(&all_sequences)
-                        .bind(&all_types)
-                        .bind(&all_serialized)
-                        #ctx_bind
+                        #(#event_binds)*
                         .fetch_all(op.as_executor())
                         .await
                         .map_err(#classifier)?;
@@ -245,28 +183,18 @@ impl ToTokens for UpdateAllFn<'_> {
         // Gathering of the event arrays only happens for the combined path;
         // the no-index-column path defers entirely to `persist_events_batch`.
         let (event_collection_vars, event_collection_pushes) = if self.columns.updates_needed() {
+            let batch_declarations = events_insert.batch_declarations(id_type);
+            let gather =
+                events_insert.gather_batch(quote! { entity.events() }, quote! { &entity.id });
             (
                 quote! {
-                    let mut all_ids: Vec<&#id_type> = Vec::new();
-                    let mut all_sequences: Vec<i32> = Vec::new();
-                    let mut all_types = Vec::new();
-                    let mut all_serialized = Vec::new();
+                    #batch_declarations
                     let mut n_persisted: std::collections::HashMap<#id_type, usize> = std::collections::HashMap::new();
-                    #ctx_var
                     #forgettable_vars
                 },
                 quote! {
-                    let offset = entity.events().len_persisted() + 1;
-                    let types = entity.events().new_event_types();
-                    let serialized = entity.events().serialize_new_events();
-                    #ctx_extend
+                    #gather
                     #forgettable_extract
-
-                    let n_new = serialized.len();
-                    all_types.extend(types);
-                    all_serialized.extend(serialized);
-                    all_ids.extend(std::iter::repeat(&entity.id).take(n_new));
-                    all_sequences.extend((offset..).take(n_new).map(|i| i as i32));
                     n_persisted.insert(entity.id.clone(), n_new);
                 },
             )

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -2,11 +2,16 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::options::*;
+use super::{error_classifier::write_error_classifier, options::*};
 
 pub struct UpdateAllFn<'a> {
     entity: &'a syn::Ident,
+    id: &'a syn::Ident,
+    event: &'a syn::Ident,
     table_name: &'a str,
+    events_table_name: &'a str,
+    event_ctx: bool,
+    forgettable_table_name: Option<&'a str>,
     columns: &'a Columns,
     modify_error: syn::Ident,
     nested_fn_names: Vec<syn::Ident>,
@@ -19,9 +24,14 @@ impl<'a> From<&'a RepositoryOptions> for UpdateAllFn<'a> {
     fn from(opts: &'a RepositoryOptions) -> Self {
         Self {
             entity: opts.entity(),
+            id: opts.id(),
+            event: opts.event(),
             modify_error: opts.modify_error(),
             columns: &opts.columns,
             table_name: opts.table_name(),
+            events_table_name: opts.events_table_name(),
+            event_ctx: opts.event_context_enabled(),
+            forgettable_table_name: opts.forgettable_table_name(),
             nested_fn_names: opts
                 .all_nested()
                 .map(|f| f.update_nested_fn_name())
@@ -55,7 +65,78 @@ impl ToTokens for UpdateAllFn<'_> {
             })
         };
 
-        let (vec_declarations, per_entity_pushes, update_tokens) = if self.columns.updates_needed()
+        let id_type = self.id;
+        let event_type = self.event;
+
+        let (forgettable_vars, forgettable_extract, forgettable_insert) = if let Some(
+            forgettable_tbl,
+        ) =
+            self.forgettable_table_name
+        {
+            let payload_insert_query = format!(
+                "INSERT INTO {} (entity_id, sequence, payload) SELECT unnested.entity_id, unnested.sequence, unnested.payload FROM UNNEST($1, $2::INT[], $3::JSONB[]) AS unnested(entity_id, sequence, payload)",
+                forgettable_tbl
+            );
+            (
+                quote! {
+                    let mut payload_ids: Vec<&#id_type> = Vec::new();
+                    let mut payload_sequences: Vec<i32> = Vec::new();
+                    let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
+                },
+                quote! {
+                    for (idx, event_with_ctx) in entity.events().iter_new_events().enumerate() {
+                        if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
+                            payload_ids.push(&entity.id);
+                            payload_sequences.push((offset + idx) as i32);
+                            payload_values.push(payload);
+                        }
+                    }
+                },
+                quote! {
+                    if !payload_sequences.is_empty() {
+                        Self::extract_concurrent_modification(
+                            sqlx::query(#payload_insert_query)
+                                .bind(&payload_ids)
+                                .bind(&payload_sequences)
+                                .bind(&payload_values)
+                                .execute(op.as_executor())
+                                .await,
+                            #modify_error::ConcurrentModification,
+                        )?;
+                    }
+                },
+            )
+        } else {
+            (quote! {}, quote! {}, quote! {})
+        };
+
+        let (ctx_var, ctx_extend, ctx_bind) = if self.event_ctx {
+            (
+                quote! {
+                    let mut all_contexts: Vec<es_entity::ContextData> = Vec::new();
+                },
+                quote! {
+                    if let Some(contexts) = entity.events().serialize_new_event_contexts() {
+                        all_contexts.extend(contexts);
+                    }
+                },
+                quote! {
+                    .bind(&if all_contexts.is_empty() {
+                        None
+                    } else {
+                        Some(all_contexts)
+                    })
+                },
+            )
+        } else {
+            (quote! {}, quote! {}, quote! {})
+        };
+
+        // Every entity in the batch is only borrowed here, so the index columns
+        // and the event arrays can be gathered in the same pass and written by
+        // a single statement; the events insert joins the `updated` CTE, which
+        // orders the index write first and detects rows that vanished.
+        let (vec_declarations, per_entity_pushes, persist_tokens) = if self.columns.updates_needed()
         {
             let (vecs, pushes, bind_tokens) = self
                 .columns
@@ -69,34 +150,128 @@ impl ToTokens for UpdateAllFn<'_> {
                 .join(", ");
             let column_list = column_names.join(", ");
             let table_name = self.table_name;
+
+            let now_p = n_columns + 1;
+            let ids_p = now_p + 1;
+            let sequences_p = now_p + 2;
+            let types_p = now_p + 3;
+            let events_p = now_p + 4;
+            let ctx_p = now_p + 5;
+
             let query = format!(
-                "UPDATE {table_name} SET {set_clause} \
+                "WITH updated AS (UPDATE {table_name} SET {set_clause} \
                      FROM UNNEST({placeholders}) \
                      AS unnested({column_list}) \
-                     WHERE {table_name}.id = unnested.id",
+                     WHERE {table_name}.id = unnested.id RETURNING {table_name}.id) \
+                     INSERT INTO {events_table} (id, recorded_at, sequence, event_type, event{ctx_col}) \
+                     SELECT unnested.id, COALESCE(${now_p}, NOW()), unnested.sequence, unnested.event_type, unnested.event{ctx_sel} \
+                     FROM UNNEST(${ids_p}, ${sequences_p}::INT[], ${types_p}::TEXT[], ${events_p}::JSONB[]{ctx_unnest}) \
+                     AS unnested(id, sequence, event_type, event{ctx_col}) \
+                     JOIN updated ON updated.id = unnested.id \
+                     RETURNING recorded_at",
+                events_table = self.events_table_name,
+                ctx_col = if self.event_ctx { ", context" } else { "" },
+                ctx_sel = if self.event_ctx {
+                    ", unnested.context"
+                } else {
+                    ""
+                },
+                ctx_unnest = if self.event_ctx {
+                    format!(", ${ctx_p}::JSONB[]")
+                } else {
+                    String::new()
+                },
             );
+
+            let classifier = write_error_classifier(modify_error, self.events_table_name);
+
             (
                 Some(vecs),
                 Some(pushes),
-                Some(quote! {
-                    sqlx::query(#query)
+                quote! {
+                    let expected_events = all_ids.len();
+                    let rows = sqlx::query(#query)
                         #(#bind_tokens)*
-                        .execute(op.as_executor())
+                        .bind(op.maybe_now())
+                        .bind(&all_ids)
+                        .bind(&all_sequences)
+                        .bind(&all_types)
+                        .bind(&all_serialized)
+                        #ctx_bind
+                        .fetch_all(op.as_executor())
                         .await
-                        .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
-                                #modify_error::ConstraintViolation {
-                                    column: Self::map_constraint_column(db_err.constraint()),
-                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            _ => #modify_error::Sqlx(e),
-                        })?;
-                }),
+                        .map_err(#classifier)?;
+
+                    #forgettable_insert
+
+                    // Every event row joins an index row this same statement
+                    // updated, so a short count means a row went missing.
+                    if rows.len() != expected_events {
+                        return Err(#modify_error::ConcurrentModification);
+                    }
+
+                    let recorded_at = rows
+                        .first()
+                        .ok_or(sqlx::Error::RowNotFound)
+                        .and_then(|row| row.try_get("recorded_at"))?;
+                    for entity in entities.iter_mut() {
+                        let events = Self::extract_events(entity);
+                        if events.any_new() {
+                            events.mark_new_events_persisted_at(recorded_at);
+                        }
+                    }
+                },
             )
         } else {
-            (None, None, None)
+            (
+                None,
+                None,
+                quote! {
+                    let mut all_event_refs: Vec<_> = entities.iter_mut()
+                        .filter_map(|entity| {
+                            let events = Self::extract_events(entity);
+                            if events.any_new() { Some(events) } else { None }
+                        })
+                        .collect();
+                    let n_persisted = Self::extract_concurrent_modification(
+                        self.persist_events_batch(op, &mut all_event_refs).await,
+                        #modify_error::ConcurrentModification,
+                    )?;
+                    drop(all_event_refs);
+                },
+            )
+        };
+
+        // Gathering of the event arrays only happens for the combined path;
+        // the no-index-column path defers entirely to `persist_events_batch`.
+        let (event_collection_vars, event_collection_pushes) = if self.columns.updates_needed() {
+            (
+                quote! {
+                    let mut all_ids: Vec<&#id_type> = Vec::new();
+                    let mut all_sequences: Vec<i32> = Vec::new();
+                    let mut all_types = Vec::new();
+                    let mut all_serialized = Vec::new();
+                    let mut n_persisted: std::collections::HashMap<#id_type, usize> = std::collections::HashMap::new();
+                    #ctx_var
+                    #forgettable_vars
+                },
+                quote! {
+                    let offset = entity.events().len_persisted() + 1;
+                    let types = entity.events().new_event_types();
+                    let serialized = entity.events().serialize_new_events();
+                    #ctx_extend
+                    #forgettable_extract
+
+                    let n_new = serialized.len();
+                    all_types.extend(types);
+                    all_serialized.extend(serialized);
+                    all_ids.extend(std::iter::repeat(&entity.id).take(n_new));
+                    all_sequences.extend((offset..).take(n_new).map(|i| i as i32));
+                    n_persisted.insert(entity.id.clone(), n_new);
+                },
+            )
+        } else {
+            (quote! {}, quote! {})
         };
 
         #[cfg(feature = "instrument")]
@@ -149,6 +324,8 @@ impl ToTokens for UpdateAllFn<'_> {
                 OP: es_entity::AtomicOperation
             {
                 let __result: Result<usize, #modify_error> = async {
+                    use es_entity::prelude::sqlx::Row;
+
                     if entities.is_empty() {
                         return Ok(0);
                     }
@@ -156,6 +333,7 @@ impl ToTokens for UpdateAllFn<'_> {
                     #nested_phase
 
                     #vec_declarations
+                    #event_collection_vars
 
                     let mut has_new_events = false;
                     for entity in entities.iter() {
@@ -165,25 +343,14 @@ impl ToTokens for UpdateAllFn<'_> {
                         has_new_events = true;
 
                         #per_entity_pushes
+                        #event_collection_pushes
                     }
 
                     if !has_new_events {
                         return Ok(0);
                     }
 
-                    #update_tokens
-
-                    let mut all_event_refs: Vec<_> = entities.iter_mut()
-                        .filter_map(|entity| {
-                            let events = Self::extract_events(entity);
-                            if events.any_new() { Some(events) } else { None }
-                        })
-                        .collect();
-                    let n_persisted = Self::extract_concurrent_modification(
-                        self.persist_events_batch(op, &mut all_event_refs).await,
-                        #modify_error::ConcurrentModification,
-                    )?;
-                    drop(all_event_refs);
+                    #persist_tokens
 
                     let mut total_events = 0usize;
                     for entity in entities.iter_mut() {
@@ -224,9 +391,15 @@ mod tests {
             )],
         );
 
+        let event = Ident::new("EntityEvent", Span::call_site());
         let update_all_fn = UpdateAllFn {
             entity: &entity,
+            id: &id,
+            event: &event,
             table_name: "entities",
+            events_table_name: "entity_events",
+            event_ctx: false,
+            forgettable_table_name: None,
             modify_error: syn::Ident::new("EntityModifyError", Span::call_site()),
             columns: &columns,
             nested_fn_names: Vec::new(),
@@ -258,12 +431,20 @@ mod tests {
                 OP: es_entity::AtomicOperation
             {
                 let __result: Result<usize, EntityModifyError> = async {
+                    use es_entity::prelude::sqlx::Row;
+
                     if entities.is_empty() {
                         return Ok(0);
                     }
 
                     let mut id_collection = Vec::new();
                     let mut name_collection = Vec::new();
+
+                    let mut all_ids: Vec<&EntityId> = Vec::new();
+                    let mut all_sequences: Vec<i32> = Vec::new();
+                    let mut all_types = Vec::new();
+                    let mut all_serialized = Vec::new();
+                    let mut n_persisted: std::collections::HashMap<EntityId, usize> = std::collections::HashMap::new();
 
                     let mut has_new_events = false;
                     for entity in entities.iter() {
@@ -276,19 +457,44 @@ mod tests {
                         let name = &entity.name;
                         id_collection.push(id);
                         name_collection.push(name);
+                        let offset = entity.events().len_persisted() + 1;
+                        let types = entity.events().new_event_types();
+                        let serialized = entity.events().serialize_new_events();
+
+                        let n_new = serialized.len();
+                        all_types.extend(types);
+                        all_serialized.extend(serialized);
+                        all_ids.extend(std::iter::repeat(&entity.id).take(n_new));
+                        all_sequences.extend((offset..).take(n_new).map(|i| i as i32));
+                        n_persisted.insert(entity.id.clone(), n_new);
                     }
 
                     if !has_new_events {
                         return Ok(0);
                     }
 
-                    sqlx::query("UPDATE entities SET name = unnested.name FROM UNNEST($1, $2) AS unnested(id, name) WHERE entities.id = unnested.id")
+                    let expected_events = all_ids.len();
+                    let rows = sqlx::query("WITH updated AS (UPDATE entities SET name = unnested.name FROM UNNEST($1, $2) AS unnested(id, name) WHERE entities.id = unnested.id RETURNING entities.id) INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, COALESCE($3, NOW()), unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($4, $5::INT[], $6::TEXT[], $7::JSONB[]) AS unnested(id, sequence, event_type, event) JOIN updated ON updated.id = unnested.id RETURNING recorded_at")
                         .bind(id_collection)
                         .bind(name_collection)
-                        .execute(op.as_executor())
+                        .bind(op.maybe_now())
+                        .bind(&all_ids)
+                        .bind(&all_sequences)
+                        .bind(&all_types)
+                        .bind(&all_serialized)
+                        .fetch_all(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
+                            sqlx::Error::Database(db_err)
+                                if db_err.is_unique_violation()
+                                    && db_err.table() == Some("entity_events") =>
+                            {
+                                EntityModifyError::ConcurrentModification
+                            }
+                            sqlx::Error::Database(db_err)
+                                if db_err.table() != Some("entity_events")
+                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+                            {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -298,17 +504,20 @@ mod tests {
                             _ => EntityModifyError::Sqlx(e),
                         })?;
 
-                    let mut all_event_refs: Vec<_> = entities.iter_mut()
-                        .filter_map(|entity| {
-                            let events = Self::extract_events(entity);
-                            if events.any_new() { Some(events) } else { None }
-                        })
-                        .collect();
-                    let n_persisted = Self::extract_concurrent_modification(
-                        self.persist_events_batch(op, &mut all_event_refs).await,
-                        EntityModifyError::ConcurrentModification,
-                    )?;
-                    drop(all_event_refs);
+                    if rows.len() != expected_events {
+                        return Err(EntityModifyError::ConcurrentModification);
+                    }
+
+                    let recorded_at = rows
+                        .first()
+                        .ok_or(sqlx::Error::RowNotFound)
+                        .and_then(|row| row.try_get("recorded_at"))?;
+                    for entity in entities.iter_mut() {
+                        let events = Self::extract_events(entity);
+                        if events.any_new() {
+                            events.mark_new_events_persisted_at(recorded_at);
+                        }
+                    }
 
                     let mut total_events = 0usize;
                     for entity in entities.iter_mut() {
@@ -337,9 +546,15 @@ mod tests {
         let mut columns = Columns::default();
         columns.set_id_column(&id);
 
+        let event = Ident::new("EntityEvent", Span::call_site());
         let update_all_fn = UpdateAllFn {
             entity: &entity,
+            id: &id,
+            event: &event,
             table_name: "entities",
+            events_table_name: "entity_events",
+            event_ctx: false,
+            forgettable_table_name: None,
             modify_error: syn::Ident::new("EntityModifyError", Span::call_site()),
             columns: &columns,
             nested_fn_names: Vec::new(),
@@ -371,6 +586,8 @@ mod tests {
                 OP: es_entity::AtomicOperation
             {
                 let __result: Result<usize, EntityModifyError> = async {
+                    use es_entity::prelude::sqlx::Row;
+
                     if entities.is_empty() {
                         return Ok(0);
                     }

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -2,11 +2,16 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::options::*;
+use super::{error_classifier::write_error_classifier, options::*};
 
 pub struct UpdateFn<'a> {
     entity: &'a syn::Ident,
+    id: &'a syn::Ident,
+    event: &'a syn::Ident,
     table_name: &'a str,
+    events_table_name: &'a str,
+    event_ctx: bool,
+    forgettable_table_name: Option<&'a str>,
     columns: &'a Columns,
     modify_error: syn::Ident,
     nested_fn_names: Vec<syn::Ident>,
@@ -19,9 +24,14 @@ impl<'a> From<&'a RepositoryOptions> for UpdateFn<'a> {
     fn from(opts: &'a RepositoryOptions) -> Self {
         Self {
             entity: opts.entity(),
+            id: opts.id(),
+            event: opts.event(),
             modify_error: opts.modify_error(),
             columns: &opts.columns,
             table_name: opts.table_name(),
+            events_table_name: opts.events_table_name(),
+            event_ctx: opts.event_context_enabled(),
+            forgettable_table_name: opts.forgettable_table_name(),
             nested_fn_names: opts
                 .all_nested()
                 .map(|f| f.update_nested_fn_name())
@@ -44,37 +54,139 @@ impl ToTokens for UpdateFn<'_> {
             }
         });
 
-        let update_tokens = if self.columns.updates_needed() {
+        // With index columns to persist, the index update and the event insert
+        // are a single statement: the event insert reads from the `updated`
+        // CTE, which forces the index write to happen first (preserving the
+        // index-error-wins precedence of the previous two-statement form) and
+        // supplies the id without re-binding it. Without index columns there
+        // is nothing to combine, so the shared `persist_events` is used.
+        let persist_tokens = if self.columns.updates_needed() {
             let assignments = self
                 .columns
                 .variable_assignments_for_update(syn::parse_quote! { entity });
             let column_updates = self.columns.sql_updates();
-            let query = format!(
-                "UPDATE {} SET {} WHERE id = $1",
-                self.table_name, column_updates,
-            );
             let args = self.columns.update_query_args();
-            Some(quote! {
-            #assignments
-            sqlx::query!(
-                #query,
-                #(#args),*
-            )
-                .execute(op.as_executor())
-                .await
-                .map_err(|e| match &e {
-                    sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
-                        #modify_error::ConstraintViolation {
-                            column: Self::map_constraint_column(db_err.constraint()),
-                            value: es_entity::extract_constraint_value(db_err.as_ref()),
-                            inner: e,
+            let now_p = args.len() + 1;
+            let offset_p = now_p + 1;
+            let types_p = now_p + 2;
+            let events_p = now_p + 3;
+            let ctx_p = now_p + 4;
+
+            let query = format!(
+                "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) \
+                INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
+                SELECT updated.id, COALESCE(${}, NOW()), ROW_NUMBER() OVER () + ${}, unnested.event_type, unnested.event{} \
+                FROM updated CROSS JOIN UNNEST(${}::TEXT[], ${}::JSONB[]{}) AS unnested(event_type, event{}) \
+                RETURNING recorded_at",
+                self.table_name,
+                column_updates,
+                self.events_table_name,
+                if self.event_ctx { ", context" } else { "" },
+                now_p,
+                offset_p,
+                if self.event_ctx {
+                    ", unnested.context"
+                } else {
+                    ""
+                },
+                types_p,
+                events_p,
+                if self.event_ctx {
+                    format!(", ${ctx_p}::JSONB[]")
+                } else {
+                    String::new()
+                },
+                if self.event_ctx { ", context" } else { "" },
+            );
+
+            let classifier = write_error_classifier(modify_error, self.events_table_name);
+
+            // Forgettable payloads are written to their own table, so they
+            // stay a follow-up statement (still one fewer round trip than
+            // before, where the index update was separate too).
+            let forgettable_code = if let Some(forgettable_tbl) = self.forgettable_table_name {
+                let id_type = self.id;
+                let event_type = self.event;
+                let payload_insert_query = format!(
+                    "INSERT INTO {} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)",
+                    forgettable_tbl
+                );
+                quote! {
+                    let mut payload_sequences: Vec<i32> = Vec::new();
+                    let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
+                    for (idx, event_with_ctx) in entity.events().iter_new_events().enumerate() {
+                        if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
+                            payload_sequences.push((offset + 1 + idx) as i32);
+                            payload_values.push(payload);
                         }
                     }
-                    _ => #modify_error::Sqlx(e),
-                })?;
-            })
+                    if !payload_sequences.is_empty() {
+                        Self::extract_concurrent_modification(
+                            sqlx::query!(
+                                #payload_insert_query,
+                                id as &#id_type,
+                                &payload_sequences,
+                                &payload_values,
+                            )
+                            .execute(op.as_executor())
+                            .await,
+                            #modify_error::ConcurrentModification,
+                        )?;
+                    }
+                }
+            } else {
+                quote! {}
+            };
+
+            let (ctx_var, ctx_arg) = if self.event_ctx {
+                (
+                    quote! { let contexts = entity.events().serialize_new_event_contexts(); },
+                    quote! {
+                        , contexts.as_deref() as Option<&[es_entity::ContextData]>
+                    },
+                )
+            } else {
+                (quote! {}, quote! {})
+            };
+
+            quote! {
+                #assignments
+                let offset = entity.events().len_persisted();
+                let events_types = entity.events().new_event_types();
+                let serialized_events = entity.events().serialize_new_events();
+                #ctx_var
+
+                let rows = sqlx::query!(
+                    #query,
+                    #(#args,)*
+                    op.maybe_now(),
+                    offset as i32,
+                    &events_types,
+                    &serialized_events
+                    #ctx_arg
+                )
+                    .fetch_all(op.as_executor())
+                    .await
+                    .map_err(#classifier)?;
+
+                #forgettable_code
+
+                let recorded_at = rows
+                    .first()
+                    .map(|row| row.recorded_at)
+                    .ok_or(sqlx::Error::RowNotFound)?;
+                let n_events = Self::extract_events(entity).mark_new_events_persisted_at(recorded_at);
+            }
         } else {
-            None
+            quote! {
+                let n_events = {
+                    let events = Self::extract_events(entity);
+                    Self::extract_concurrent_modification(
+                        self.persist_events(op, events).await,
+                        #modify_error::ConcurrentModification,
+                    )?
+                };
+            }
         };
 
         #[cfg(feature = "instrument")]
@@ -151,14 +263,7 @@ impl ToTokens for UpdateFn<'_> {
                         return Ok(0);
                     }
 
-                    #update_tokens
-                    let n_events = {
-                        let events = Self::extract_events(entity);
-                        Self::extract_concurrent_modification(
-                            self.persist_events(op, events).await,
-                            #modify_error::ConcurrentModification,
-                        )?
-                    };
+                    #persist_tokens
 
                     #post_persist_check
 
@@ -191,9 +296,15 @@ mod tests {
             )],
         );
 
+        let event = Ident::new("EntityEvent", Span::call_site());
         let update_fn = UpdateFn {
             entity: &entity,
+            id: &id,
+            event: &event,
             table_name: "entities",
+            events_table_name: "entity_events",
+            event_ctx: false,
+            forgettable_table_name: None,
             modify_error: syn::Ident::new("EntityModifyError", Span::call_site()),
             columns: &columns,
             nested_fn_names: Vec::new(),
@@ -240,15 +351,32 @@ mod tests {
 
                     let id = &entity.id;
                     let name = &entity.name;
-                    sqlx::query!(
-                        "UPDATE entities SET name = $2 WHERE id = $1",
+                    let offset = entity.events().len_persisted();
+                    let events_types = entity.events().new_event_types();
+                    let serialized_events = entity.events().serialize_new_events();
+
+                    let rows = sqlx::query!(
+                        "WITH updated AS (UPDATE entities SET name = $2 WHERE id = $1 RETURNING id) INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) SELECT updated.id, COALESCE($3, NOW()), ROW_NUMBER() OVER () + $4, unnested.event_type, unnested.event FROM updated CROSS JOIN UNNEST($5::TEXT[], $6::JSONB[]) AS unnested(event_type, event) RETURNING recorded_at",
                         id as &EntityId,
-                        name as &String
+                        name as &String,
+                        op.maybe_now(),
+                        offset as i32,
+                        &events_types,
+                        &serialized_events
                     )
-                        .execute(op.as_executor())
+                        .fetch_all(op.as_executor())
                         .await
                         .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err) if es_entity::is_classified_constraint_violation(db_err.as_ref()) => {
+                            sqlx::Error::Database(db_err)
+                                if db_err.is_unique_violation()
+                                    && db_err.table() == Some("entity_events") =>
+                            {
+                                EntityModifyError::ConcurrentModification
+                            }
+                            sqlx::Error::Database(db_err)
+                                if db_err.table() != Some("entity_events")
+                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+                            {
                                 EntityModifyError::ConstraintViolation {
                                     column: Self::map_constraint_column(db_err.constraint()),
                                     value: es_entity::extract_constraint_value(db_err.as_ref()),
@@ -258,13 +386,11 @@ mod tests {
                             _ => EntityModifyError::Sqlx(e),
                         })?;
 
-                    let n_events = {
-                        let events = Self::extract_events(entity);
-                        Self::extract_concurrent_modification(
-                            self.persist_events(op, events).await,
-                            EntityModifyError::ConcurrentModification,
-                        )?
-                    };
+                    let recorded_at = rows
+                        .first()
+                        .map(|row| row.recorded_at)
+                        .ok_or(sqlx::Error::RowNotFound)?;
+                    let n_events = Self::extract_events(entity).mark_new_events_persisted_at(recorded_at);
 
                     Ok(n_events)
                 }.await;
@@ -284,9 +410,15 @@ mod tests {
         let mut columns = Columns::default();
         columns.set_id_column(&id);
 
+        let event = Ident::new("EntityEvent", Span::call_site());
         let update_fn = UpdateFn {
             entity: &entity,
+            id: &id,
+            event: &event,
             table_name: "entities",
+            events_table_name: "entity_events",
+            event_ctx: false,
+            forgettable_table_name: None,
             modify_error: syn::Ident::new("EntityModifyError", Span::call_site()),
             columns: &columns,
             nested_fn_names: Vec::new(),

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::write_error_classifier, options::*};
+use super::{
+    error_classifier::write_error_classifier,
+    events_write::{EventSource, EventsInsert, ForgettablePayloads},
+    options::*,
+};
 
 pub struct UpdateFn<'a> {
     entity: &'a syn::Ident,
@@ -66,104 +70,45 @@ impl ToTokens for UpdateFn<'_> {
                 .variable_assignments_for_update(syn::parse_quote! { entity });
             let column_updates = self.columns.sql_updates();
             let args = self.columns.update_query_args();
-            let now_p = args.len() + 1;
-            let offset_p = now_p + 1;
-            let types_p = now_p + 2;
-            let events_p = now_p + 3;
-            let ctx_p = now_p + 4;
 
+            let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+            let now_p = args.len() + 1;
+            let source = EventSource::PerEntityCte {
+                cte: "updated",
+                offset_param: Some(now_p + 1),
+            };
             let query = format!(
-                "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) \
-                INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-                SELECT updated.id, COALESCE(${}, NOW()), ROW_NUMBER() OVER () + ${}, unnested.event_type, unnested.event{} \
-                FROM updated CROSS JOIN UNNEST(${}::TEXT[], ${}::JSONB[]{}) AS unnested(event_type, event{}) \
-                RETURNING recorded_at",
+                "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) {}",
                 self.table_name,
                 column_updates,
-                self.events_table_name,
-                if self.event_ctx { ", context" } else { "" },
-                now_p,
-                offset_p,
-                if self.event_ctx {
-                    ", unnested.context"
-                } else {
-                    ""
-                },
-                types_p,
-                events_p,
-                if self.event_ctx {
-                    format!(", ${ctx_p}::JSONB[]")
-                } else {
-                    String::new()
-                },
-                if self.event_ctx { ", context" } else { "" },
+                events_insert.sql(&source, now_p, now_p + 2),
             );
 
             let classifier = write_error_classifier(modify_error, self.events_table_name);
+            let gather = events_insert.gather_per_entity(quote! { entity.events() });
+            let event_args = events_insert.arg_exprs(&source);
 
             // Forgettable payloads are written to their own table, so they
             // stay a follow-up statement (still one fewer round trip than
             // before, where the index update was separate too).
-            let forgettable_code = if let Some(forgettable_tbl) = self.forgettable_table_name {
-                let id_type = self.id;
-                let event_type = self.event;
-                let payload_insert_query = format!(
-                    "INSERT INTO {} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)",
-                    forgettable_tbl
-                );
-                quote! {
-                    let mut payload_sequences: Vec<i32> = Vec::new();
-                    let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
-                    for (idx, event_with_ctx) in entity.events().iter_new_events().enumerate() {
-                        if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
-                            payload_sequences.push((offset + 1 + idx) as i32);
-                            payload_values.push(payload);
-                        }
-                    }
-                    if !payload_sequences.is_empty() {
-                        Self::extract_concurrent_modification(
-                            sqlx::query!(
-                                #payload_insert_query,
-                                id as &#id_type,
-                                &payload_sequences,
-                                &payload_values,
-                            )
-                            .execute(op.as_executor())
-                            .await,
-                            #modify_error::ConcurrentModification,
-                        )?;
-                    }
+            let forgettable_code = match self.forgettable_table_name {
+                Some(table) => ForgettablePayloads {
+                    table,
+                    id_type: self.id,
+                    event_type: self.event,
                 }
-            } else {
-                quote! {}
-            };
-
-            let (ctx_var, ctx_arg) = if self.event_ctx {
-                (
-                    quote! { let contexts = entity.events().serialize_new_event_contexts(); },
-                    quote! {
-                        , contexts.as_deref() as Option<&[es_entity::ContextData]>
-                    },
-                )
-            } else {
-                (quote! {}, quote! {})
+                .insert_per_entity(quote! { entity.events() }, modify_error),
+                None => quote! {},
             };
 
             quote! {
                 #assignments
-                let offset = entity.events().len_persisted();
-                let events_types = entity.events().new_event_types();
-                let serialized_events = entity.events().serialize_new_events();
-                #ctx_var
+                #gather
 
                 let rows = sqlx::query!(
                     #query,
                     #(#args,)*
-                    op.maybe_now(),
-                    offset as i32,
-                    &events_types,
-                    &serialized_events
-                    #ctx_arg
+                    #(#event_args),*
                 )
                     .fetch_all(op.as_executor())
                     .await

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -171,10 +171,15 @@ impl ToTokens for UpdateFn<'_> {
 
                 #forgettable_code
 
+                // There are new events (checked above), so the events insert
+                // produced a row unless the CTE's UPDATE matched nothing —
+                // i.e. the index row was deleted underneath us. Report that as
+                // a lost race, matching `update_all`, rather than leaking it as
+                // an internal `Sqlx(RowNotFound)`.
                 let recorded_at = rows
                     .first()
                     .map(|row| row.recorded_at)
-                    .ok_or(sqlx::Error::RowNotFound)?;
+                    .ok_or(#modify_error::ConcurrentModification)?;
                 let n_events = Self::extract_events(entity).mark_new_events_persisted_at(recorded_at);
             }
         } else {
@@ -389,7 +394,7 @@ mod tests {
                     let recorded_at = rows
                         .first()
                         .map(|row| row.recorded_at)
-                        .ok_or(sqlx::Error::RowNotFound)?;
+                        .ok_or(EntityModifyError::ConcurrentModification)?;
                     let n_events = Self::extract_events(entity).mark_new_events_persisted_at(recorded_at);
 
                     Ok(n_events)

--- a/src/forgettable.rs
+++ b/src/forgettable.rs
@@ -225,6 +225,50 @@ pub fn inject_forgettable_payload(event_json: &mut serde_json::Value, payload: s
     }
 }
 
+/// Storage-level remnants of forgettable data found by a repository's
+/// generated `verify_forgotten` check.
+///
+/// `verify_forgotten` inspects the database directly — not hydrated entity
+/// state — and reports anything that should have been erased by `forget()`:
+///
+/// - `payload_rows`: rows still present in the `_forgettable_payloads` table
+/// - `live_index_columns`: `Forgettable<..>` index columns that are non-NULL
+///   in the lookup table
+/// - `event_fields`: `(event_type, field)` pairs of forgettable fields whose
+///   durable event JSON holds a non-null value (defense-in-depth — the
+///   framework always writes `null` there, so any hit indicates data written
+///   outside the framework's serialization path)
+///
+/// An empty report means all configured forgettable data is physically absent
+/// at the storage level.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ForgettableRemnants {
+    /// Number of rows remaining in the forgettable payloads table.
+    pub payload_rows: usize,
+    /// Names of `Forgettable<..>` index columns that are still non-NULL.
+    pub live_index_columns: Vec<&'static str>,
+    /// `(event_type, field)` pairs with non-null forgettable values in the
+    /// durable event JSON.
+    pub event_fields: Vec<(String, String)>,
+}
+
+impl ForgettableRemnants {
+    /// True when no forgettable data remains at the storage level.
+    pub fn is_empty(&self) -> bool {
+        self.payload_rows == 0 && self.live_index_columns.is_empty() && self.event_fields.is_empty()
+    }
+}
+
+impl fmt::Display for ForgettableRemnants {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "forgettable data still present at storage level: {} payload row(s), non-NULL index columns {:?}, non-null event fields {:?}",
+            self.payload_rows, self.live_index_columns, self.event_fields
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub use es_entity_macros::retry_on_concurrent_modification;
 #[doc(inline)]
 pub use events::*;
 #[doc(inline)]
-pub use forgettable::{Forgettable, ForgettableRef};
+pub use forgettable::{Forgettable, ForgettableRef, ForgettableRemnants};
 #[doc(inline)]
 pub use idempotent::*;
 #[doc(inline)]

--- a/tests/forgettable.rs
+++ b/tests/forgettable.rs
@@ -286,6 +286,96 @@ async fn forget_persists_staged_events_without_laundering() -> anyhow::Result<()
 }
 
 #[tokio::test]
+async fn verify_forgotten_reports_remnants_before_and_passes_after_forget() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = Customers::new(pool);
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Verify Vera")
+        .email("verify@example.com")
+        .build()
+        .unwrap();
+    let mut customer = customers.create(new_customer).await?;
+    let _ = customer.update_name("Vera Verified");
+    customers.update(&mut customer).await?;
+
+    // Live entity: the storage-level check reports the payload rows.
+    let err = customers
+        .verify_forgotten(id)
+        .await
+        .expect_err("live entity must not verify as forgotten");
+    let remnants = err
+        .not_forgotten_remnants()
+        .expect("expected NotForgotten error");
+    assert_eq!(remnants.payload_rows, 2);
+    assert!(remnants.live_index_columns.is_empty());
+    assert!(remnants.event_fields.is_empty());
+
+    // After forget: physically absent.
+    let mut customer = customers.find_by_id(id).await?;
+    customer.record_erasure();
+    customers.forget(customer).await?;
+    customers.verify_forgotten(id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn verify_forgotten_detects_out_of_band_event_json_writes() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = Customers::new(pool.clone());
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Tampered Tim")
+        .email("tampered@example.com")
+        .build()
+        .unwrap();
+    let mut customer = customers.create(new_customer).await?;
+    customer.record_erasure();
+    customers.forget(customer).await?;
+    customers.verify_forgotten(id).await?;
+
+    // Simulate an out-of-band write leaking a raw value into the durable
+    // event JSON (the framework itself always writes null there).
+    sqlx::query!(
+        r#"UPDATE customer_events
+           SET event = jsonb_set(event, '{name}', '"leaked"')
+           WHERE id = $1 AND event_type = 'initialized'"#,
+        id as CustomerId
+    )
+    .execute(&pool)
+    .await?;
+
+    let err = customers
+        .verify_forgotten(id)
+        .await
+        .expect_err("leaked event JSON must fail verification");
+    let remnants = err.not_forgotten_remnants().expect("NotForgotten");
+    assert_eq!(remnants.payload_rows, 0);
+    assert_eq!(
+        remnants.event_fields,
+        vec![("initialized".to_string(), "name".to_string())]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn verify_forgotten_passes_trivially_for_unknown_id() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = Customers::new(pool);
+
+    // An id that was never persisted has nothing to erase.
+    customers.verify_forgotten(CustomerId::new()).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn events_table_stores_null_for_live_forgettable_fields() -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;
     let customers = Customers::new(pool.clone());

--- a/tests/forgettable_columns.rs
+++ b/tests/forgettable_columns.rs
@@ -320,3 +320,30 @@ async fn soft_delete_auto_forgets_the_index_column() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn verify_forgotten_reports_live_index_columns() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let subscribers = Subscribers::new(pool);
+
+    let (mut subscriber, _email) = new_subscriber(&subscribers).await?;
+    let id = subscriber.id;
+
+    // Live entity: both the payload row and the materialised index column
+    // still hold the value.
+    let err = subscribers
+        .verify_forgotten(id)
+        .await
+        .expect_err("live entity must not verify as forgotten");
+    let remnants = err.not_forgotten_remnants().expect("NotForgotten");
+    assert_eq!(remnants.payload_rows, 1);
+    assert_eq!(remnants.live_index_columns, vec!["email"]);
+    assert!(remnants.event_fields.is_empty());
+
+    // After a fenced forget everything is physically absent.
+    subscriber.record_erasure();
+    subscribers.forget(subscriber).await?;
+    subscribers.verify_forgotten(id).await?;
+
+    Ok(())
+}

--- a/tests/forgettable_hooks.rs
+++ b/tests/forgettable_hooks.rs
@@ -1,0 +1,310 @@
+//! Post-persist hook execution on the generated `forget` / `forget_in_op`
+//! path.
+//!
+//! Forgetting an entity must run the same post-persist hook as normal
+//! persists — exactly once, after the payload delete and rebuild (so the hook
+//! observes the forgotten representation), and inside the erasure transaction
+//! (so a failing hook rolls the whole erasure back and outbox-style
+//! publishers never publish uncommitted data).
+
+mod entities;
+mod helpers;
+
+use sqlx::PgPool;
+
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use entities::customer::*;
+use es_entity::*;
+
+#[derive(Debug)]
+pub struct CustomerPublishError(String);
+
+impl std::fmt::Display for CustomerPublishError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "publish failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for CustomerPublishError {}
+
+/// One recorded hook invocation.
+#[derive(Debug, Clone)]
+pub struct HookCall {
+    /// Event types of the events handed to the hook, in order.
+    pub event_types: Vec<String>,
+    /// The entity's `name` as the hook observed it.
+    pub entity_name: String,
+    /// Whether any `NameUpdated` event handed to the hook still carried a
+    /// readable (non-forgotten) name value.
+    pub saw_raw_name: bool,
+    /// Payload rows present for the entity at hook time (queried through the
+    /// hook's own operation — i.e. inside the same transaction).
+    pub payload_rows_at_hook_time: i64,
+}
+
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "Customer",
+    forgettable,
+    columns(email(ty = "String")),
+    post_persist_hook(method = "publish", error = "CustomerPublishError")
+)]
+pub struct CustomersWithHook {
+    pool: PgPool,
+    calls: Mutex<Vec<HookCall>>,
+    fail_on_forgot: AtomicBool,
+}
+
+impl CustomersWithHook {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+            calls: Mutex::new(Vec::new()),
+            fail_on_forgot: AtomicBool::new(false),
+        }
+    }
+
+    pub fn calls(&self) -> Vec<HookCall> {
+        self.calls.lock().unwrap().clone()
+    }
+
+    async fn publish<OP: es_entity::AtomicOperation>(
+        &self,
+        op: &mut OP,
+        entity: &Customer,
+        new_events: es_entity::events::LastPersisted<'_, CustomerEvent>,
+    ) -> Result<(), CustomerPublishError> {
+        let events: Vec<_> = new_events.collect();
+        let event_types: Vec<String> = events
+            .iter()
+            .map(|e| match &e.event {
+                CustomerEvent::Initialized { .. } => "initialized".to_string(),
+                CustomerEvent::NameUpdated { .. } => "name_updated".to_string(),
+                CustomerEvent::EmailUpdated { .. } => "email_updated".to_string(),
+                CustomerEvent::Forgot { .. } => "forgot".to_string(),
+            })
+            .collect();
+        let saw_raw_name = events.iter().any(|e| match &e.event {
+            CustomerEvent::NameUpdated { name } => name.value().is_some(),
+            _ => false,
+        });
+        let id = entity.id;
+        let payload_rows_at_hook_time = sqlx::query!(
+            r#"SELECT COUNT(*) AS "count!" FROM customers_forgettable_payloads
+               WHERE entity_id = $1"#,
+            id as CustomerId
+        )
+        .fetch_one(op.as_executor())
+        .await
+        .map_err(|e| CustomerPublishError(e.to_string()))?
+        .count;
+
+        if self.fail_on_forgot.load(Ordering::SeqCst) && event_types.iter().any(|t| t == "forgot") {
+            return Err(CustomerPublishError(format!(
+                "publisher rejected forgot event for {id}"
+            )));
+        }
+
+        self.calls.lock().unwrap().push(HookCall {
+            event_types,
+            entity_name: entity.name.clone(),
+            saw_raw_name,
+            payload_rows_at_hook_time,
+        });
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn forget_runs_post_persist_hook_for_staged_erasure_event() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = CustomersWithHook::new(pool);
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Hooked Hannah")
+        .email("hooked@example.com")
+        .build()
+        .unwrap();
+    let mut customer = customers.create(new_customer).await?;
+    assert_eq!(customers.calls().len(), 1, "create fires the hook once");
+
+    customer.record_erasure();
+    customers.forget(customer).await?;
+
+    let calls = customers.calls();
+    assert_eq!(calls.len(), 2, "forget fires the hook exactly once more");
+    let forget_call = &calls[1];
+    assert_eq!(forget_call.event_types, vec!["forgot"]);
+    // The hook observes the rebuilt (forgotten) entity, not the raw one.
+    assert_eq!(forget_call.entity_name, "[forgotten]");
+    // ...and runs after the payload delete, inside the erasure transaction.
+    assert_eq!(forget_call.payload_rows_at_hook_time, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn forget_without_staged_events_does_not_run_hook() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = CustomersWithHook::new(pool);
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Quiet Quinn")
+        .email("quiet@example.com")
+        .build()
+        .unwrap();
+    let customer = customers.create(new_customer).await?;
+    assert_eq!(customers.calls().len(), 1);
+
+    // No staged events: nothing is persisted, so there is nothing to publish
+    // — mirroring `update`'s no-op semantics.
+    customers.forget(customer).await?;
+    assert_eq!(customers.calls().len(), 1, "hook must not fire");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn hook_sees_forgotten_payloads_for_staged_pii_events() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = CustomersWithHook::new(pool);
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Leaky Lou")
+        .email("leaky@example.com")
+        .build()
+        .unwrap();
+    let mut customer = customers.create(new_customer).await?;
+
+    // A staged-but-unpersisted PII event rides along with the erasure. The
+    // hook must receive it in its forgotten form — the raw value must never
+    // reach a publisher during an erasure.
+    let _ = customer.update_name("Unpersisted Raw Name");
+    customer.record_erasure();
+    customers.forget(customer).await?;
+
+    let calls = customers.calls();
+    assert_eq!(calls.len(), 2);
+    let forget_call = &calls[1];
+    assert_eq!(forget_call.event_types, vec!["name_updated", "forgot"]);
+    assert!(
+        !forget_call.saw_raw_name,
+        "hook must never observe raw PII during an erasure"
+    );
+    assert_eq!(forget_call.entity_name, "[forgotten]");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn hook_error_rolls_back_the_entire_erasure() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = CustomersWithHook::new(pool.clone());
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Rollback Rae")
+        .email("rollback@example.com")
+        .build()
+        .unwrap();
+    let mut customer = customers.create(new_customer).await?;
+
+    customers.fail_on_forgot.store(true, Ordering::SeqCst);
+    customer.record_erasure();
+    let err = match customers.forget(customer).await {
+        Err(e) => e,
+        Ok(_) => panic!("hook failure must fail the forget"),
+    };
+    match err {
+        CustomerForgetError::PostPersistHookError(inner) => {
+            assert!(inner.to_string().contains("rejected forgot event"));
+        }
+        e => panic!("expected PostPersistHookError, got: {e}"),
+    }
+
+    // The whole erasure rolled back: payloads still present, entity still
+    // live, no forgot event persisted.
+    let payloads = sqlx::query!(
+        r#"SELECT COUNT(*) AS "count!" FROM customers_forgettable_payloads
+           WHERE entity_id = $1"#,
+        id as CustomerId
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(payloads.count, 1);
+
+    let reloaded = customers.find_by_id(id).await?;
+    assert_eq!(reloaded.name, "Rollback Rae");
+    let forgot_events = sqlx::query!(
+        r#"SELECT COUNT(*) AS "count!" FROM customer_events
+           WHERE id = $1 AND event_type = 'forgot'"#,
+        id as CustomerId
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(forgot_events.count, 0);
+
+    // Retry after the publisher recovers: the erasure is retryable.
+    customers.fail_on_forgot.store(false, Ordering::SeqCst);
+    let mut customer = customers.find_by_id(id).await?;
+    customer.record_erasure();
+    let customer = customers.forget(customer).await?;
+    assert_eq!(customer.name, "[forgotten]");
+    customers.verify_forgotten(id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn stale_writer_pii_is_fenced_and_leaves_no_trace_after_forget() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let customers = CustomersWithHook::new(pool.clone());
+
+    let id = CustomerId::new();
+    let new_customer = NewCustomer::builder()
+        .id(id)
+        .name("Fenced Fran")
+        .email("fenced@example.com")
+        .build()
+        .unwrap();
+    customers.create(new_customer).await?;
+
+    let mut stale = customers.find_by_id(id).await?;
+    let mut fresh = customers.find_by_id(id).await?;
+
+    fresh.record_erasure();
+    customers.forget(fresh).await?;
+
+    // A stale instance trying to write PII after the concurrent forget is
+    // rejected by the sequence fence...
+    let _ = stale.update_name("Resurrected PII");
+    let err = customers
+        .update(&mut stale)
+        .await
+        .expect_err("stale PII write after forget must fail");
+    assert!(err.was_concurrent_modification());
+
+    // ...the rejected write publishes nothing...
+    let calls = customers.calls();
+    assert_eq!(
+        calls.len(),
+        2,
+        "create + forget only — no publish for the rejected write"
+    );
+
+    // ...and leaves no PII behind at the storage level.
+    customers.verify_forgotten(id).await?;
+
+    Ok(())
+}

--- a/tests/repo_crud.rs
+++ b/tests/repo_crud.rs
@@ -238,3 +238,68 @@ async fn update_all() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Two writers loading the same entity and both updating: the second write
+/// hits the events table's `UNIQUE(id, sequence)` and must surface as
+/// `ConcurrentModification`, not as an index `ConstraintViolation`. Pins the
+/// classification of the combined index+events statement, which can no longer
+/// tell the two apart positionally.
+#[tokio::test]
+async fn update_concurrent_modification() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let users = Users::new(pool);
+
+    let new_user = NewUser::builder()
+        .id(UserId::new())
+        .name("Concurrent")
+        .build()
+        .unwrap();
+    let user = users.create(new_user).await?;
+
+    let mut first = users.find_by_id(user.id).await?;
+    let mut second = users.find_by_id(user.id).await?;
+
+    let _ = first.update_name("first_writer");
+    users.update(&mut first).await?;
+
+    let _ = second.update_name("second_writer");
+    match users.update(&mut second).await {
+        Err(UserModifyError::ConcurrentModification) => {}
+        other => panic!("expected ConcurrentModification, got: {other:?}"),
+    }
+
+    // The losing write left nothing behind.
+    let loaded = users.find_by_id(user.id).await?;
+    assert_eq!(loaded.name, "first_writer");
+
+    Ok(())
+}
+
+/// Same race through the bulk path: `update_all`'s combined statement must
+/// classify the events-table unique violation as `ConcurrentModification`.
+#[tokio::test]
+async fn update_all_concurrent_modification() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let users = Users::new(pool);
+
+    let new_user = NewUser::builder()
+        .id(UserId::new())
+        .name("BulkConcurrent")
+        .build()
+        .unwrap();
+    let user = users.create(new_user).await?;
+
+    let mut first = vec![users.find_by_id(user.id).await?];
+    let mut second = vec![users.find_by_id(user.id).await?];
+
+    let _ = first[0].update_name("bulk_first");
+    users.update_all(&mut first).await?;
+
+    let _ = second[0].update_name("bulk_second");
+    match users.update_all(&mut second).await {
+        Err(UserModifyError::ConcurrentModification) => {}
+        other => panic!("expected ConcurrentModification, got: {other:?}"),
+    }
+
+    Ok(())
+}

--- a/tests/repo_crud.rs
+++ b/tests/repo_crud.rs
@@ -303,3 +303,71 @@ async fn update_all_concurrent_modification() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Hard-deletes an entity's index and event rows out from under a loaded copy.
+async fn vanish(pool: &PgPool, id: UserId) -> anyhow::Result<()> {
+    sqlx::query("DELETE FROM user_events WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// A concurrent hard delete of the index row makes the combined statement's
+/// CTE match nothing, so no event row comes back. That is a lost race and must
+/// surface as `ConcurrentModification` on the single-entity path, exactly as it
+/// does on the bulk path — not as an internal `Sqlx(RowNotFound)`.
+#[tokio::test]
+async fn update_of_vanished_row_is_concurrent_modification() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let users = Users::new(pool.clone());
+
+    let mut user = users
+        .create(
+            NewUser::builder()
+                .id(UserId::new())
+                .name("Vanishing")
+                .build()
+                .unwrap(),
+        )
+        .await?;
+    vanish(&pool, user.id).await?;
+
+    let _ = user.update_name("never_lands");
+    match users.update(&mut user).await {
+        Err(UserModifyError::ConcurrentModification) => {}
+        other => panic!("expected ConcurrentModification, got: {other:?}"),
+    }
+
+    Ok(())
+}
+
+/// The bulk path's row-count guard classifies the same vanished-row race.
+#[tokio::test]
+async fn update_all_of_vanished_row_is_concurrent_modification() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let users = Users::new(pool.clone());
+
+    let mut batch = users
+        .create_all(vec![
+            NewUser::builder()
+                .id(UserId::new())
+                .name("BulkVanishing")
+                .build()
+                .unwrap(),
+        ])
+        .await?;
+    vanish(&pool, batch[0].id).await?;
+
+    let _ = batch[0].update_name("never_lands");
+    match users.update_all(&mut batch).await {
+        Err(UserModifyError::ConcurrentModification) => {}
+        other => panic!("expected ConcurrentModification, got: {other:?}"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Every `create`, `create_all`, `update` and `update_all` issued **two sequential statements** — one for the index table, one for the events table. Both now run as a **single data-modifying CTE**, halving the round trips on every write path that has index columns to persist.

| Path | Statements before | After |
|---|---|---|
| `create_in_op` | index INSERT + events INSERT | **1** |
| `create_all_in_op` | bulk INSERT + batch events INSERT | **1** |
| `update_in_op` | UPDATE + events INSERT | **1** |
| `update_all_in_op` | bulk UPDATE + batch events INSERT | **1** |
| soft `delete` / `forget` | unchanged (still via `persist_events`) | unchanged |

Standalone (non-`_in_op`) calls go from 4 round trips to 3; the remaining two are `BEGIN`/`COMMIT`.

## The shape

```sql
WITH new_row AS (
    INSERT INTO users (id, name, created_at) VALUES ($1, $2, COALESCE($3, NOW())) RETURNING id
)
INSERT INTO user_events (id, recorded_at, sequence, event_type, event)
SELECT new_row.id, COALESCE($3, NOW()), ROW_NUMBER() OVER (), unnested.event_type, unnested.event
FROM new_row CROSS JOIN UNNEST($4::TEXT[], $5::JSONB[]) AS unnested(event_type, event)
RETURNING recorded_at
```

The events insert **reads from the CTE** (`CROSS JOIN` for single-entity forms, `JOIN … ON id` for bulk) rather than sitting beside it as an unreferenced sibling. That is load-bearing, not cosmetic:

- it forces the index write to execute first, so a duplicate id still surfaces as the index constraint violation (`users_pkey`) rather than as a unique violation on the events table — preserving what `repo_errors.rs` pins;
- it lets the bulk paths notice index rows that vanished underneath them (short `RETURNING` count → `ConcurrentModification`), a check the two-statement form never had.

FK from events → index table is satisfied because FK checks are AFTER-row triggers that fire at end of statement.

## Error attribution

One statement covering two tables means errors can no longer be attributed positionally. The new shared classifier (`error_classifier.rs`) switches on sqlx's `DatabaseError::table()`:

- unique violation **on the events table** → `ConcurrentModification`
- classified violation **anywhere else** → `ConstraintViolation`
- everything else → `Sqlx` (including events-table FK violations, as before)

## Notes

- `create`/`create_all` encode index columns into `PgArguments` eagerly, ending the borrows on the new entities so they can be consumed into the event stream for the same statement. `update`/`update_all` only borrow, so `update` keeps `sqlx::query!` compile-time checking.
- `persist_events` / `persist_events_batch` lost their callers on these paths and are now emitted **only** where still used (soft delete, forget, column-less updates). Consumers build with `-D warnings`, so an uncalled generated helper would break them.
- Forgettable payload inserts stay a follow-up statement (third table), so forgettable repos go 3 statements → 2.
- **Downstream consumers must re-run `cargo sqlx prepare`** — the generated query text changed.

## Verification

- 325/325 tests pass against live Postgres (incl. 2 new `ConcurrentModification` tests covering the reclassification for `update` and `update_all`).
- `nix flake check`: all checks passed.
- Confirmed against Postgres statement logs — each path now logs `BEGIN → one statement → COMMIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to generated persistence SQL and forgettable PII erasure semantics; downstream repos need regenerated sqlx queries and API updates for `forget`.
> 
> **Overview**
> **Write path performance and correctness:** Generated `create`, `create_all`, `update`, `update_all`, and soft `delete` now fold the index-table change and event insert into a **single data-modifying CTE** (events read from the CTE via `CROSS JOIN` / `JOIN`), cutting round trips and preserving index-first error precedence. Shared helpers in `events_write.rs` and `error_classifier.rs` centralize SQL tails and classify failures by Postgres `table()` (events unique → `ConcurrentModification`, index violations → `ConstraintViolation`). `persist_events` / `persist_events_batch` are emitted only where still needed (column-less updates, some forget paths).
> 
> **Forget / erasure:** `forget` **consumes** the entity and **returns** the rebuilt forgotten copy. New **`verify_forgotten`** / **`verify_forgotten_in_op`** check payloads, NULL forgettable index columns, and durable event JSON (`ForgettableRemnants`, `NotForgotten` on `ForgetError`). **`post_persist_hook`** runs on forget after rebuild inside the erasure transaction. `EsEvent` adds `FORGETTABLE_JSON_FIELDS` keyed to **`event_type()`** (snake ident), not serde tags, so verification joins match the DB.
> 
> Docs and integration tests cover hooks, concurrent modification on vanished rows, and out-of-band JSON tampering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c969baaff7e414be1569c77103d946adcaf150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->