### PR TITLE
refactor(macros): extract the shared events-write codegen

### DIFF
--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::write_error_classifier, options::*};
+use super::{
+    error_classifier::write_error_classifier,
+    events_write::{EventSource, EventsInsert, ForgettablePayloads},
+    options::*,
+};
 
 pub struct CreateAllFn<'a> {
     entity: &'a syn::Ident,
@@ -69,119 +73,59 @@ impl ToTokens for CreateAllFn<'_> {
             .columns
             .create_all_arg_collection(syn::parse_quote! { new_entity });
 
-        let ids_p = column_names.len() + 2;
-        let sequences_p = ids_p + 1;
-        let types_p = ids_p + 2;
-        let events_p = ids_p + 3;
-        let ctx_p = ids_p + 4;
-
         // Both inserts in one statement. The events insert joins the `new_rows`
         // CTE, which forces the index rows to be written first — so a duplicate
         // id surfaces as the index constraint violation rather than as a unique
         // violation on the events table.
+        let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+        let source = EventSource::BatchCte { cte: "new_rows" };
         let query = format!(
             "WITH new_rows AS (INSERT INTO {} (created_at, {}) \
             SELECT COALESCE($1, NOW()), unnested.{} \
             FROM UNNEST({}) \
-            AS unnested({}) RETURNING id) \
-            INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-            SELECT unnested.id, COALESCE($1, NOW()), unnested.sequence, unnested.event_type, unnested.event{} \
-            FROM UNNEST(${}, ${}::INT[], ${}::TEXT[], ${}::JSONB[]{}) \
-            AS unnested(id, sequence, event_type, event{}) \
-            JOIN new_rows ON new_rows.id = unnested.id \
-            RETURNING recorded_at",
+            AS unnested({}) RETURNING id) {}",
             table_name,
             column_names.join(", "),
             column_names.join(", unnested."),
             placeholders,
             column_names.join(", "),
-            self.events_table_name,
-            if self.event_ctx { ", context" } else { "" },
-            if self.event_ctx {
-                ", unnested.context"
-            } else {
-                ""
-            },
-            ids_p,
-            sequences_p,
-            types_p,
-            events_p,
-            if self.event_ctx {
-                format!(", ${ctx_p}::JSONB[]")
-            } else {
-                String::new()
-            },
-            if self.event_ctx { ", context" } else { "" },
+            events_insert.sql(&source, 1, column_names.len() + 2),
         );
 
         let classifier = write_error_classifier(create_error, self.events_table_name);
 
         let id_type = self.id;
-        let event_type = self.event;
 
-        let (ctx_var, ctx_extend, ctx_add) = if self.event_ctx {
-            (
-                quote! {
-                    let mut all_contexts: Vec<es_entity::ContextData> = Vec::new();
-                },
-                quote! {
-                    if let Some(contexts) = events.serialize_new_event_contexts() {
-                        all_contexts.extend(contexts);
-                    }
-                },
-                quote! {
-                    __query_args.add(if all_contexts.is_empty() {
-                        None
-                    } else {
-                        Some(&all_contexts)
-                    }).map_err(sqlx::Error::Encode)?;
-                },
-            )
-        } else {
-            (quote! {}, quote! {}, quote! {})
-        };
+        let batch_declarations = events_insert.batch_declarations(id_type);
+        let gather = events_insert.gather_batch(quote! { events }, quote! { id });
+        // The index columns are encoded first (their borrows on the new
+        // entities must end before those are consumed), so the event arrays
+        // follow — hence skipping the shared `now` argument here.
+        let event_arg_adds = events_insert
+            .arg_exprs(&source)
+            .into_iter()
+            .skip(1)
+            .map(|expr| quote! { __query_args.add(#expr).map_err(sqlx::Error::Encode)?; });
 
-        let (forgettable_vars, forgettable_extract, forgettable_insert) = if let Some(
-            forgettable_tbl,
-        ) =
-            self.forgettable_table_name
-        {
-            let payload_insert_query = format!(
-                "INSERT INTO {} (entity_id, sequence, payload) SELECT unnested.entity_id, unnested.sequence, unnested.payload FROM UNNEST($1, $2::INT[], $3::JSONB[]) AS unnested(entity_id, sequence, payload)",
-                forgettable_tbl
-            );
-            (
-                quote! {
-                    let mut payload_ids: Vec<&#id_type> = Vec::new();
-                    let mut payload_sequences: Vec<i32> = Vec::new();
-                    let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
-                },
-                quote! {
-                    for (idx, event_with_ctx) in events.iter_new_events().enumerate() {
-                        if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
-                            payload_ids.push(id);
-                            payload_sequences.push((offset + idx) as i32);
-                            payload_values.push(payload);
-                        }
-                    }
-                },
-                quote! {
-                    if !payload_sequences.is_empty() {
-                        Self::extract_concurrent_modification(
-                            sqlx::query(#payload_insert_query)
-                                .bind(&payload_ids)
-                                .bind(&payload_sequences)
-                                .bind(&payload_values)
-                                .execute(op.as_executor())
-                                .await,
-                            #create_error::ConcurrentModification,
-                        )?;
-                    }
-                },
-            )
-        } else {
-            (quote! {}, quote! {}, quote! {})
-        };
+        let payloads = self
+            .forgettable_table_name
+            .map(|table| ForgettablePayloads {
+                table,
+                id_type,
+                event_type: self.event,
+            });
+        let forgettable_vars = payloads
+            .as_ref()
+            .map(|p| p.batch_declarations())
+            .unwrap_or_default();
+        let forgettable_extract = payloads
+            .as_ref()
+            .map(|p| p.gather_batch(quote! { events }, quote! { id }))
+            .unwrap_or_default();
+        let forgettable_insert = payloads
+            .as_ref()
+            .map(|p| p.insert_batch(create_error))
+            .unwrap_or_default();
 
         #[cfg(feature = "instrument")]
         let (instrument_attr, error_recording) = {
@@ -259,35 +203,18 @@ impl ToTokens for CreateAllFn<'_> {
 
                     let mut all_events: Vec<es_entity::EntityEvents<<#entity as es_entity::EsEntity>::Event>> = new_entities.into_iter().map(Self::convert_new).collect();
 
-                    let mut all_ids: Vec<&#id_type> = Vec::new();
-                    let mut all_sequences: Vec<i32> = Vec::new();
-                    let mut all_types = Vec::new();
-                    let mut all_serialized = Vec::new();
+                    #batch_declarations
                     let mut n_persisted: Vec<usize> = Vec::new();
-                    #ctx_var
                     #forgettable_vars
 
                     for events in all_events.iter() {
                         let id = events.id();
-                        let offset = events.len_persisted() + 1;
-                        let types = events.new_event_types();
-                        let serialized = events.serialize_new_events();
-                        #ctx_extend
+                        #gather
                         #forgettable_extract
-
-                        let n_events = serialized.len();
-                        all_types.extend(types);
-                        all_serialized.extend(serialized);
-                        all_ids.extend(std::iter::repeat(id).take(n_events));
-                        all_sequences.extend((offset..).take(n_events).map(|i| i as i32));
-                        n_persisted.push(n_events);
+                        n_persisted.push(n_new);
                     }
 
-                    __query_args.add(&all_ids).map_err(sqlx::Error::Encode)?;
-                    __query_args.add(&all_sequences).map_err(sqlx::Error::Encode)?;
-                    __query_args.add(&all_types).map_err(sqlx::Error::Encode)?;
-                    __query_args.add(&all_serialized).map_err(sqlx::Error::Encode)?;
-                    #ctx_add
+                    #(#event_arg_adds)*
 
                     let expected_events = all_ids.len();
                     let rows = sqlx::query_with(#query, __query_args)
@@ -429,12 +356,12 @@ mod tests {
                         let types = events.new_event_types();
                         let serialized = events.serialize_new_events();
 
-                        let n_events = serialized.len();
+                        let n_new = serialized.len();
                         all_types.extend(types);
                         all_serialized.extend(serialized);
-                        all_ids.extend(std::iter::repeat(id).take(n_events));
-                        all_sequences.extend((offset..).take(n_events).map(|i| i as i32));
-                        n_persisted.push(n_events);
+                        all_ids.extend(std::iter::repeat(id).take(n_new));
+                        all_sequences.extend((offset..).take(n_new).map(|i| i as i32));
+                        n_persisted.push(n_new);
                     }
 
                     __query_args.add(&all_ids).map_err(sqlx::Error::Encode)?;

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::write_error_classifier, options::*};
+use super::{
+    error_classifier::write_error_classifier,
+    events_write::{EventSource, EventsInsert, ForgettablePayloads},
+    options::*,
+};
 
 pub struct CreateFn<'a> {
     entity: &'a syn::Ident,
@@ -68,10 +72,6 @@ impl ToTokens for CreateFn<'_> {
 
         let column_names = self.columns.insert_column_names();
         let placeholders = self.columns.insert_placeholders(0);
-        let now_p = column_names.len() + 1;
-        let types_p = now_p + 1;
-        let events_p = now_p + 2;
-        let ctx_p = now_p + 3;
         let arg_adds = self.columns.create_query_arg_adds();
 
         // Index insert and events insert combined into one statement. The
@@ -79,79 +79,54 @@ impl ToTokens for CreateFn<'_> {
         // written first — preserving error precedence (a duplicate id
         // surfaces as the index pkey violation, not as a unique violation on
         // the events table) and providing the id without a second bind.
+        //
+        // A brand-new entity has no persisted events, so sequences start at 1
+        // and no offset parameter is needed.
+        let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+        let now_p = column_names.len() + 1;
+        let source = EventSource::PerEntityCte {
+            cte: "new_row",
+            offset_param: None,
+        };
         let query = format!(
-            "WITH new_row AS (INSERT INTO {} ({}, created_at) VALUES ({}, COALESCE(${}, NOW())) RETURNING id) \
-            INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-            SELECT new_row.id, COALESCE(${}, NOW()), ROW_NUMBER() OVER (), unnested.event_type, unnested.event{} \
-            FROM new_row CROSS JOIN UNNEST(${}::TEXT[], ${}::JSONB[]{}) AS unnested(event_type, event{}) \
-            RETURNING recorded_at",
+            "WITH new_row AS (INSERT INTO {} ({}, created_at) VALUES ({}, COALESCE(${}, NOW())) RETURNING id) {}",
             table_name,
             column_names.join(", "),
             placeholders,
             now_p,
-            self.events_table_name,
-            if self.event_ctx { ", context" } else { "" },
-            now_p,
-            if self.event_ctx {
-                ", unnested.context"
-            } else {
-                ""
-            },
-            types_p,
-            events_p,
-            if self.event_ctx {
-                format!(", ${ctx_p}::JSONB[]")
-            } else {
-                String::new()
-            },
-            if self.event_ctx { ", context" } else { "" },
+            events_insert.sql(&source, now_p, now_p + 1),
         );
 
         let classifier = write_error_classifier(create_error, self.events_table_name);
 
-        let ctx_add = if self.event_ctx {
-            quote! {
-                let contexts = events.serialize_new_event_contexts();
-                __query_args.add(contexts.as_deref() as Option<&[es_entity::ContextData]>).map_err(sqlx::Error::Encode)?;
-            }
+        // The event arrays are encoded after the index columns, whose borrows
+        // on the new entity must end before it is consumed into events.
+        let event_arg_adds = events_insert
+            .arg_exprs(&source)
+            .into_iter()
+            .skip(1)
+            .map(|expr| quote! { __query_args.add(#expr).map_err(sqlx::Error::Encode)?; });
+        let ctx_var = if self.event_ctx {
+            quote! { let contexts = events.serialize_new_event_contexts(); }
         } else {
             quote! {}
         };
 
-        let forgettable_code = if let Some(forgettable_tbl) = self.forgettable_table_name {
-            let id_type = &self.id;
-            let event_type = &self.event;
-            let payload_insert_query = format!(
-                "INSERT INTO {} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)",
-                forgettable_tbl
-            );
-            quote! {
-                let mut payload_sequences: Vec<i32> = Vec::new();
-                let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
-                let offset = events.len_persisted();
-                for (idx, event_with_ctx) in events.iter_new_events().enumerate() {
-                    if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
-                        payload_sequences.push((offset + 1 + idx) as i32);
-                        payload_values.push(payload);
-                    }
+        let forgettable_code = match self.forgettable_table_name {
+            Some(table) => {
+                let payloads = ForgettablePayloads {
+                    table,
+                    id_type: self.id,
+                    event_type: self.event,
                 }
-                if !payload_sequences.is_empty() {
+                .insert_per_entity(quote! { events }, create_error);
+                quote! {
+                    let offset = events.len_persisted();
                     let id = events.id();
-                    Self::extract_concurrent_modification(
-                        sqlx::query!(
-                            #payload_insert_query,
-                            id as &#id_type,
-                            &payload_sequences,
-                            &payload_values,
-                        )
-                        .execute(op.as_executor())
-                        .await,
-                        #create_error::ConcurrentModification,
-                    )?;
+                    #payloads
                 }
             }
-        } else {
-            quote! {}
+            None => quote! {},
         };
 
         #[cfg(feature = "instrument")]
@@ -245,9 +220,8 @@ impl ToTokens for CreateFn<'_> {
                     let mut events = Self::convert_new(new_entity);
                     let events_types = events.new_event_types();
                     let serialized_events = events.serialize_new_events();
-                    __query_args.add(&events_types).map_err(sqlx::Error::Encode)?;
-                    __query_args.add(&serialized_events).map_err(sqlx::Error::Encode)?;
-                    #ctx_add
+                    #ctx_var
+                    #(#event_arg_adds)*
 
                     let rows = sqlx::query_with(#query, __query_args)
                         .fetch_all(op.as_executor())

--- a/es-entity-macros/src/repo/delete_fn.rs
+++ b/es-entity-macros/src/repo/delete_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::write_error_classifier, options::*};
+use super::{
+    error_classifier::write_error_classifier,
+    events_write::{EventSource, EventsInsert, ForgettablePayloads},
+    options::*,
+};
 
 pub struct DeleteFn<'a> {
     id: &'a syn::Ident,
@@ -68,56 +72,27 @@ impl ToTokens for DeleteFn<'_> {
         let column_updates = self.columns.sql_updates_for_delete();
         let args = self.columns.update_query_args_for_delete();
 
-        let now_p = args.len() + 1;
-        let offset_p = now_p + 1;
-        let types_p = now_p + 2;
-        let events_p = now_p + 3;
-        let ctx_p = now_p + 4;
-
         // The soft-delete flag and the entity's staged events go out as one
         // statement; the events insert reads from the CTE so the index write
         // is ordered first. `delete` may have no staged events at all, in
         // which case the UNNEST is empty and only the CTE does work.
+        let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+        let now_p = args.len() + 1;
+        let source = EventSource::PerEntityCte {
+            cte: "updated",
+            offset_param: Some(now_p + 1),
+        };
         let query = format!(
-            "WITH updated AS (UPDATE {} SET {}{}deleted = TRUE WHERE id = $1 RETURNING id) \
-            INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-            SELECT updated.id, COALESCE(${}, NOW()), ROW_NUMBER() OVER () + ${}, unnested.event_type, unnested.event{} \
-            FROM updated CROSS JOIN UNNEST(${}::TEXT[], ${}::JSONB[]{}) AS unnested(event_type, event{}) \
-            RETURNING recorded_at",
+            "WITH updated AS (UPDATE {} SET {}{}deleted = TRUE WHERE id = $1 RETURNING id) {}",
             self.table_name,
             column_updates,
             if column_updates.is_empty() { "" } else { ", " },
-            self.events_table_name,
-            if self.event_ctx { ", context" } else { "" },
-            now_p,
-            offset_p,
-            if self.event_ctx {
-                ", unnested.context"
-            } else {
-                ""
-            },
-            types_p,
-            events_p,
-            if self.event_ctx {
-                format!(", ${ctx_p}::JSONB[]")
-            } else {
-                String::new()
-            },
-            if self.event_ctx { ", context" } else { "" },
+            events_insert.sql(&source, now_p, now_p + 2),
         );
 
         let classifier = write_error_classifier(modify_error, self.events_table_name);
-
-        let (ctx_var, ctx_arg) = if self.event_ctx {
-            (
-                quote! { let contexts = entity.events().serialize_new_event_contexts(); },
-                quote! {
-                    , contexts.as_deref() as Option<&[es_entity::ContextData]>
-                },
-            )
-        } else {
-            (quote! {}, quote! {})
-        };
+        let gather = events_insert.gather_per_entity(quote! { entity.events() });
+        let event_args = events_insert.arg_exprs(&source);
 
         #[cfg(feature = "instrument")]
         let (instrument_attr, record_id, error_recording) = {
@@ -170,36 +145,14 @@ impl ToTokens for DeleteFn<'_> {
             quote! {}
         };
 
-        let staged_payload_insert = if let Some(forgettable_tbl) = self.forgettable_table_name {
-            let payload_insert_query = format!(
-                "INSERT INTO {} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)",
-                forgettable_tbl
-            );
-            quote! {
-                let mut payload_sequences: Vec<i32> = Vec::new();
-                let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
-                for (idx, event_with_ctx) in entity.events().iter_new_events().enumerate() {
-                    if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
-                        payload_sequences.push((offset + 1 + idx) as i32);
-                        payload_values.push(payload);
-                    }
-                }
-                if !payload_sequences.is_empty() {
-                    Self::extract_concurrent_modification(
-                        sqlx::query!(
-                            #payload_insert_query,
-                            id as &#id_type,
-                            &payload_sequences,
-                            &payload_values,
-                        )
-                        .execute(op.as_executor())
-                        .await,
-                        #modify_error::ConcurrentModification,
-                    )?;
-                }
+        let staged_payload_insert = match self.forgettable_table_name {
+            Some(table) => ForgettablePayloads {
+                table,
+                id_type,
+                event_type,
             }
-        } else {
-            quote! {}
+            .insert_per_entity(quote! { entity.events() }, modify_error),
+            None => quote! {},
         };
 
         tokens.append_all(quote! {
@@ -229,19 +182,12 @@ impl ToTokens for DeleteFn<'_> {
                     #forget_payloads
 
                     let new_events = entity.events().any_new();
-                    let offset = entity.events().len_persisted();
-                    let events_types = entity.events().new_event_types();
-                    let serialized_events = entity.events().serialize_new_events();
-                    #ctx_var
+                    #gather
 
                     let rows = sqlx::query!(
                         #query,
                         #(#args,)*
-                        op.maybe_now(),
-                        offset as i32,
-                        &events_types,
-                        &serialized_events
-                        #ctx_arg
+                        #(#event_args),*
                     )
                         .fetch_all(op.as_executor())
                         .await

--- a/es-entity-macros/src/repo/events_write.rs
+++ b/es-entity-macros/src/repo/events_write.rs
@@ -1,0 +1,430 @@
+//! Shared pieces of the combined index+events write statements.
+//!
+//! Every write path (`create`, `create_all`, `update`, `update_all`, `delete`,
+//! `forget`) emits the same tail: an `INSERT INTO {events_table} … SELECT …
+//! FROM UNNEST(…) RETURNING recorded_at` fed by arrays of serialized events.
+//! Only the *head* — the data-modifying CTE that writes the index row — is
+//! genuinely per-path. This module owns the tail, the preamble that gathers
+//! the arrays, and the follow-up forgettable payload insert, so the
+//! `event_context` branching and the `$n` placeholder arithmetic each exist
+//! once instead of six times.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Where the event rows' ids and sequences come from.
+///
+/// Two orthogonal axes: whether one entity's events or many are being written
+/// (which decides what the arrays carry), and whether the id comes from a
+/// data-modifying CTE in the same statement or is supplied directly (the
+/// standalone `persist_events` helpers, used where there is no index write to
+/// fold into).
+pub enum EventSource<'a> {
+    /// One entity, id bound directly — the standalone `persist_events`.
+    PerEntityStandalone {
+        id_param: usize,
+        offset_param: usize,
+    },
+    /// One entity, id taken from a CTE the same statement writes. The event
+    /// arrays are crossed with the single CTE row and the sequence comes from
+    /// `ROW_NUMBER()`. `offset_param` is `None` where the entity is brand new
+    /// and sequences therefore start at 1 (`create`).
+    PerEntityCte {
+        cte: &'a str,
+        offset_param: Option<usize>,
+    },
+    /// Many entities, ids and sequences in the arrays — the standalone
+    /// `persist_events_batch`.
+    BatchStandalone,
+    /// Many entities, joined back to a CTE the same statement writes, which
+    /// both orders the writes and reveals index rows that vanished (a short
+    /// `RETURNING` count).
+    BatchCte { cte: &'a str },
+}
+
+impl EventSource<'_> {
+    fn is_batch(&self) -> bool {
+        matches!(self, Self::BatchStandalone | Self::BatchCte { .. })
+    }
+}
+
+/// Emitter for the events-table half of a combined write statement.
+pub struct EventsInsert<'a> {
+    pub events_table: &'a str,
+    pub event_ctx: bool,
+}
+
+impl<'a> EventsInsert<'a> {
+    pub fn new(events_table: &'a str, event_ctx: bool) -> Self {
+        Self {
+            events_table,
+            event_ctx,
+        }
+    }
+
+    /// The `INSERT INTO {events} … RETURNING recorded_at` tail.
+    ///
+    /// `now_param` is the placeholder holding `op.maybe_now()` (shared with
+    /// the head, which uses it for `created_at`); `first_array_param` is the
+    /// first placeholder this tail owns.
+    pub fn sql(
+        &self,
+        source: &EventSource<'_>,
+        now_param: usize,
+        first_array_param: usize,
+    ) -> String {
+        let ctx_col = if self.event_ctx { ", context" } else { "" };
+        let ctx_sel = if self.event_ctx {
+            ", unnested.context"
+        } else {
+            ""
+        };
+        let p = first_array_param;
+
+        let (id_expr, sequence_expr, from_clause) = match source {
+            EventSource::PerEntityStandalone {
+                id_param,
+                offset_param,
+            } => (
+                format!("${id_param}"),
+                format!("ROW_NUMBER() OVER () + ${offset_param}"),
+                self.per_entity_unnest(p, None),
+            ),
+            EventSource::PerEntityCte { cte, offset_param } => {
+                let sequence_expr = match offset_param {
+                    Some(offset) => format!("ROW_NUMBER() OVER () + ${offset}"),
+                    None => "ROW_NUMBER() OVER ()".to_string(),
+                };
+                (
+                    format!("{cte}.id"),
+                    sequence_expr,
+                    self.per_entity_unnest(p, Some(cte)),
+                )
+            }
+            EventSource::BatchStandalone => (
+                "unnested.id".to_string(),
+                "unnested.sequence".to_string(),
+                self.batch_unnest(p, None),
+            ),
+            EventSource::BatchCte { cte } => (
+                "unnested.id".to_string(),
+                "unnested.sequence".to_string(),
+                self.batch_unnest(p, Some(cte)),
+            ),
+        };
+
+        format!(
+            "INSERT INTO {} (id, recorded_at, sequence, event_type, event{ctx_col}) \
+             SELECT {id_expr}, COALESCE(${now_param}, NOW()), {sequence_expr}, unnested.event_type, unnested.event{ctx_sel} \
+             {from_clause} \
+             RETURNING recorded_at",
+            self.events_table,
+        )
+    }
+
+    /// `FROM` clause for the one-entity shapes: the arrays carry only the
+    /// event type and body, optionally crossed with a CTE row supplying the id.
+    fn per_entity_unnest(&self, p: usize, cte: Option<&str>) -> String {
+        let ctx_col = if self.event_ctx { ", context" } else { "" };
+        let ctx_unnest = if self.event_ctx {
+            format!(", ${}::JSONB[]", p + 2)
+        } else {
+            String::new()
+        };
+        let cross_join = match cte {
+            Some(cte) => format!("{cte} CROSS JOIN "),
+            None => String::new(),
+        };
+        format!(
+            "FROM {cross_join}UNNEST(${}::TEXT[], ${}::JSONB[]{ctx_unnest}) AS unnested(event_type, event{ctx_col})",
+            p,
+            p + 1,
+        )
+    }
+
+    /// `FROM` clause for the many-entity shapes: the arrays also carry ids and
+    /// sequences, optionally joined back to a CTE.
+    fn batch_unnest(&self, p: usize, cte: Option<&str>) -> String {
+        let ctx_col = if self.event_ctx { ", context" } else { "" };
+        let ctx_unnest = if self.event_ctx {
+            format!(", ${}::JSONB[]", p + 4)
+        } else {
+            String::new()
+        };
+        let join = match cte {
+            Some(cte) => format!(" JOIN {cte} ON {cte}.id = unnested.id"),
+            None => String::new(),
+        };
+        format!(
+            "FROM UNNEST(${}, ${}::INT[], ${}::TEXT[], ${}::JSONB[]{ctx_unnest}) AS unnested(id, sequence, event_type, event{ctx_col}){join}",
+            p,
+            p + 1,
+            p + 2,
+            p + 3,
+        )
+    }
+
+    /// Statements that gather the serialized events for one entity into the
+    /// locals the tail's arguments name. `events` is an expression evaluating
+    /// to `&EntityEvents<_>`.
+    pub fn gather_per_entity(&self, events: TokenStream) -> TokenStream {
+        let ctx_var = if self.event_ctx {
+            quote! { let contexts = #events.serialize_new_event_contexts(); }
+        } else {
+            quote! {}
+        };
+        quote! {
+            let offset = #events.len_persisted();
+            let events_types = #events.new_event_types();
+            let serialized_events = #events.serialize_new_events();
+            #ctx_var
+        }
+    }
+
+    /// Declarations for the batch gather accumulators.
+    pub fn batch_declarations(&self, id_type: &syn::Ident) -> TokenStream {
+        let ctx_var = if self.event_ctx {
+            quote! { let mut all_contexts: Vec<es_entity::ContextData> = Vec::new(); }
+        } else {
+            quote! {}
+        };
+        quote! {
+            let mut all_ids: Vec<&#id_type> = Vec::new();
+            let mut all_sequences: Vec<i32> = Vec::new();
+            let mut all_types = Vec::new();
+            let mut all_serialized = Vec::new();
+            #ctx_var
+        }
+    }
+
+    /// Per-entity body of the batch gather loop. `events` evaluates to
+    /// `&EntityEvents<_>` and `id` to `&{IdType}`; both are re-read rather
+    /// than threaded so callers keep their own borrow shapes.
+    pub fn gather_batch(&self, events: TokenStream, id: TokenStream) -> TokenStream {
+        let ctx_extend = if self.event_ctx {
+            quote! {
+                if let Some(contexts) = #events.serialize_new_event_contexts() {
+                    all_contexts.extend(contexts);
+                }
+            }
+        } else {
+            quote! {}
+        };
+        quote! {
+            let offset = #events.len_persisted() + 1;
+            let types = #events.new_event_types();
+            let serialized = #events.serialize_new_events();
+            #ctx_extend
+
+            let n_new = serialized.len();
+            all_types.extend(types);
+            all_serialized.extend(serialized);
+            all_ids.extend(std::iter::repeat(#id).take(n_new));
+            all_sequences.extend((offset..).take(n_new).map(|i| i as i32));
+        }
+    }
+
+    /// The argument expressions the tail binds, in placeholder order, starting
+    /// with `op.maybe_now()`. Callers wrap them for their own call style —
+    /// positional `query!` arguments, `PgArguments::add`, or `.bind`.
+    pub fn arg_exprs(&self, source: &EventSource<'_>) -> Vec<TokenStream> {
+        let mut args = vec![quote! { op.maybe_now() }];
+        if source.is_batch() {
+            args.push(quote! { &all_ids });
+            args.push(quote! { &all_sequences });
+            args.push(quote! { &all_types });
+            args.push(quote! { &all_serialized });
+            if self.event_ctx {
+                args.push(quote! {
+                    &if all_contexts.is_empty() {
+                        None
+                    } else {
+                        Some(all_contexts)
+                    }
+                });
+            }
+        } else {
+            let has_offset = !matches!(
+                source,
+                EventSource::PerEntityCte {
+                    offset_param: None,
+                    ..
+                }
+            );
+            if has_offset {
+                args.push(quote! { offset as i32 });
+            }
+            args.push(quote! { &events_types });
+            args.push(quote! { &serialized_events });
+            if self.event_ctx {
+                args.push(quote! { contexts.as_deref() as Option<&[es_entity::ContextData]> });
+            }
+        }
+        args
+    }
+}
+
+/// Emitter for the follow-up forgettable payload insert.
+///
+/// Payloads live in a third table, so they cannot join the combined statement:
+/// sub-statements of a data-modifying CTE do not see each other's writes, and
+/// `forget`'s payload delete has to be able to see them.
+pub struct ForgettablePayloads<'a> {
+    pub table: &'a str,
+    pub id_type: &'a syn::Ident,
+    pub event_type: &'a syn::Ident,
+}
+
+impl ForgettablePayloads<'_> {
+    /// Collects and inserts the payloads of one entity's new events.
+    /// Requires `offset` (the pre-persist `len_persisted`) and `id` in scope.
+    pub fn insert_per_entity(&self, events: TokenStream, error: &syn::Ident) -> TokenStream {
+        let Self {
+            table,
+            id_type,
+            event_type,
+        } = self;
+        let query = format!(
+            "INSERT INTO {table} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)"
+        );
+        quote! {
+            let mut payload_sequences: Vec<i32> = Vec::new();
+            let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
+            for (idx, event_with_ctx) in #events.iter_new_events().enumerate() {
+                if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
+                    payload_sequences.push((offset + 1 + idx) as i32);
+                    payload_values.push(payload);
+                }
+            }
+            if !payload_sequences.is_empty() {
+                Self::extract_concurrent_modification(
+                    sqlx::query!(
+                        #query,
+                        id as &#id_type,
+                        &payload_sequences,
+                        &payload_values,
+                    )
+                    .execute(op.as_executor())
+                    .await,
+                    #error::ConcurrentModification,
+                )?;
+            }
+        }
+    }
+
+    /// Declarations for the batch payload accumulators.
+    pub fn batch_declarations(&self) -> TokenStream {
+        let id_type = self.id_type;
+        quote! {
+            let mut payload_ids: Vec<&#id_type> = Vec::new();
+            let mut payload_sequences: Vec<i32> = Vec::new();
+            let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
+        }
+    }
+
+    /// Per-entity body of the batch payload gather. Requires `offset` (the
+    /// 1-based first sequence for this entity) in scope.
+    pub fn gather_batch(&self, events: TokenStream, id: TokenStream) -> TokenStream {
+        let event_type = self.event_type;
+        quote! {
+            for (idx, event_with_ctx) in #events.iter_new_events().enumerate() {
+                if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
+                    payload_ids.push(#id);
+                    payload_sequences.push((offset + idx) as i32);
+                    payload_values.push(payload);
+                }
+            }
+        }
+    }
+
+    /// The batch payload insert.
+    pub fn insert_batch(&self, error: &syn::Ident) -> TokenStream {
+        let query = format!(
+            "INSERT INTO {} (entity_id, sequence, payload) SELECT unnested.entity_id, unnested.sequence, unnested.payload FROM UNNEST($1, $2::INT[], $3::JSONB[]) AS unnested(entity_id, sequence, payload)",
+            self.table
+        );
+        quote! {
+            if !payload_sequences.is_empty() {
+                Self::extract_concurrent_modification(
+                    sqlx::query(#query)
+                        .bind(&payload_ids)
+                        .bind(&payload_sequences)
+                        .bind(&payload_values)
+                        .execute(op.as_executor())
+                        .await,
+                    #error::ConcurrentModification,
+                )?;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn per_entity_sql_without_offset_matches_create() {
+        let insert = EventsInsert::new("entity_events", false);
+        let source = EventSource::PerEntityCte {
+            cte: "new_row",
+            offset_param: None,
+        };
+        assert_eq!(
+            insert.sql(&source, 2, 3),
+            "INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) \
+             SELECT new_row.id, COALESCE($2, NOW()), ROW_NUMBER() OVER (), unnested.event_type, unnested.event \
+             FROM new_row CROSS JOIN UNNEST($3::TEXT[], $4::JSONB[]) AS unnested(event_type, event) \
+             RETURNING recorded_at"
+        );
+    }
+
+    #[test]
+    fn per_entity_sql_with_offset_and_context() {
+        let insert = EventsInsert::new("entity_events", true);
+        let source = EventSource::PerEntityCte {
+            cte: "updated",
+            offset_param: Some(4),
+        };
+        assert_eq!(
+            insert.sql(&source, 3, 5),
+            "INSERT INTO entity_events (id, recorded_at, sequence, event_type, event, context) \
+             SELECT updated.id, COALESCE($3, NOW()), ROW_NUMBER() OVER () + $4, unnested.event_type, unnested.event, unnested.context \
+             FROM updated CROSS JOIN UNNEST($5::TEXT[], $6::JSONB[], $7::JSONB[]) AS unnested(event_type, event, context) \
+             RETURNING recorded_at"
+        );
+    }
+
+    #[test]
+    fn batch_sql_joins_the_cte() {
+        let insert = EventsInsert::new("entity_events", false);
+        let source = EventSource::BatchCte { cte: "new_rows" };
+        assert_eq!(
+            insert.sql(&source, 1, 4),
+            "INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) \
+             SELECT unnested.id, COALESCE($1, NOW()), unnested.sequence, unnested.event_type, unnested.event \
+             FROM UNNEST($4, $5::INT[], $6::TEXT[], $7::JSONB[]) AS unnested(id, sequence, event_type, event) \
+             JOIN new_rows ON new_rows.id = unnested.id \
+             RETURNING recorded_at"
+        );
+    }
+
+    #[test]
+    fn arg_exprs_follow_placeholder_order() {
+        let insert = EventsInsert::new("entity_events", false);
+        let per_entity = insert.arg_exprs(&EventSource::PerEntityCte {
+            cte: "updated",
+            offset_param: Some(3),
+        });
+        let rendered: Vec<_> = per_entity.iter().map(|t| t.to_string()).collect();
+        assert_eq!(
+            rendered,
+            vec![
+                "op . maybe_now ()",
+                "offset as i32",
+                "& events_types",
+                "& serialized_events"
+            ]
+        );
+    }
+}

--- a/es-entity-macros/src/repo/forget_fn.rs
+++ b/es-entity-macros/src/repo/forget_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::concurrent_modification_classifier, options::*};
+use super::{
+    error_classifier::concurrent_modification_classifier,
+    events_write::{EventSource, EventsInsert},
+    options::*,
+};
 
 pub struct ForgetFn<'a> {
     id: &'a syn::Ident,
@@ -75,55 +79,32 @@ impl ToTokens for ForgetFn<'_> {
                 .map(|c| format!("{} = NULL", c))
                 .collect::<Vec<_>>()
                 .join(", ");
+            let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+            let source = EventSource::PerEntityCte {
+                cte: "updated",
+                offset_param: Some(3),
+            };
             let combined_query = format!(
-                "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) \
-                INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-                SELECT updated.id, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event{} \
-                FROM updated CROSS JOIN UNNEST($4::TEXT[], $5::JSONB[]{}) AS unnested(event_type, event{}) \
-                RETURNING recorded_at",
+                "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) {}",
                 self.table_name,
                 set_clause,
-                self.events_table_name,
-                if self.event_ctx { ", context" } else { "" },
-                if self.event_ctx {
-                    ", unnested.context"
-                } else {
-                    ""
-                },
-                if self.event_ctx { ", $6::JSONB[]" } else { "" },
-                if self.event_ctx { ", context" } else { "" },
+                events_insert.sql(&source, 2, 4),
             );
 
             let classifier = concurrent_modification_classifier(error, self.events_table_name);
-
-            let (ctx_var, ctx_arg) = if self.event_ctx {
-                (
-                    quote! { let contexts = entity.events().serialize_new_event_contexts(); },
-                    quote! {
-                        , contexts.as_deref() as Option<&[es_entity::ContextData]>
-                    },
-                )
-            } else {
-                (quote! {}, quote! {})
-            };
+            let gather = events_insert.gather_per_entity(quote! { entity.events() });
+            let event_args = events_insert.arg_exprs(&source);
 
             quote! {
                 let has_new_events = entity.events().any_new();
-                let offset = entity.events().len_persisted();
-                let events_types = entity.events().new_event_types();
-                let serialized_events = entity.events().serialize_new_events();
-                #ctx_var
+                #gather
 
                 let rows = {
                     let id = &entity.id;
                     sqlx::query!(
                         #combined_query,
                         id as &#id_type,
-                        op.maybe_now(),
-                        offset as i32,
-                        &events_types,
-                        &serialized_events
-                        #ctx_arg
+                        #(#event_args),*
                     )
                     .fetch_all(op.as_executor())
                     .await

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -5,6 +5,7 @@ mod create_fn;
 mod delete_fn;
 mod error_classifier;
 mod error_types;
+mod events_write;
 mod find_all_fn;
 mod find_by_fn;
 mod forget_fn;

--- a/es-entity-macros/src/repo/persist_events_batch_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_batch_fn.rs
@@ -2,7 +2,10 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::options::*;
+use super::{
+    events_write::{EventSource, EventsInsert},
+    options::*,
+};
 
 pub struct PersistEventsBatchFn<'a> {
     id: &'a syn::Ident,
@@ -29,20 +32,12 @@ impl ToTokens for PersistEventsBatchFn<'_> {
         let id_type = &self.id;
         let event_type = &self.event;
 
-        let query = format!(
-            "INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-             SELECT unnested.id, COALESCE($1, NOW()), unnested.sequence, unnested.event_type, unnested.event{} \
-             FROM UNNEST($2, $3::INT[], $4::TEXT[], $5::JSONB[]{}) \
-             AS unnested(id, sequence, event_type, event{}) RETURNING recorded_at",
-            self.events_table_name,
-            if self.event_ctx { ", context" } else { "" },
-            if self.event_ctx {
-                ", unnested.context"
-            } else {
-                ""
-            },
-            if self.event_ctx { ", $6::JSONB[]" } else { "" },
-            if self.event_ctx { ", context" } else { "" }
+        // Same events-table tail as the combined bulk write statements, just
+        // without a CTE to join back to.
+        let query = EventsInsert::new(self.events_table_name, self.event_ctx).sql(
+            &EventSource::BatchStandalone,
+            1,
+            2,
         );
 
         let (ctx_var, ctx_extend, ctx_bind) = if self.event_ctx {

--- a/es-entity-macros/src/repo/persist_events_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_fn.rs
@@ -2,7 +2,10 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::options::*;
+use super::{
+    events_write::{EventSource, EventsInsert},
+    options::*,
+};
 
 pub struct PersistEventsFn<'a> {
     id: &'a syn::Ident,
@@ -26,18 +29,14 @@ impl<'a> From<&'a RepositoryOptions> for PersistEventsFn<'a> {
 
 impl ToTokens for PersistEventsFn<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let query = format!(
-            "INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) SELECT $1, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event{} FROM UNNEST($4::TEXT[], $5::JSONB[]{}) AS unnested(event_type, event{}) RETURNING recorded_at",
-            self.events_table_name,
-            if self.event_ctx { ", context" } else { "" },
-            if self.event_ctx {
-                ", unnested.context"
-            } else {
-                ""
-            },
-            if self.event_ctx { ", $6::JSONB[]" } else { "" },
-            if self.event_ctx { ", context" } else { "" }
-        );
+        // Same events-table tail as the combined write statements, just with
+        // the id bound directly instead of read from a CTE.
+        let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+        let source = EventSource::PerEntityStandalone {
+            id_param: 1,
+            offset_param: 3,
+        };
+        let query = events_insert.sql(&source, 2, 4);
 
         let (ctx_var, ctx_arg) = if self.event_ctx {
             (

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::write_error_classifier, options::*};
+use super::{
+    error_classifier::write_error_classifier,
+    events_write::{EventSource, EventsInsert, ForgettablePayloads},
+    options::*,
+};
 
 pub struct UpdateAllFn<'a> {
     entity: &'a syn::Ident,
@@ -66,71 +70,28 @@ impl ToTokens for UpdateAllFn<'_> {
         };
 
         let id_type = self.id;
-        let event_type = self.event;
 
-        let (forgettable_vars, forgettable_extract, forgettable_insert) = if let Some(
-            forgettable_tbl,
-        ) =
-            self.forgettable_table_name
-        {
-            let payload_insert_query = format!(
-                "INSERT INTO {} (entity_id, sequence, payload) SELECT unnested.entity_id, unnested.sequence, unnested.payload FROM UNNEST($1, $2::INT[], $3::JSONB[]) AS unnested(entity_id, sequence, payload)",
-                forgettable_tbl
-            );
-            (
-                quote! {
-                    let mut payload_ids: Vec<&#id_type> = Vec::new();
-                    let mut payload_sequences: Vec<i32> = Vec::new();
-                    let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
-                },
-                quote! {
-                    for (idx, event_with_ctx) in entity.events().iter_new_events().enumerate() {
-                        if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
-                            payload_ids.push(&entity.id);
-                            payload_sequences.push((offset + idx) as i32);
-                            payload_values.push(payload);
-                        }
-                    }
-                },
-                quote! {
-                    if !payload_sequences.is_empty() {
-                        Self::extract_concurrent_modification(
-                            sqlx::query(#payload_insert_query)
-                                .bind(&payload_ids)
-                                .bind(&payload_sequences)
-                                .bind(&payload_values)
-                                .execute(op.as_executor())
-                                .await,
-                            #modify_error::ConcurrentModification,
-                        )?;
-                    }
-                },
-            )
-        } else {
-            (quote! {}, quote! {}, quote! {})
-        };
+        let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
 
-        let (ctx_var, ctx_extend, ctx_bind) = if self.event_ctx {
-            (
-                quote! {
-                    let mut all_contexts: Vec<es_entity::ContextData> = Vec::new();
-                },
-                quote! {
-                    if let Some(contexts) = entity.events().serialize_new_event_contexts() {
-                        all_contexts.extend(contexts);
-                    }
-                },
-                quote! {
-                    .bind(&if all_contexts.is_empty() {
-                        None
-                    } else {
-                        Some(all_contexts)
-                    })
-                },
-            )
-        } else {
-            (quote! {}, quote! {}, quote! {})
-        };
+        let payloads = self
+            .forgettable_table_name
+            .map(|table| ForgettablePayloads {
+                table,
+                id_type,
+                event_type: self.event,
+            });
+        let forgettable_vars = payloads
+            .as_ref()
+            .map(|p| p.batch_declarations())
+            .unwrap_or_default();
+        let forgettable_extract = payloads
+            .as_ref()
+            .map(|p| p.gather_batch(quote! { entity.events() }, quote! { &entity.id }))
+            .unwrap_or_default();
+        let forgettable_insert = payloads
+            .as_ref()
+            .map(|p| p.insert_batch(modify_error))
+            .unwrap_or_default();
 
         // Every entity in the batch is only borrowed here, so the index columns
         // and the event arrays can be gathered in the same pass and written by
@@ -152,38 +113,20 @@ impl ToTokens for UpdateAllFn<'_> {
             let table_name = self.table_name;
 
             let now_p = n_columns + 1;
-            let ids_p = now_p + 1;
-            let sequences_p = now_p + 2;
-            let types_p = now_p + 3;
-            let events_p = now_p + 4;
-            let ctx_p = now_p + 5;
-
+            let source = EventSource::BatchCte { cte: "updated" };
             let query = format!(
                 "WITH updated AS (UPDATE {table_name} SET {set_clause} \
                      FROM UNNEST({placeholders}) \
                      AS unnested({column_list}) \
-                     WHERE {table_name}.id = unnested.id RETURNING {table_name}.id) \
-                     INSERT INTO {events_table} (id, recorded_at, sequence, event_type, event{ctx_col}) \
-                     SELECT unnested.id, COALESCE(${now_p}, NOW()), unnested.sequence, unnested.event_type, unnested.event{ctx_sel} \
-                     FROM UNNEST(${ids_p}, ${sequences_p}::INT[], ${types_p}::TEXT[], ${events_p}::JSONB[]{ctx_unnest}) \
-                     AS unnested(id, sequence, event_type, event{ctx_col}) \
-                     JOIN updated ON updated.id = unnested.id \
-                     RETURNING recorded_at",
-                events_table = self.events_table_name,
-                ctx_col = if self.event_ctx { ", context" } else { "" },
-                ctx_sel = if self.event_ctx {
-                    ", unnested.context"
-                } else {
-                    ""
-                },
-                ctx_unnest = if self.event_ctx {
-                    format!(", ${ctx_p}::JSONB[]")
-                } else {
-                    String::new()
-                },
+                     WHERE {table_name}.id = unnested.id RETURNING {table_name}.id) {}",
+                events_insert.sql(&source, now_p, now_p + 1),
             );
 
             let classifier = write_error_classifier(modify_error, self.events_table_name);
+            let event_binds = events_insert
+                .arg_exprs(&source)
+                .into_iter()
+                .map(|expr| quote! { .bind(#expr) });
 
             (
                 Some(vecs),
@@ -192,12 +135,7 @@ impl ToTokens for UpdateAllFn<'_> {
                     let expected_events = all_ids.len();
                     let rows = sqlx::query(#query)
                         #(#bind_tokens)*
-                        .bind(op.maybe_now())
-                        .bind(&all_ids)
-                        .bind(&all_sequences)
-                        .bind(&all_types)
-                        .bind(&all_serialized)
-                        #ctx_bind
+                        #(#event_binds)*
                         .fetch_all(op.as_executor())
                         .await
                         .map_err(#classifier)?;
@@ -245,28 +183,18 @@ impl ToTokens for UpdateAllFn<'_> {
         // Gathering of the event arrays only happens for the combined path;
         // the no-index-column path defers entirely to `persist_events_batch`.
         let (event_collection_vars, event_collection_pushes) = if self.columns.updates_needed() {
+            let batch_declarations = events_insert.batch_declarations(id_type);
+            let gather =
+                events_insert.gather_batch(quote! { entity.events() }, quote! { &entity.id });
             (
                 quote! {
-                    let mut all_ids: Vec<&#id_type> = Vec::new();
-                    let mut all_sequences: Vec<i32> = Vec::new();
-                    let mut all_types = Vec::new();
-                    let mut all_serialized = Vec::new();
+                    #batch_declarations
                     let mut n_persisted: std::collections::HashMap<#id_type, usize> = std::collections::HashMap::new();
-                    #ctx_var
                     #forgettable_vars
                 },
                 quote! {
-                    let offset = entity.events().len_persisted() + 1;
-                    let types = entity.events().new_event_types();
-                    let serialized = entity.events().serialize_new_events();
-                    #ctx_extend
+                    #gather
                     #forgettable_extract
-
-                    let n_new = serialized.len();
-                    all_types.extend(types);
-                    all_serialized.extend(serialized);
-                    all_ids.extend(std::iter::repeat(&entity.id).take(n_new));
-                    all_sequences.extend((offset..).take(n_new).map(|i| i as i32));
                     n_persisted.insert(entity.id.clone(), n_new);
                 },
             )

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -2,7 +2,11 @@ use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
-use super::{error_classifier::write_error_classifier, options::*};
+use super::{
+    error_classifier::write_error_classifier,
+    events_write::{EventSource, EventsInsert, ForgettablePayloads},
+    options::*,
+};
 
 pub struct UpdateFn<'a> {
     entity: &'a syn::Ident,
@@ -66,104 +70,45 @@ impl ToTokens for UpdateFn<'_> {
                 .variable_assignments_for_update(syn::parse_quote! { entity });
             let column_updates = self.columns.sql_updates();
             let args = self.columns.update_query_args();
-            let now_p = args.len() + 1;
-            let offset_p = now_p + 1;
-            let types_p = now_p + 2;
-            let events_p = now_p + 3;
-            let ctx_p = now_p + 4;
 
+            let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
+            let now_p = args.len() + 1;
+            let source = EventSource::PerEntityCte {
+                cte: "updated",
+                offset_param: Some(now_p + 1),
+            };
             let query = format!(
-                "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) \
-                INSERT INTO {} (id, recorded_at, sequence, event_type, event{}) \
-                SELECT updated.id, COALESCE(${}, NOW()), ROW_NUMBER() OVER () + ${}, unnested.event_type, unnested.event{} \
-                FROM updated CROSS JOIN UNNEST(${}::TEXT[], ${}::JSONB[]{}) AS unnested(event_type, event{}) \
-                RETURNING recorded_at",
+                "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) {}",
                 self.table_name,
                 column_updates,
-                self.events_table_name,
-                if self.event_ctx { ", context" } else { "" },
-                now_p,
-                offset_p,
-                if self.event_ctx {
-                    ", unnested.context"
-                } else {
-                    ""
-                },
-                types_p,
-                events_p,
-                if self.event_ctx {
-                    format!(", ${ctx_p}::JSONB[]")
-                } else {
-                    String::new()
-                },
-                if self.event_ctx { ", context" } else { "" },
+                events_insert.sql(&source, now_p, now_p + 2),
             );
 
             let classifier = write_error_classifier(modify_error, self.events_table_name);
+            let gather = events_insert.gather_per_entity(quote! { entity.events() });
+            let event_args = events_insert.arg_exprs(&source);
 
             // Forgettable payloads are written to their own table, so they
             // stay a follow-up statement (still one fewer round trip than
             // before, where the index update was separate too).
-            let forgettable_code = if let Some(forgettable_tbl) = self.forgettable_table_name {
-                let id_type = self.id;
-                let event_type = self.event;
-                let payload_insert_query = format!(
-                    "INSERT INTO {} (entity_id, sequence, payload) SELECT $1, unnested.sequence, unnested.payload FROM UNNEST($2::INT[], $3::JSONB[]) AS unnested(sequence, payload)",
-                    forgettable_tbl
-                );
-                quote! {
-                    let mut payload_sequences: Vec<i32> = Vec::new();
-                    let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();
-                    for (idx, event_with_ctx) in entity.events().iter_new_events().enumerate() {
-                        if let Some(payload) = #event_type::extract_forgettable_payloads(&event_with_ctx.event) {
-                            payload_sequences.push((offset + 1 + idx) as i32);
-                            payload_values.push(payload);
-                        }
-                    }
-                    if !payload_sequences.is_empty() {
-                        Self::extract_concurrent_modification(
-                            sqlx::query!(
-                                #payload_insert_query,
-                                id as &#id_type,
-                                &payload_sequences,
-                                &payload_values,
-                            )
-                            .execute(op.as_executor())
-                            .await,
-                            #modify_error::ConcurrentModification,
-                        )?;
-                    }
+            let forgettable_code = match self.forgettable_table_name {
+                Some(table) => ForgettablePayloads {
+                    table,
+                    id_type: self.id,
+                    event_type: self.event,
                 }
-            } else {
-                quote! {}
-            };
-
-            let (ctx_var, ctx_arg) = if self.event_ctx {
-                (
-                    quote! { let contexts = entity.events().serialize_new_event_contexts(); },
-                    quote! {
-                        , contexts.as_deref() as Option<&[es_entity::ContextData]>
-                    },
-                )
-            } else {
-                (quote! {}, quote! {})
+                .insert_per_entity(quote! { entity.events() }, modify_error),
+                None => quote! {},
             };
 
             quote! {
                 #assignments
-                let offset = entity.events().len_persisted();
-                let events_types = entity.events().new_event_types();
-                let serialized_events = entity.events().serialize_new_events();
-                #ctx_var
+                #gather
 
                 let rows = sqlx::query!(
                     #query,
                     #(#args,)*
-                    op.maybe_now(),
-                    offset as i32,
-                    &events_types,
-                    &serialized_events
-                    #ctx_arg
+                    #(#event_args),*
                 )
                     .fetch_all(op.as_executor())
                     .await


### PR DESCRIPTION
**Stacked on #196** — base is `task/single-round-trip-write-019ff789`, so this PR's diff is only the refactor. Open it alongside #196 to compare the two shapes.

## The problem this addresses

Collapsing the writes into single statements (#196) removed `persist_events` from the hot paths — and with it the DRY-ing it was quietly providing. Each write path ended up with its own copy of the events-table INSERT:

| Duplicated shape | Copies before |
|---|---|
| events-INSERT SQL tail | 8 (6 write paths + 2 `persist_events` helpers) |
| `event_context` ternaries | ~30 branch sites |
| hand-maintained `$n` placeholder counters | 6 independent runs |
| forgettable payload insert | 7 |

The placeholder counters were the sharp edge: six separate `let now_p = …; let offset_p = now_p + 1; let types_p = now_p + 2; …` runs, each one a silent-miscompile waiting to happen if a parameter is inserted.

## The shape

`events_write.rs` gains two emitters:

- **`EventsInsert`** — owns the `INSERT INTO {events} … SELECT … FROM UNNEST(…) RETURNING recorded_at` tail, the preamble that gathers the arrays, and the argument expressions in placeholder order.
- **`ForgettablePayloads`** — owns the follow-up payload insert (single + batch).

`EventSource` names the four shapes that actually exist, along two honest axes — one entity or many, and id from a CTE the same statement writes or supplied directly:

```rust
PerEntityStandalone { id_param, offset_param }   // persist_events
PerEntityCte        { cte, offset_param }        // create / update / delete / forget
BatchStandalone                                   // persist_events_batch
BatchCte            { cte }                      // create_all / update_all
```

Each write path keeps its **own head** — the data-modifying CTE, which is the genuinely per-path part — and composes the tail onto it:

```rust
let source = EventSource::PerEntityCte { cte: "updated", offset_param: Some(now_p + 1) };
let query = format!(
    "WITH updated AS (UPDATE {} SET {} WHERE id = $1 RETURNING id) {}",
    self.table_name, column_updates, events_insert.sql(&source, now_p, now_p + 2),
);
```

Argument expressions are returned as a *list* rather than pre-wrapped, because the call styles differ and should: `update`/`delete`/`forget` keep compile-checked `sqlx::query!` positional args, `create`/`create_all` need eager `PgArguments::add` (their index-column borrows must end before the entity is consumed into events), and `update_all` binds at runtime.

## Equivalence proof

**Every exact-token codegen test is unchanged and still passes** — all eight emitters produce byte-identical output. That is the strongest evidence available that this is purely a codegen-source refactor.

Two deliberate, inert exceptions, both in `create_all`'s gather loop: a `n_events` local renamed to `n_new` (the two bulk paths had gratuitously different names for the same thing), and payload extraction now running after the gather rather than interleaved with it.

## Cost

| | lines |
|---|---|
| 8 write-path emitters | 2085 → 1780 (**−305**) |
| new `events_write.rs` | +362 |
| **net** | **+57** |

**Raw LOC is a wash — that is not the argument.** The 305 removed lines were eight copies of one thing; the 362 added are one copy, plus docs and four unit tests that pin the SQL shapes directly. The win is single-point-of-truth: adding a column to the events table is now one edit instead of eight, and the `$n` arithmetic is centralised.

## The trade-off to weigh

**Against this PR:** reading `update_fn.rs` no longer shows you the SQL it emits — you compose it mentally from the builder. Before #196, each fn owning its own SQL string *was* the house style. The exact-token tests also grow a level of indirection between the source and the pinned output.

**For it:** the per-path files now show what actually differs between the paths (the head, the borrow shape, the error type) instead of burying it in ~50 lines of identical tail-building each.

## Verification

- 331/331 tests pass against live Postgres (327 from #196 + 4 new `events_write` unit tests)
- `nix flake check`: all checks passed
- all pre-existing exact-token codegen tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Macro-only refactor with byte-identical codegen tests; no runtime behavior or schema changes, and it reduces duplicate SQL placeholder logic.
> 
> **Overview**
> **Centralizes** repeated macro codegen for combined index+events writes into `events_write.rs`, so write paths no longer each embed the events-table `INSERT` tail, `event_context` branches, `$n` placeholder math, and forgettable payload follow-ups.
> 
> **Adds** `EventsInsert` (SQL tail, batch/per-entity gather, bind expressions) and `ForgettablePayloads` (per-entity and batch payload inserts), keyed by `EventSource` for the four real shapes (single vs batch, CTE vs standalone id).
> 
> **Updates** `create`, `create_all`, `update`, `update_all`, `delete`, `forget`, and the `persist_events` helpers to compose each path’s own CTE “head” with the shared tail; per-path files shrink while emitted SQL stays the same per exact-token tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1172dbca70b739c3d490137a1238baeccee11dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->