### PR TITLE
fix(repo): classify duplicate-id create violations deterministically

### DIFF
--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
 use super::{
-    error_classifier::write_error_classifier,
+    error_classifier::create_error_classifier,
     events_write::{EventSource, EventsInsert, ForgettablePayloads},
     options::*,
 };
@@ -74,9 +74,11 @@ impl ToTokens for CreateAllFn<'_> {
             .create_all_arg_collection(syn::parse_quote! { new_entity });
 
         // Both inserts in one statement. The events insert joins the `new_rows`
-        // CTE, which forces the index rows to be written first — so a duplicate
-        // id surfaces as the index constraint violation rather than as a unique
-        // violation on the events table.
+        // CTE, which reveals index rows that vanished (a short RETURNING
+        // count). Postgres interleaves the CTE and main inserts with no
+        // guaranteed ordering, so a duplicate id (including an intra-batch
+        // one) may surface as either table's constraint — the classifier maps
+        // both to the same `ConstraintViolation`.
         let events_insert = EventsInsert::new(self.events_table_name, self.event_ctx);
         let source = EventSource::BatchCte { cte: "new_rows" };
         let query = format!(
@@ -92,7 +94,7 @@ impl ToTokens for CreateAllFn<'_> {
             events_insert.sql(&source, 1, column_names.len() + 2),
         );
 
-        let classifier = write_error_classifier(create_error, self.events_table_name);
+        let classifier = create_error_classifier(create_error, self.events_table_name, table_name);
 
         let id_type = self.id;
 
@@ -381,7 +383,11 @@ mod tests {
                                 if db_err.is_unique_violation()
                                     && db_err.table() == Some("entity_events") =>
                             {
-                                EntityCreateError::ConcurrentModification
+                                EntityCreateError::ConstraintViolation {
+                                    column: Self::map_constraint_column(Some("entities_pkey")),
+                                    value: es_entity::extract_events_pkey_id_value(db_err.as_ref()),
+                                    inner: e,
+                                }
                             }
                             sqlx::Error::Database(db_err)
                                 if db_err.table() != Some("entity_events")

--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -3,7 +3,6 @@ use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
 use super::{
-    error_classifier::create_error_classifier,
     events_write::{EventSource, EventsInsert, ForgettablePayloads},
     options::*,
 };
@@ -93,8 +92,6 @@ impl ToTokens for CreateAllFn<'_> {
             column_names.join(", "),
             events_insert.sql(&source, 1, column_names.len() + 2),
         );
-
-        let classifier = create_error_classifier(create_error, self.events_table_name, table_name);
 
         let id_type = self.id;
 
@@ -222,7 +219,7 @@ impl ToTokens for CreateAllFn<'_> {
                     let rows = sqlx::query_with(#query, __query_args)
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(#classifier)?;
+                        .map_err(Self::classify_create_error)?;
 
                     #forgettable_insert
 
@@ -378,29 +375,7 @@ mod tests {
                     )
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err)
-                                if db_err.is_unique_violation()
-                                    && db_err.table() == Some("entity_events") =>
-                            {
-                                EntityCreateError::ConstraintViolation {
-                                    column: Self::map_constraint_column(Some("entities_pkey")),
-                                    value: es_entity::extract_events_pkey_id_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            sqlx::Error::Database(db_err)
-                                if db_err.table() != Some("entity_events")
-                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
-                            {
-                                EntityCreateError::ConstraintViolation {
-                                    column: Self::map_constraint_column(db_err.constraint()),
-                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            _ => EntityCreateError::Sqlx(e),
-                        })?;
+                        .map_err(Self::classify_create_error)?;
 
                     if expected_events > 0 {
                         if rows.len() != expected_events {

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -3,7 +3,6 @@ use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
 use super::{
-    error_classifier::create_error_classifier,
     events_write::{EventSource, EventsInsert, ForgettablePayloads},
     options::*,
 };
@@ -97,8 +96,6 @@ impl ToTokens for CreateFn<'_> {
             now_p,
             events_insert.sql(&source, now_p, now_p + 1),
         );
-
-        let classifier = create_error_classifier(create_error, self.events_table_name, table_name);
 
         // The event arrays are encoded after the index columns, whose borrows
         // on the new entity must end before it is consumed into events.
@@ -227,7 +224,7 @@ impl ToTokens for CreateFn<'_> {
                     let rows = sqlx::query_with(#query, __query_args)
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(#classifier)?;
+                        .map_err(Self::classify_create_error)?;
 
                     #forgettable_code
 
@@ -345,29 +342,7 @@ mod tests {
                     )
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err)
-                                if db_err.is_unique_violation()
-                                    && db_err.table() == Some("entity_events") =>
-                            {
-                                EntityCreateError::ConstraintViolation {
-                                    column: Self::map_constraint_column(Some("entities_pkey")),
-                                    value: es_entity::extract_events_pkey_id_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            sqlx::Error::Database(db_err)
-                                if db_err.table() != Some("entity_events")
-                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
-                            {
-                                EntityCreateError::ConstraintViolation {
-                                    column: Self::map_constraint_column(db_err.constraint()),
-                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            _ => EntityCreateError::Sqlx(e),
-                        })?;
+                        .map_err(Self::classify_create_error)?;
 
                     let recorded_at = rows
                         .first()
@@ -479,29 +454,7 @@ mod tests {
                     )
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err)
-                                if db_err.is_unique_violation()
-                                    && db_err.table() == Some("entity_events") =>
-                            {
-                                EntityCreateError::ConstraintViolation {
-                                    column: Self::map_constraint_column(Some("entities_pkey")),
-                                    value: es_entity::extract_events_pkey_id_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            sqlx::Error::Database(db_err)
-                                if db_err.table() != Some("entity_events")
-                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
-                            {
-                                EntityCreateError::ConstraintViolation {
-                                    column: Self::map_constraint_column(db_err.constraint()),
-                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            _ => EntityCreateError::Sqlx(e),
-                        })?;
+                        .map_err(Self::classify_create_error)?;
 
                     let recorded_at = rows
                         .first()

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
 use super::{
-    error_classifier::write_error_classifier,
+    error_classifier::create_error_classifier,
     events_write::{EventSource, EventsInsert, ForgettablePayloads},
     options::*,
 };
@@ -75,10 +75,11 @@ impl ToTokens for CreateFn<'_> {
         let arg_adds = self.columns.create_query_arg_adds();
 
         // Index insert and events insert combined into one statement. The
-        // outer insert reads from the CTE, which forces the index row to be
-        // written first — preserving error precedence (a duplicate id
-        // surfaces as the index pkey violation, not as a unique violation on
-        // the events table) and providing the id without a second bind.
+        // outer insert reads from the CTE, which provides the id without a
+        // second bind. Postgres interleaves the CTE and main inserts with no
+        // guaranteed ordering, so a duplicate id may surface as either
+        // table's constraint — the classifier maps both to the same
+        // `ConstraintViolation`.
         //
         // A brand-new entity has no persisted events, so sequences start at 1
         // and no offset parameter is needed.
@@ -97,7 +98,7 @@ impl ToTokens for CreateFn<'_> {
             events_insert.sql(&source, now_p, now_p + 1),
         );
 
-        let classifier = write_error_classifier(create_error, self.events_table_name);
+        let classifier = create_error_classifier(create_error, self.events_table_name, table_name);
 
         // The event arrays are encoded after the index columns, whose borrows
         // on the new entity must end before it is consumed into events.
@@ -349,7 +350,11 @@ mod tests {
                                 if db_err.is_unique_violation()
                                     && db_err.table() == Some("entity_events") =>
                             {
-                                EntityCreateError::ConcurrentModification
+                                EntityCreateError::ConstraintViolation {
+                                    column: Self::map_constraint_column(Some("entities_pkey")),
+                                    value: es_entity::extract_events_pkey_id_value(db_err.as_ref()),
+                                    inner: e,
+                                }
                             }
                             sqlx::Error::Database(db_err)
                                 if db_err.table() != Some("entity_events")
@@ -479,7 +484,11 @@ mod tests {
                                 if db_err.is_unique_violation()
                                     && db_err.table() == Some("entity_events") =>
                             {
-                                EntityCreateError::ConcurrentModification
+                                EntityCreateError::ConstraintViolation {
+                                    column: Self::map_constraint_column(Some("entities_pkey")),
+                                    value: es_entity::extract_events_pkey_id_value(db_err.as_ref()),
+                                    inner: e,
+                                }
                             }
                             sqlx::Error::Database(db_err)
                                 if db_err.table() != Some("entity_events")

--- a/es-entity-macros/src/repo/delete_fn.rs
+++ b/es-entity-macros/src/repo/delete_fn.rs
@@ -3,7 +3,6 @@ use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
 use super::{
-    error_classifier::write_error_classifier,
     events_write::{EventSource, EventsInsert, ForgettablePayloads},
     options::*,
 };
@@ -90,7 +89,6 @@ impl ToTokens for DeleteFn<'_> {
             events_insert.sql(&source, now_p, now_p + 2),
         );
 
-        let classifier = write_error_classifier(modify_error, self.events_table_name);
         let gather = events_insert.gather_per_entity(quote! { entity.events() });
         let event_args = events_insert.arg_exprs(&source);
 
@@ -191,7 +189,7 @@ impl ToTokens for DeleteFn<'_> {
                     )
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(#classifier)?;
+                        .map_err(Self::classify_write_error)?;
 
                     #staged_payload_insert
 
@@ -290,25 +288,7 @@ mod tests {
                     )
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err)
-                                if db_err.is_unique_violation()
-                                    && db_err.table() == Some("entity_events") =>
-                            {
-                                EntityModifyError::ConcurrentModification
-                            }
-                            sqlx::Error::Database(db_err)
-                                if db_err.table() != Some("entity_events")
-                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
-                            {
-                                EntityModifyError::ConstraintViolation {
-                                    column: Self::map_constraint_column(db_err.constraint()),
-                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            _ => EntityModifyError::Sqlx(e),
-                        })?;
+                        .map_err(Self::classify_write_error)?;
 
                     if new_events {
                         let recorded_at = rows
@@ -402,25 +382,7 @@ mod tests {
                     )
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err)
-                                if db_err.is_unique_violation()
-                                    && db_err.table() == Some("entity_events") =>
-                            {
-                                EntityModifyError::ConcurrentModification
-                            }
-                            sqlx::Error::Database(db_err)
-                                if db_err.table() != Some("entity_events")
-                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
-                            {
-                                EntityModifyError::ConstraintViolation {
-                                    column: Self::map_constraint_column(db_err.constraint()),
-                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            _ => EntityModifyError::Sqlx(e),
-                        })?;
+                        .map_err(Self::classify_write_error)?;
 
                     if new_events {
                         let recorded_at = rows
@@ -513,25 +475,7 @@ mod tests {
                     )
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err)
-                                if db_err.is_unique_violation()
-                                    && db_err.table() == Some("entity_events") =>
-                            {
-                                EntityModifyError::ConcurrentModification
-                            }
-                            sqlx::Error::Database(db_err)
-                                if db_err.table() != Some("entity_events")
-                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
-                            {
-                                EntityModifyError::ConstraintViolation {
-                                    column: Self::map_constraint_column(db_err.constraint()),
-                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            _ => EntityModifyError::Sqlx(e),
-                        })?;
+                        .map_err(Self::classify_write_error)?;
 
                     let mut payload_sequences: Vec<i32> = Vec::new();
                     let mut payload_values: Vec<es_entity::prelude::serde_json::Value> = Vec::new();

--- a/es-entity-macros/src/repo/error_classifier.rs
+++ b/es-entity-macros/src/repo/error_classifier.rs
@@ -1,5 +1,8 @@
+use darling::ToTokens;
 use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
+
+use super::options::*;
 
 /// Postgres reports the bare table name in errors, so a schema-qualified
 /// events table from the repo options is reduced to its last path component
@@ -83,27 +86,43 @@ fn index_violation_arm(error: &syn::Ident, events_table: &str) -> TokenStream {
 /// The classifier helpers for the combined index+events write statements,
 /// emitted once per repo so the call sites are a bare `map_err` function
 /// reference instead of a match rendered into every write path.
-///
-/// `classify_write_error` is only emitted when a write path actually calls it
-/// — an uncalled private helper is dead code, and consumers build with
-/// `-D warnings`. `classify_create_error` has unconditional callers
-/// (`create` and `create_all` both always issue the combined statement).
-pub fn error_classifier_fns(
-    create_error: &syn::Ident,
-    modify_error: &syn::Ident,
-    events_table_name: &str,
-    table_name: &str,
+pub struct ErrorClassifier<'a> {
+    create_error: syn::Ident,
+    modify_error: syn::Ident,
+    events_table_name: &'a str,
+    table_name: &'a str,
+    /// `classify_write_error` is emitted only where a write path actually
+    /// calls it — an uncalled private helper is dead code, and consumers build
+    /// with `-D warnings`. `classify_create_error` needs no such gate:
+    /// `create` and `create_all` always issue the combined statement.
     needs_write_classifier: bool,
-) -> TokenStream {
-    let create = create_error_classifier_fn(create_error, events_table_name, table_name);
-    let write = if needs_write_classifier {
-        write_error_classifier_fn(modify_error, events_table_name)
-    } else {
-        TokenStream::new()
-    };
-    quote! {
-        #create
-        #write
+}
+
+impl<'a> From<&'a RepositoryOptions> for ErrorClassifier<'a> {
+    fn from(opts: &'a RepositoryOptions) -> Self {
+        Self {
+            create_error: opts.create_error(),
+            modify_error: opts.modify_error(),
+            events_table_name: opts.events_table_name(),
+            table_name: opts.table_name(),
+            needs_write_classifier: opts.columns.updates_needed() || opts.delete.is_soft(),
+        }
+    }
+}
+
+impl ToTokens for ErrorClassifier<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append_all(create_error_classifier_fn(
+            &self.create_error,
+            self.events_table_name,
+            self.table_name,
+        ));
+        if self.needs_write_classifier {
+            tokens.append_all(write_error_classifier_fn(
+                &self.modify_error,
+                self.events_table_name,
+            ));
+        }
     }
 }
 

--- a/es-entity-macros/src/repo/error_classifier.rs
+++ b/es-entity-macros/src/repo/error_classifier.rs
@@ -58,8 +58,57 @@ pub fn concurrent_modification_classifier(
     }
 }
 
-/// The `map_err` closure for the create paths' combined index+events write
-/// statement (`create` / `create_all`).
+/// The match arm shared by both combined-write classifiers: a classified
+/// violation reported against any table other than the events table is the
+/// index table's, and maps straight from the constraint Postgres named.
+///
+/// The events table name may be schema-qualified in the repo options;
+/// Postgres reports the bare table name in errors, so only the last path
+/// component is compared.
+fn index_violation_arm(error: &syn::Ident, events_table: &str) -> TokenStream {
+    quote! {
+        sqlx::Error::Database(db_err)
+            if db_err.table() != Some(#events_table)
+                && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+        {
+            #error::ConstraintViolation {
+                column: Self::map_constraint_column(db_err.constraint()),
+                value: es_entity::extract_constraint_value(db_err.as_ref()),
+                inner: e,
+            }
+        }
+    }
+}
+
+/// The classifier helpers for the combined index+events write statements,
+/// emitted once per repo so the call sites are a bare `map_err` function
+/// reference instead of a match rendered into every write path.
+///
+/// `classify_write_error` is only emitted when a write path actually calls it
+/// — an uncalled private helper is dead code, and consumers build with
+/// `-D warnings`. `classify_create_error` has unconditional callers
+/// (`create` and `create_all` both always issue the combined statement).
+pub fn error_classifier_fns(
+    create_error: &syn::Ident,
+    modify_error: &syn::Ident,
+    events_table_name: &str,
+    table_name: &str,
+    needs_write_classifier: bool,
+) -> TokenStream {
+    let create = create_error_classifier_fn(create_error, events_table_name, table_name);
+    let write = if needs_write_classifier {
+        write_error_classifier_fn(modify_error, events_table_name)
+    } else {
+        TokenStream::new()
+    };
+    quote! {
+        #create
+        #write
+    }
+}
+
+/// Classifier for the create paths' combined index+events write statement
+/// (`create` / `create_all`).
 ///
 /// A brand-new entity's events always start at sequence 1, so a unique
 /// violation on the events-table `(id, sequence)` primary key can only mean
@@ -79,7 +128,7 @@ pub fn concurrent_modification_classifier(
 /// - classified violation elsewhere (the index table) → `ConstraintViolation`
 ///   mapped from the reported constraint
 /// - anything else → `Sqlx`
-pub fn create_error_classifier(
+fn create_error_classifier_fn(
     error: &syn::Ident,
     events_table_name: &str,
     table_name: &str,
@@ -88,34 +137,29 @@ pub fn create_error_classifier(
     // Must match the id column's constraint name in `ErrorTypes::new`, which
     // formats it from the un-shortened table name.
     let index_pkey = format!("{table_name}_pkey");
+    let index_arm = index_violation_arm(error, events_table);
     quote! {
-        |e| match &e {
-            sqlx::Error::Database(db_err)
-                if db_err.is_unique_violation()
-                    && db_err.table() == Some(#events_table) =>
-            {
-                #error::ConstraintViolation {
-                    column: Self::map_constraint_column(Some(#index_pkey)),
-                    value: es_entity::extract_events_pkey_id_value(db_err.as_ref()),
-                    inner: e,
+        #[inline(always)]
+        fn classify_create_error(e: sqlx::Error) -> #error {
+            match &e {
+                sqlx::Error::Database(db_err)
+                    if db_err.is_unique_violation()
+                        && db_err.table() == Some(#events_table) =>
+                {
+                    #error::ConstraintViolation {
+                        column: Self::map_constraint_column(Some(#index_pkey)),
+                        value: es_entity::extract_events_pkey_id_value(db_err.as_ref()),
+                        inner: e,
+                    }
                 }
+                #index_arm
+                _ => #error::Sqlx(e),
             }
-            sqlx::Error::Database(db_err)
-                if db_err.table() != Some(#events_table)
-                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
-            {
-                #error::ConstraintViolation {
-                    column: Self::map_constraint_column(db_err.constraint()),
-                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                    inner: e,
-                }
-            }
-            _ => #error::Sqlx(e),
         }
     }
 }
 
-/// The `map_err` closure for a combined index+events write statement on the
+/// Classifier for a combined index+events write statement on the
 /// update/delete paths.
 ///
 /// A single statement can fail from either table, so classification switches
@@ -125,30 +169,25 @@ pub fn create_error_classifier(
 /// - classified violation elsewhere (the index table) → `ConstraintViolation`
 /// - anything else (including events-table FK violations) → `Sqlx`
 ///
-/// The events table name may be schema-qualified in the repo options;
-/// Postgres reports the bare table name in errors, so only the last path
-/// component is compared.
-pub fn write_error_classifier(error: &syn::Ident, events_table_name: &str) -> TokenStream {
+/// Unlike the create paths, the entity here already has persisted events, so
+/// an events-table `(id, sequence)` conflict genuinely means another writer
+/// claimed the next sequence first.
+fn write_error_classifier_fn(error: &syn::Ident, events_table_name: &str) -> TokenStream {
     let events_table = bare_table_name(events_table_name);
+    let index_arm = index_violation_arm(error, events_table);
     quote! {
-        |e| match &e {
-            sqlx::Error::Database(db_err)
-                if db_err.is_unique_violation()
-                    && db_err.table() == Some(#events_table) =>
-            {
-                #error::ConcurrentModification
-            }
-            sqlx::Error::Database(db_err)
-                if db_err.table() != Some(#events_table)
-                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
-            {
-                #error::ConstraintViolation {
-                    column: Self::map_constraint_column(db_err.constraint()),
-                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                    inner: e,
+        #[inline(always)]
+        fn classify_write_error(e: sqlx::Error) -> #error {
+            match &e {
+                sqlx::Error::Database(db_err)
+                    if db_err.is_unique_violation()
+                        && db_err.table() == Some(#events_table) =>
+                {
+                    #error::ConcurrentModification
                 }
+                #index_arm
+                _ => #error::Sqlx(e),
             }
-            _ => #error::Sqlx(e),
         }
     }
 }

--- a/es-entity-macros/src/repo/error_classifier.rs
+++ b/es-entity-macros/src/repo/error_classifier.rs
@@ -58,7 +58,65 @@ pub fn concurrent_modification_classifier(
     }
 }
 
-/// The `map_err` closure for a combined index+events write statement.
+/// The `map_err` closure for the create paths' combined index+events write
+/// statement (`create` / `create_all`).
+///
+/// A brand-new entity's events always start at sequence 1, so a unique
+/// violation on the events-table `(id, sequence)` primary key can only mean
+/// the id already exists — a pre-existing row, a concurrent create, or an
+/// intra-batch duplicate in `create_all`. That is semantically a duplicate
+/// id, not a concurrent modification.
+///
+/// Postgres executes the data-modifying CTE (index insert) and the main
+/// statement (events insert) interleaved with no guaranteed ordering, so for
+/// a duplicate id either table's constraint may fire first depending on the
+/// chosen plan. Both are therefore classified identically as the id column's
+/// `ConstraintViolation`:
+///
+/// - unique violation on the events table → `ConstraintViolation` with the
+///   column resolved via the index table's pkey constraint name and the value
+///   being the id half of the `(id, sequence)` key
+/// - classified violation elsewhere (the index table) → `ConstraintViolation`
+///   mapped from the reported constraint
+/// - anything else → `Sqlx`
+pub fn create_error_classifier(
+    error: &syn::Ident,
+    events_table_name: &str,
+    table_name: &str,
+) -> TokenStream {
+    let events_table = bare_table_name(events_table_name);
+    // Must match the id column's constraint name in `ErrorTypes::new`, which
+    // formats it from the un-shortened table name.
+    let index_pkey = format!("{table_name}_pkey");
+    quote! {
+        |e| match &e {
+            sqlx::Error::Database(db_err)
+                if db_err.is_unique_violation()
+                    && db_err.table() == Some(#events_table) =>
+            {
+                #error::ConstraintViolation {
+                    column: Self::map_constraint_column(Some(#index_pkey)),
+                    value: es_entity::extract_events_pkey_id_value(db_err.as_ref()),
+                    inner: e,
+                }
+            }
+            sqlx::Error::Database(db_err)
+                if db_err.table() != Some(#events_table)
+                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
+            {
+                #error::ConstraintViolation {
+                    column: Self::map_constraint_column(db_err.constraint()),
+                    value: es_entity::extract_constraint_value(db_err.as_ref()),
+                    inner: e,
+                }
+            }
+            _ => #error::Sqlx(e),
+        }
+    }
+}
+
+/// The `map_err` closure for a combined index+events write statement on the
+/// update/delete paths.
 ///
 /// A single statement can fail from either table, so classification switches
 /// on `DatabaseError::table()` instead of on which statement failed:

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -44,6 +44,7 @@ pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream
 pub struct EsRepo<'a> {
     repo: &'a syn::Ident,
     generics: &'a syn::Generics,
+    error_classifier: TokenStream,
     extract_concurrent_modification_fn: Option<TokenStream>,
     persist_events_fn: Option<persist_events_fn::PersistEventsFn<'a>>,
     persist_events_batch_fn: Option<persist_events_batch_fn::PersistEventsBatchFn<'a>>,
@@ -130,9 +131,23 @@ impl<'a> From<&'a RepositoryOptions> for EsRepo<'a> {
             || opts.forgettable_enabled())
         .then(error_classifier::extract_concurrent_modification_fn);
 
+        // The combined-write classifiers are emitted once per repo and called
+        // by every write path, rather than rendered inline at each call site.
+        // `classify_write_error` only has callers when a write path actually
+        // issues the combined statement: `update`/`update_all` when there are
+        // index columns to persist, and soft `delete` always.
+        let error_classifier = error_classifier::error_classifier_fns(
+            &opts.create_error(),
+            &opts.modify_error(),
+            opts.events_table_name(),
+            opts.table_name(),
+            opts.columns.updates_needed() || opts.delete.is_soft(),
+        );
+
         Self {
             repo: &opts.ident,
             generics: &opts.generics,
+            error_classifier,
             extract_concurrent_modification_fn,
             persist_events_fn: needs_persist_events
                 .then(|| persist_events_fn::PersistEventsFn::from(opts)),
@@ -164,6 +179,7 @@ impl<'a> From<&'a RepositoryOptions> for EsRepo<'a> {
 impl ToTokens for EsRepo<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let repo = &self.repo;
+        let error_classifier = &self.error_classifier;
         let extract_concurrent_modification_fn = &self.extract_concurrent_modification_fn;
         let persist_events_fn = &self.persist_events_fn;
         let persist_events_batch_fn = &self.persist_events_batch_fn;
@@ -372,6 +388,7 @@ impl ToTokens for EsRepo<'_> {
                 #scoped_fn
 
                 #map_constraint_fn
+                #error_classifier
                 #begin
                 #post_hydrate_hook
                 #post_persist_hook
@@ -466,6 +483,55 @@ mod tests {
             }
         };
         assert!(derive(input).is_ok());
+    }
+
+    /// The combined-write classifiers are emitted once per repo, not rendered
+    /// into every write path. `classify_write_error` is gated to repos that
+    /// actually have a caller — an uncalled private helper is dead code, and
+    /// consumers build with `-D warnings`.
+    #[test]
+    fn error_classifiers_are_emitted_once_and_gated() {
+        let with_columns: syn::DeriveInput = parse_quote! {
+            #[es_repo(entity = "User", columns(name(ty = "String")))]
+            struct Users {
+                pool: sqlx::PgPool,
+            }
+        };
+        let out = derive(with_columns).unwrap().to_string();
+        assert_eq!(
+            out.matches("fn classify_create_error").count(),
+            1,
+            "create classifier should be defined exactly once"
+        );
+        assert_eq!(
+            out.matches("fn classify_write_error").count(),
+            1,
+            "write classifier should be defined exactly once"
+        );
+        // Both create paths call the shared fn rather than inlining a match.
+        assert_eq!(
+            out.matches("Self :: classify_create_error").count(),
+            2,
+            "create and create_all should both call the shared classifier"
+        );
+
+        // No index columns to persist and no soft delete → nothing calls the
+        // write classifier, so it must not be emitted.
+        let no_columns: syn::DeriveInput = parse_quote! {
+            #[es_repo(entity = "User")]
+            struct Users {
+                pool: sqlx::PgPool,
+            }
+        };
+        let out = derive(no_columns).unwrap().to_string();
+        assert!(
+            !out.contains("fn classify_write_error"),
+            "write classifier must not be emitted without a caller"
+        );
+        assert!(
+            out.contains("fn classify_create_error"),
+            "create classifier always has callers"
+        );
     }
 
     // Guard 1 (event has Forgettable fields but the repo omits `forgettable`)

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -44,7 +44,7 @@ pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream
 pub struct EsRepo<'a> {
     repo: &'a syn::Ident,
     generics: &'a syn::Generics,
-    error_classifier: TokenStream,
+    error_classifier: error_classifier::ErrorClassifier<'a>,
     extract_concurrent_modification_fn: Option<TokenStream>,
     persist_events_fn: Option<persist_events_fn::PersistEventsFn<'a>>,
     persist_events_batch_fn: Option<persist_events_batch_fn::PersistEventsBatchFn<'a>>,
@@ -131,23 +131,10 @@ impl<'a> From<&'a RepositoryOptions> for EsRepo<'a> {
             || opts.forgettable_enabled())
         .then(error_classifier::extract_concurrent_modification_fn);
 
-        // The combined-write classifiers are emitted once per repo and called
-        // by every write path, rather than rendered inline at each call site.
-        // `classify_write_error` only has callers when a write path actually
-        // issues the combined statement: `update`/`update_all` when there are
-        // index columns to persist, and soft `delete` always.
-        let error_classifier = error_classifier::error_classifier_fns(
-            &opts.create_error(),
-            &opts.modify_error(),
-            opts.events_table_name(),
-            opts.table_name(),
-            opts.columns.updates_needed() || opts.delete.is_soft(),
-        );
-
         Self {
             repo: &opts.ident,
             generics: &opts.generics,
-            error_classifier,
+            error_classifier: error_classifier::ErrorClassifier::from(opts),
             extract_concurrent_modification_fn,
             persist_events_fn: needs_persist_events
                 .then(|| persist_events_fn::PersistEventsFn::from(opts)),

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -3,7 +3,6 @@ use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
 use super::{
-    error_classifier::write_error_classifier,
     events_write::{EventSource, EventsInsert, ForgettablePayloads},
     options::*,
 };
@@ -122,7 +121,6 @@ impl ToTokens for UpdateAllFn<'_> {
                 events_insert.sql(&source, now_p, now_p + 1),
             );
 
-            let classifier = write_error_classifier(modify_error, self.events_table_name);
             let event_binds = events_insert
                 .arg_exprs(&source)
                 .into_iter()
@@ -138,7 +136,7 @@ impl ToTokens for UpdateAllFn<'_> {
                         #(#event_binds)*
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(#classifier)?;
+                        .map_err(Self::classify_write_error)?;
 
                     #forgettable_insert
 
@@ -412,25 +410,7 @@ mod tests {
                         .bind(&all_serialized)
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err)
-                                if db_err.is_unique_violation()
-                                    && db_err.table() == Some("entity_events") =>
-                            {
-                                EntityModifyError::ConcurrentModification
-                            }
-                            sqlx::Error::Database(db_err)
-                                if db_err.table() != Some("entity_events")
-                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
-                            {
-                                EntityModifyError::ConstraintViolation {
-                                    column: Self::map_constraint_column(db_err.constraint()),
-                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            _ => EntityModifyError::Sqlx(e),
-                        })?;
+                        .map_err(Self::classify_write_error)?;
 
                     if rows.len() != expected_events {
                         return Err(EntityModifyError::ConcurrentModification);

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -3,7 +3,6 @@ use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
 use super::{
-    error_classifier::write_error_classifier,
     events_write::{EventSource, EventsInsert, ForgettablePayloads},
     options::*,
 };
@@ -84,7 +83,6 @@ impl ToTokens for UpdateFn<'_> {
                 events_insert.sql(&source, now_p, now_p + 2),
             );
 
-            let classifier = write_error_classifier(modify_error, self.events_table_name);
             let gather = events_insert.gather_per_entity(quote! { entity.events() });
             let event_args = events_insert.arg_exprs(&source);
 
@@ -112,7 +110,7 @@ impl ToTokens for UpdateFn<'_> {
                 )
                     .fetch_all(op.as_executor())
                     .await
-                    .map_err(#classifier)?;
+                    .map_err(Self::classify_write_error)?;
 
                 #forgettable_code
 
@@ -316,25 +314,7 @@ mod tests {
                     )
                         .fetch_all(op.as_executor())
                         .await
-                        .map_err(|e| match &e {
-                            sqlx::Error::Database(db_err)
-                                if db_err.is_unique_violation()
-                                    && db_err.table() == Some("entity_events") =>
-                            {
-                                EntityModifyError::ConcurrentModification
-                            }
-                            sqlx::Error::Database(db_err)
-                                if db_err.table() != Some("entity_events")
-                                    && es_entity::is_classified_constraint_violation(db_err.as_ref()) =>
-                            {
-                                EntityModifyError::ConstraintViolation {
-                                    column: Self::map_constraint_column(db_err.constraint()),
-                                    value: es_entity::extract_constraint_value(db_err.as_ref()),
-                                    inner: e,
-                                }
-                            }
-                            _ => EntityModifyError::Sqlx(e),
-                        })?;
+                        .map_err(Self::classify_write_error)?;
 
                     let recorded_at = rows
                         .first()

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,28 @@ pub fn extract_constraint_value(db_err: &dyn sqlx::error::DatabaseError) -> Opti
     parse_constraint_detail_value(pg_err.detail())
 }
 
+#[doc(hidden)]
+/// Extracts the conflicting id from an events-table primary-key violation.
+///
+/// The events tables' primary key is `(id, sequence)`, so the violation
+/// detail reads `Key (id, sequence)=(<id>, <seq>) already exists.` — the id
+/// is everything before the last `, `. The sequence is an integer and can
+/// never contain `, `, so splitting at the last occurrence is unambiguous
+/// even for ids that themselves contain commas.
+///
+/// **Security note:** see [`parse_constraint_detail_value`] — the returned
+/// value may be PII and must not be exposed to untrusted clients.
+pub fn extract_events_pkey_id_value(db_err: &dyn sqlx::error::DatabaseError) -> Option<String> {
+    events_pkey_id_from_value(extract_constraint_value(db_err)?)
+}
+
+fn events_pkey_id_from_value(value: String) -> Option<String> {
+    match value.rsplit_once(", ") {
+        Some((id, _sequence)) => Some(id.to_string()),
+        None => Some(value),
+    }
+}
+
 /// The kind of database constraint behind a classified `ConstraintViolation`.
 ///
 /// Returned by the generated `{Entity}Constraint::kind()` method.
@@ -147,6 +169,34 @@ mod tests {
         assert_eq!(
             parse_constraint_detail_value(detail),
             Some("foo (bar)".to_string())
+        );
+    }
+
+    #[test]
+    fn events_pkey_id_strips_the_sequence() {
+        let value = parse_constraint_detail_value(Some(
+            "Key (id, sequence)=(550e8400-e29b-41d4-a716-446655440000, 1) already exists.",
+        ))
+        .unwrap();
+        assert_eq!(
+            events_pkey_id_from_value(value),
+            Some("550e8400-e29b-41d4-a716-446655440000".to_string())
+        );
+    }
+
+    #[test]
+    fn events_pkey_id_keeps_commas_inside_the_id() {
+        assert_eq!(
+            events_pkey_id_from_value("a, b, 3".to_string()),
+            Some("a, b".to_string())
+        );
+    }
+
+    #[test]
+    fn events_pkey_id_without_separator_returns_value_as_is() {
+        assert_eq!(
+            events_pkey_id_from_value("plain".to_string()),
+            Some("plain".to_string())
         );
     }
 

--- a/tests/repo_errors.rs
+++ b/tests/repo_errors.rs
@@ -137,6 +137,93 @@ async fn create_duplicate_id_returns_constraint_violation_with_value() -> anyhow
     Ok(())
 }
 
+/// Regression test for the #196 combined index+events write: Postgres
+/// interleaves the CTE (index insert) and main statement (events insert), so
+/// for an intra-batch duplicate id either the index-table pkey or the
+/// events-table `(id, sequence)` pkey may fire first. Both must classify as
+/// the duplicate-id `ConstraintViolation` — never `ConcurrentModification`.
+#[tokio::test]
+async fn create_all_intra_batch_duplicate_id_classifies_as_duplicate() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let users = Users::new(pool);
+
+    // Duplicate in different positions and batch sizes, in case the chosen
+    // plan (and therefore which constraint fires first) varies with shape.
+    for batch_size in [2usize, 5] {
+        for dup_pos in [0usize, batch_size - 1] {
+            let dup_id = UserId::new();
+            let new_users: Vec<_> = (0..=batch_size)
+                .map(|i| {
+                    let id = if i == dup_pos || i == batch_size {
+                        dup_id
+                    } else {
+                        UserId::new()
+                    };
+                    NewUser::builder()
+                        .id(id)
+                        .name(format!("User{i}"))
+                        .build()
+                        .unwrap()
+                })
+                .collect();
+
+            let err = match users.create_all(new_users).await {
+                Err(e) => e,
+                Ok(_) => panic!("expected constraint violation"),
+            };
+
+            assert!(
+                !err.was_concurrent_modification(),
+                "duplicate id must not classify as ConcurrentModification: {err:?}"
+            );
+            assert!(err.was_duplicate(), "expected duplicate: {err:?}");
+            assert!(
+                err.was_duplicate_by(UserColumn::Id),
+                "wrong column: {err:?}"
+            );
+            assert_eq!(err.duplicate_value(), Some(dup_id.to_string().as_str()));
+
+            // The whole batch rolls back.
+            assert!(users.find_by_id(dup_id).await.is_err());
+        }
+    }
+
+    Ok(())
+}
+
+/// A `create_all` batch containing an id that already exists in the database
+/// must classify the same way as the intra-batch case.
+#[tokio::test]
+async fn create_all_preexisting_duplicate_id_classifies_as_duplicate() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let users = Users::new(pool);
+
+    let id = UserId::new();
+    users
+        .create(NewUser::builder().id(id).name("First").build().unwrap())
+        .await?;
+
+    let new_users = vec![
+        NewUser::builder()
+            .id(UserId::new())
+            .name("Fresh")
+            .build()
+            .unwrap(),
+        NewUser::builder().id(id).name("Dup").build().unwrap(),
+    ];
+    let err = match users.create_all(new_users).await {
+        Err(e) => e,
+        Ok(_) => panic!("expected constraint violation"),
+    };
+
+    assert!(!err.was_concurrent_modification());
+    assert!(err.was_duplicate());
+    assert!(err.was_duplicate_by(UserColumn::Id));
+    assert_eq!(err.duplicate_value(), Some(id.to_string().as_str()));
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn update_to_duplicate_email_returns_constraint_violation_with_value() -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;


### PR DESCRIPTION
## What

Restores deterministic duplicate-id classification on the create paths, fixing fallout from #196 (released as 0.12.6).

## Why

#196 collapsed the index and events inserts into one statement. Postgres interleaves a data-modifying CTE with the main statement, so for a duplicate id — including an intra-batch one in `create_all` — either the index-table pkey or the events-table `(id, sequence)` unique constraint may fire first. The old classifier mapped any events-table unique violation to `ConcurrentModification`, so downstream consumers nondeterministically saw `ConcurrentModification` where they expect a duplicate-id `ConstraintViolation` (surfaced e.g. in the job crate's bulk-spawn rollback test against 0.12.6).

On a create, an events-table unique violation can only mean the id already exists (new entities always start at sequence 1) — it is semantically a duplicate id. The create paths now get their own classifier that maps that case to the same id-column `ConstraintViolation` as the index pkey violation, with the value trimmed to the id half of the `(id, sequence)` key. Update/delete paths keep the existing classification, where an events-table unique violation genuinely means concurrent modification.

The SQL is untouched: still a single round trip, so the #196 performance win is preserved.

A regression test covers intra-batch and pre-existing duplicate ids in `create_all`; the events-table constraint is the one that fires first under the current planner, so the test exercises exactly the previously misclassified path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)