### PR TITLE
feat(operation): savepoint-scoped ops for per-item batch isolation

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -34,6 +34,7 @@
   - [Connection Traits](./connection-traits.md)
   - [DbOp](./db-op.md)
   - [Commit Hooks](./commit-hooks.md)
+  - [Savepoints](./savepoints.md)
 
 - [Aggregates](./aggregates.md)
   - [Nesting](./nesting.md)

--- a/book/src/db-op.md
+++ b/book/src/db-op.md
@@ -43,6 +43,19 @@ let op_with_time = op.with_system_time();
 let op_with_time = op.with_db_time().await?;
 ```
 
+## Savepoints
+
+`DbOp` can scope part of its work to a `SAVEPOINT`, so a failure undoes only that part instead of poisoning the whole transaction:
+
+```rust,ignore
+// Ok keeps the work (and its staged hooks), Err undoes it
+let res: Result<(), MyError> = op
+    .with_savepoint(async |op| self.process_in_op(op, item).await)
+    .await?;
+```
+
+See [Savepoints](./savepoints.md) for the full semantics, including how commit hooks are staged.
+
 ## DbOpWithTime
 
 `DbOpWithTime` is equivalent to `DbOp` but guarantees that a timestamp is cached:

--- a/book/src/savepoints.md
+++ b/book/src/savepoints.md
@@ -1,0 +1,74 @@
+# Savepoints
+
+A `SAVEPOINT` is a mark inside a transaction that you can roll back to without ending the transaction. `DbOp` exposes this as `with_savepoint`, which makes it possible to process a batch of items in **one** transaction while isolating each item's failure.
+
+This matters for two reasons:
+
+- **Throughput.** A batch of N items processed as N transactions pays N WAL flushes. Processed as one transaction with N savepoints it pays one — savepoints themselves are cheap round trips that never fsync.
+- **Poisoning.** Once a statement errors, a Postgres transaction refuses all further statements until it is rolled back. Without savepoints, one bad item takes down every other item sharing the transaction.
+
+## Usage
+
+```rust,ignore
+let mut op = DbOp::init(&pool).await?;
+let mut outcomes = Vec::with_capacity(items.len());
+
+for item in items {
+    // The outer `?`: the savepoint machinery itself failed, so the whole
+    // operation is suspect — abandon it rather than commit.
+    let res = op
+        .with_savepoint(async |op| self.process_in_op(op, item).await)
+        .await?;
+
+    // The inner Result: this item's own outcome, already rolled back cleanly
+    // if it failed. The loop continues either way.
+    outcomes.push(match res {
+        Ok(()) => Outcome::Complete,
+        Err(e) => Outcome::Retry(e),
+    });
+}
+
+op.commit().await?;
+```
+
+The closure receives a `SavepointOp`, which implements `AtomicOperation` — so existing `*_in_op` methods take it unchanged.
+
+## Two layers of `Result`
+
+`with_savepoint` returns `Result<Result<T, E>, sqlx::Error>`:
+
+| Layer | Meaning | What to do |
+|---|---|---|
+| Outer `Err(sqlx::Error)` | The `SAVEPOINT` / `RELEASE` / `ROLLBACK TO` failed, or the error was never savepoint-recoverable (e.g. the connection died) | Abandon the operation — do not commit |
+| Inner `Err(E)` | The item failed; its writes and staged hooks are gone | Record the outcome, continue the loop |
+
+If the closure fails *and* the rollback fails, the rollback error surfaces as the outer `Err` and the item error is dropped — the poisoned-transaction signal is the one the caller must act on.
+
+## Commit hooks are staged
+
+Hooks registered inside a savepoint — including those repositories register internally via [`post_persist_hook`](./repo-hooks.md) — are **staged**, not added to the parent operation:
+
+- On **release**, the staged hooks are folded into the parent's buffer through the ordinary registration/merge path. A mergeable hook type therefore accumulates across the whole batch exactly as if every item had registered on the parent directly.
+- On **rollback**, the staged hooks are dropped. A rolled-back item contributes zero hook state to match its zero database state — no event published for a row that no longer exists.
+
+No hook callback runs at a savepoint boundary. [`pre_commit`](./commit-hooks.md) runs once at the parent's `commit()` over the final merged set, `post_commit` still only after a durable `COMMIT`, and `on_rollback` still only when the whole transaction is gone.
+
+While a savepoint is open, `commit_hook::<H>()` reads the staged buffer first and falls back to the parent's — so an item sees the state accumulated by earlier, already-released items. A hook type present in both is reported as the staged instance until release merges them.
+
+## Collecting outcomes
+
+The closure may borrow from its environment, but **host-side mutations do not unwind with the savepoint**. Pushing an outcome inside the closure before a later statement fails would report success for work that was undone. Return the verdict through `Ok`/`Err` and record it outside, as in the example above.
+
+## Explicit form
+
+When the closure form doesn't fit, `begin_savepoint()` returns the `SavepointOp` directly. It must be finished with `release()` (keep the work) or `rollback()` (discard it); dropping it rolls back.
+
+```rust,ignore
+let mut sp = op.begin_savepoint().await?;
+self.process_in_op(&mut sp, item).await?;
+sp.release().await?;
+```
+
+## When not to use savepoints
+
+If every item performs the same statement, `create_all` / `update_all` / `find_all` remain cheaper — one statement for the whole batch beats one savepoint pair per item. Reach for savepoints when items need genuinely per-item logic *and* per-item error isolation.

--- a/book/src/transactions.md
+++ b/book/src/transactions.md
@@ -24,6 +24,8 @@ See [Connection Types and Traits](./connection-traits.md) for details on these t
 
 - **[Commit Hooks](./commit-hooks.md)**: Execute custom logic before and after transaction commits, with support for hook merging and database operations during pre-commit.
 
+- **[Savepoints](./savepoints.md)**: Isolate each item of a batch inside a single transaction, so one item's failure rolls back only its own writes and hooks.
+
 ## Basic Example
 
 ```rust

--- a/migrations/20260814000000_savepoint_test.sql
+++ b/migrations/20260814000000_savepoint_test.sql
@@ -1,0 +1,11 @@
+-- Fixture for tests/savepoint.rs.
+--
+-- The savepoint tests write raw rows to assert what a rolled-back item leaves
+-- behind, so they need a table of their own: writing to a shared entity table
+-- (e.g. `users`) would leave rows with no corresponding events and break the
+-- hydration-based tests. The primary key is what the poisoning test violates to
+-- produce an error that would otherwise abort the whole transaction.
+CREATE TABLE savepoint_items (
+  id UUID PRIMARY KEY,
+  label VARCHAR NOT NULL
+);

--- a/src/operation/hooks.rs
+++ b/src/operation/hooks.rs
@@ -42,6 +42,17 @@
 //! Registration order is a determinism guarantee, not a priority mechanism — there
 //! is no way to reorder hooks independently of the order in which they were added.
 //!
+//! # Savepoints
+//!
+//! Hooks registered on a [`SavepointOp`] are staged and only enter the parent
+//! operation's set — through the same registration/merge path — when the savepoint
+//! is released; a rolled-back savepoint discards them. No callback runs at a
+//! savepoint boundary, so the lifecycle above is unchanged: one `pre_commit` pass at
+//! the parent's commit, `post_commit` only after a durable `COMMIT`. See
+//! [`SavepointOp`] for details.
+//!
+//! [`SavepointOp`]: super::SavepointOp
+//!
 //! # Examples
 //!
 //! ## Hook with Database Operations and Channel-Based Publishing
@@ -362,10 +373,24 @@ impl CommitHooks {
     }
 
     pub(super) fn add<H: CommitHook>(&mut self, hook: H) {
-        let type_id = TypeId::of::<H>();
+        self.push_or_merge(TypeId::of::<H>(), Box::new(hook));
+    }
 
-        let mut new_hook: Box<dyn DynHook> = Box::new(hook);
+    /// Folds the hooks staged by a released [`SavepointOp`] into this buffer.
+    ///
+    /// Replays them through the same path as [`add`](Self::add), in their
+    /// staging order, so the result is indistinguishable from having registered
+    /// them on this operation directly: mergeable types accumulate into the
+    /// earlier instance (keeping its position), non-mergeable ones append.
+    ///
+    /// [`SavepointOp`]: super::SavepointOp
+    pub(super) fn absorb_staged(&mut self, staged: Self) {
+        for (type_id, hook) in staged.hooks {
+            self.push_or_merge(type_id, hook);
+        }
+    }
 
+    fn push_or_merge(&mut self, type_id: TypeId, mut new_hook: Box<dyn DynHook>) {
         // Merge with the most recently added hook of the same type, keeping the
         // existing hook's original (earlier) position in the execution order.
         if let Some((_, existing)) = self.hooks.iter_mut().rev().find(|(t, _)| *t == type_id)

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -1,12 +1,14 @@
 //! Handle execution of database operations and transactions.
 
 pub mod hooks;
+mod savepoint;
 mod with_time;
 
 use sqlx::{Acquire, Transaction};
 
 use crate::{clock::ClockHandle, db, one_time_executor::OneTimeExecutor};
 
+pub use savepoint::*;
 pub use with_time::*;
 
 /// Default return type of the derived EsRepo::begin_op().
@@ -104,6 +106,86 @@ impl<'c> DbOp<'c> {
             self.clock.clone(),
             self.now,
         ))
+    }
+
+    /// Runs `f` inside a `SAVEPOINT`, keeping its work on `Ok` and undoing it on `Err`.
+    ///
+    /// This is the building block for processing a batch of items in **one**
+    /// transaction — one `COMMIT`, one WAL flush — while still isolating each
+    /// item's failure. An item that errors unwinds only its own writes and
+    /// staged commit hooks; the transaction stays usable, so the loop continues
+    /// and its healthy items still commit.
+    ///
+    /// # Two layers of `Result`
+    ///
+    /// - The **outer** `Err(sqlx::Error)` means the savepoint machinery itself
+    ///   failed (or the error was never savepoint-recoverable, e.g. the
+    ///   connection died). The parent operation is in an indeterminate state:
+    ///   abandon it, don't commit.
+    /// - The **inner** `Err(E)` is the item's own failure, already rolled back
+    ///   cleanly. Record the outcome and keep going.
+    ///
+    /// If the closure fails *and* the rollback fails, the rollback error is
+    /// returned as the outer `Err` and the item's error is dropped — the
+    /// poisoned-transaction signal is what the caller must act on.
+    ///
+    /// # Collecting per-item outcomes
+    ///
+    /// The closure may borrow from its environment, but host-side mutations do
+    /// **not** unwind with the savepoint. Return the item's verdict through
+    /// `Ok`/`Err` and record it outside, where the outcome is authoritative:
+    ///
+    /// ```rust,ignore
+    /// let mut op = DbOp::init(&pool).await?;
+    /// let mut outcomes = Vec::with_capacity(items.len());
+    ///
+    /// for item in items {
+    ///     // `?` here: infra failure — abandon the whole batch.
+    ///     let res = op
+    ///         .with_savepoint(async |op| self.process_in_op(op, item).await)
+    ///         .await?;
+    ///
+    ///     outcomes.push(match res {
+    ///         Ok(()) => Outcome::Complete,
+    ///         Err(e) => Outcome::Retry(e),
+    ///     });
+    /// }
+    ///
+    /// op.commit().await?;
+    /// ```
+    ///
+    /// See [`SavepointOp`] for how commit hooks are staged and folded in.
+    pub async fn with_savepoint<T, E, F>(&mut self, f: F) -> Result<Result<T, E>, sqlx::Error>
+    where
+        F: AsyncFnOnce(&mut SavepointOp<'_>) -> Result<T, E>,
+    {
+        let mut op = self.begin_savepoint().await?;
+        match f(&mut op).await {
+            Ok(value) => {
+                op.release().await?;
+                Ok(Ok(value))
+            }
+            Err(error) => {
+                op.rollback().await?;
+                Ok(Err(error))
+            }
+        }
+    }
+
+    /// Begins a `SAVEPOINT` scope explicitly.
+    ///
+    /// The escape hatch for when [`with_savepoint`](Self::with_savepoint)'s
+    /// closure form doesn't fit — the returned [`SavepointOp`] must be finished
+    /// with [`release`](SavepointOp::release) or
+    /// [`rollback`](SavepointOp::rollback). Dropping it rolls back.
+    pub async fn begin_savepoint(&mut self) -> Result<SavepointOp<'_>, sqlx::Error> {
+        SavepointOp::begin(
+            &mut self.tx,
+            self.clock.clone(),
+            self.now,
+            &mut self.commit_hooks,
+        )
+        .await
     }
 
     /// Commits the inner transaction.
@@ -207,6 +289,23 @@ impl<'c> DbOpWithTime<'c> {
     /// Begins a nested transaction.
     pub async fn begin(&mut self) -> Result<DbOpWithTime<'_>, sqlx::Error> {
         Ok(DbOpWithTime::new(self.inner.begin().await?, self.now))
+    }
+
+    /// Runs `f` inside a `SAVEPOINT` — see [`DbOp::with_savepoint`].
+    ///
+    /// The cached time is propagated, so the [`SavepointOp`] reports it from
+    /// [`maybe_now`](AtomicOperation::maybe_now) and wrapping it in
+    /// [`OpWithTime`] is free.
+    pub async fn with_savepoint<T, E, F>(&mut self, f: F) -> Result<Result<T, E>, sqlx::Error>
+    where
+        F: AsyncFnOnce(&mut SavepointOp<'_>) -> Result<T, E>,
+    {
+        self.inner.with_savepoint(f).await
+    }
+
+    /// Begins a `SAVEPOINT` scope explicitly — see [`DbOp::begin_savepoint`].
+    pub async fn begin_savepoint(&mut self) -> Result<SavepointOp<'_>, sqlx::Error> {
+        self.inner.begin_savepoint().await
     }
 
     /// Commits the inner transaction.

--- a/src/operation/savepoint.rs
+++ b/src/operation/savepoint.rs
@@ -1,0 +1,146 @@
+//! Savepoint-scoped operations for per-item isolation inside a single transaction.
+
+use sqlx::{Acquire, Transaction};
+
+use crate::{clock::ClockHandle, db};
+
+use super::{AtomicOperation, hooks};
+
+/// An [`AtomicOperation`] scoped to a database `SAVEPOINT` inside a parent [`DbOp`].
+///
+/// Created by [`DbOp::with_savepoint`] / [`DbOp::begin_savepoint`]. Statements
+/// executed through it run inside the savepoint, so they can be undone with
+/// [`rollback`](Self::rollback) without poisoning — or ending — the parent
+/// transaction. This is what makes a "loop over N items in one transaction, but
+/// isolate each item's failure" pattern possible: one `COMMIT` (one WAL flush)
+/// for the whole batch, while a failing item unwinds only its own writes.
+///
+/// # Hooks are staged, not executed
+///
+/// Commit hooks registered on a `SavepointOp` — including the ones repositories
+/// register internally, e.g. via `post_persist_hook` — are **staged** in a
+/// private buffer rather than added to the parent operation:
+///
+/// - [`release`](Self::release) issues `RELEASE SAVEPOINT` and then folds the
+///   staged hooks into the parent's buffer through the ordinary
+///   registration/merge path, exactly as if they had been registered on the
+///   parent directly.
+/// - [`rollback`](Self::rollback) issues `ROLLBACK TO SAVEPOINT` and drops the
+///   staged hooks. A rolled-back item therefore contributes zero hook state to
+///   match its zero database state — no phantom event publishes, no inserts
+///   referencing rows that no longer exist.
+///
+/// No hook's [`pre_commit`] / [`post_commit`] ever runs at savepoint boundaries.
+/// They run once, at the parent's [`commit`](DbOp::commit), over the final merged
+/// hook set — so `post_commit` still only fires after a durable `COMMIT`, and
+/// [`on_rollback`] still only fires when the whole transaction is gone.
+///
+/// [`DbOp`]: super::DbOp
+/// [`DbOp::with_savepoint`]: super::DbOp::with_savepoint
+/// [`DbOp::begin_savepoint`]: super::DbOp::begin_savepoint
+/// [`pre_commit`]: hooks::CommitHook::pre_commit
+/// [`post_commit`]: hooks::CommitHook::post_commit
+/// [`on_rollback`]: hooks::CommitHook::on_rollback
+pub struct SavepointOp<'t> {
+    tx: Transaction<'t, db::Db>,
+    clock: ClockHandle,
+    now: Option<chrono::DateTime<chrono::Utc>>,
+    /// Hooks registered while the savepoint is open. Folded into
+    /// `parent_hooks` on release, dropped on rollback.
+    staged: hooks::CommitHooks,
+    /// The parent operation's hook buffer. Held as a `&mut` to a *disjoint*
+    /// field of the parent (the nested transaction borrows its `tx` field), so
+    /// the savepoint can fold into it without the parent's hooks ever leaving
+    /// the parent.
+    parent_hooks: &'t mut Option<hooks::CommitHooks>,
+}
+
+impl<'t> SavepointOp<'t> {
+    pub(super) async fn begin(
+        tx: &'t mut Transaction<'_, db::Db>,
+        clock: ClockHandle,
+        now: Option<chrono::DateTime<chrono::Utc>>,
+        parent_hooks: &'t mut Option<hooks::CommitHooks>,
+    ) -> Result<Self, sqlx::Error> {
+        Ok(Self {
+            tx: tx.begin().await?,
+            clock,
+            now,
+            staged: hooks::CommitHooks::new(),
+            parent_hooks,
+        })
+    }
+
+    /// Releases the savepoint, keeping this scope's work.
+    ///
+    /// Issues `RELEASE SAVEPOINT`, then folds the staged commit hooks into the
+    /// parent operation's buffer via the normal registration/merge path — so a
+    /// mergeable hook type accumulates across savepoints exactly as it would
+    /// have on the parent, and a non-mergeable one lands at its own position in
+    /// release order.
+    ///
+    /// If the `RELEASE` itself fails the staged hooks are dropped and the error
+    /// is returned: the parent transaction is in an indeterminate state and the
+    /// caller must abandon it rather than commit.
+    pub async fn release(self) -> Result<(), sqlx::Error> {
+        let Self {
+            tx,
+            staged,
+            parent_hooks,
+            ..
+        } = self;
+        tx.commit().await?;
+        parent_hooks
+            .as_mut()
+            .expect("no hooks")
+            .absorb_staged(staged);
+        Ok(())
+    }
+
+    /// Rolls back to the savepoint, discarding this scope's work.
+    ///
+    /// Issues `ROLLBACK TO SAVEPOINT` and drops the staged commit hooks. The
+    /// parent transaction stays alive and usable — including after an error
+    /// that would otherwise have poisoned it.
+    ///
+    /// Dropping a `SavepointOp` without calling either `release` or `rollback`
+    /// has the same database effect (sqlx queues the rollback on the
+    /// connection) and likewise discards the staged hooks.
+    pub async fn rollback(self) -> Result<(), sqlx::Error> {
+        self.tx.rollback().await
+    }
+}
+
+impl AtomicOperation for SavepointOp<'_> {
+    fn maybe_now(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.now
+    }
+
+    fn clock(&self) -> &ClockHandle {
+        &self.clock
+    }
+
+    fn connection(&mut self) -> &mut db::Connection {
+        self.tx.connection()
+    }
+
+    fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
+        self.staged.add(hook);
+        Ok(())
+    }
+
+    /// Reads the staged buffer first, falling back to the parent's.
+    ///
+    /// While a savepoint is open the two are not yet merged, so a hook type
+    /// present in *both* reports only the staged instance here — they become
+    /// one hook when the savepoint is released.
+    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
+        self.staged
+            .get_last::<H>()
+            .or_else(|| self.parent_hooks.as_ref()?.get_last::<H>())
+    }
+
+    fn supports_hooks(&self) -> bool {
+        true
+    }
+}

--- a/tests/savepoint.rs
+++ b/tests/savepoint.rs
@@ -1,0 +1,487 @@
+mod helpers;
+
+use es_entity::operation::{
+    AtomicOperation, DbOp,
+    hooks::{CommitHook, HookOperation, PreCommitRet},
+};
+use std::sync::{Arc, Mutex};
+
+es_entity::entity_id! { SavepointItemId }
+
+fn new_id() -> uuid::Uuid {
+    SavepointItemId::new().into()
+}
+
+/// Mirrors a real `do_thing_in_op` service method: generic over the operation,
+/// so it accepts a `SavepointOp` with no signature change.
+async fn insert_item_in_op(
+    op: &mut impl AtomicOperation,
+    id: uuid::Uuid,
+    label: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        "INSERT INTO savepoint_items (id, label) VALUES ($1, $2)",
+        id,
+        label
+    )
+    .execute(op.as_executor())
+    .await?;
+    Ok(())
+}
+
+async fn labels(pool: &sqlx::PgPool, prefix: &str) -> anyhow::Result<Vec<String>> {
+    let labels = sqlx::query!(
+        "SELECT label FROM savepoint_items WHERE label LIKE $1 ORDER BY label",
+        format!("{prefix}%")
+    )
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|r| r.label)
+    .collect();
+    Ok(labels)
+}
+
+/// Records which lifecycle callbacks fired, with the labels carried by the hook.
+#[derive(Debug, Clone, Default)]
+struct Probe {
+    pre: Arc<Mutex<Vec<String>>>,
+    post: Arc<Mutex<Vec<String>>>,
+    rolled_back: Arc<Mutex<Vec<String>>>,
+}
+
+impl Probe {
+    fn hook(&self, label: &str) -> MergingProbeHook {
+        MergingProbeHook {
+            labels: vec![label.to_string()],
+            probe: self.clone(),
+        }
+    }
+
+    fn standalone_hook(&self, label: &str) -> StandaloneProbeHook {
+        StandaloneProbeHook {
+            label: label.to_string(),
+            probe: self.clone(),
+        }
+    }
+
+    fn pre(&self) -> Vec<String> {
+        self.pre.lock().unwrap().clone()
+    }
+
+    fn post(&self) -> Vec<String> {
+        self.post.lock().unwrap().clone()
+    }
+
+    fn rolled_back(&self) -> Vec<String> {
+        self.rolled_back.lock().unwrap().clone()
+    }
+}
+
+/// Stands in for an outbox publisher: always merges, so a whole batch's worth
+/// of registrations collapses into one hook.
+#[derive(Debug)]
+struct MergingProbeHook {
+    labels: Vec<String>,
+    probe: Probe,
+}
+
+impl CommitHook for MergingProbeHook {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.probe.pre.lock().unwrap().extend(self.labels.clone());
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.probe.post.lock().unwrap().extend(self.labels);
+    }
+
+    fn on_rollback(self) {
+        self.probe.rolled_back.lock().unwrap().extend(self.labels);
+    }
+
+    fn merge(&mut self, other: &mut Self) -> bool {
+        self.labels.append(&mut other.labels);
+        true
+    }
+}
+
+/// Never merges — each registration keeps its own execution slot.
+#[derive(Debug)]
+struct StandaloneProbeHook {
+    label: String,
+    probe: Probe,
+}
+
+impl CommitHook for StandaloneProbeHook {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.probe.pre.lock().unwrap().push(self.label.clone());
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.probe.post.lock().unwrap().push(self.label);
+    }
+}
+
+#[tokio::test]
+async fn released_savepoint_folds_staged_hooks_into_parent() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let probe = Probe::default();
+
+    let res = op
+        .with_savepoint(async |op| {
+            op.add_commit_hook(probe.hook("item-1")).unwrap();
+            Ok::<_, anyhow::Error>(())
+        })
+        .await?;
+    assert!(res.is_ok());
+
+    // Releasing a savepoint must not run any part of the hook lifecycle: the
+    // transaction has not committed, so nothing may be announced yet.
+    assert!(probe.pre().is_empty());
+    assert!(probe.post().is_empty());
+
+    op.commit().await?;
+
+    assert_eq!(probe.pre(), vec!["item-1"]);
+    assert_eq!(probe.post(), vec!["item-1"]);
+    assert!(probe.rolled_back().is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn rolled_back_savepoint_discards_staged_hooks() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let probe = Probe::default();
+
+    let res = op
+        .with_savepoint(async |op| {
+            op.add_commit_hook(probe.hook("doomed")).unwrap();
+            Err::<(), _>("item failed")
+        })
+        .await?;
+    assert_eq!(res, Err("item failed"));
+
+    op.commit().await?;
+
+    // The item's writes were undone, so its hooks must produce nothing —
+    // not even `on_rollback`, which is reserved for a failed *commit*.
+    assert!(probe.pre().is_empty());
+    assert!(probe.post().is_empty());
+    assert!(probe.rolled_back().is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn staged_hooks_merge_across_savepoints() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let probe = Probe::default();
+
+    for label in ["item-1", "item-2", "item-3"] {
+        op.with_savepoint(async |op| {
+            op.add_commit_hook(probe.hook(label)).unwrap();
+            Ok::<_, anyhow::Error>(())
+        })
+        .await?
+        .unwrap();
+    }
+
+    op.commit().await?;
+
+    // One merged hook, accumulated batch-wide in release order — identical to
+    // registering all three on the parent directly.
+    assert_eq!(probe.pre(), vec!["item-1", "item-2", "item-3"]);
+    assert_eq!(probe.post(), vec!["item-1", "item-2", "item-3"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn only_released_items_contribute_hooks() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let probe = Probe::default();
+
+    for (label, succeeds) in [("item-1", true), ("item-2", false), ("item-3", true)] {
+        let res = op
+            .with_savepoint(async |op| {
+                op.add_commit_hook(probe.hook(label)).unwrap();
+                if succeeds { Ok(()) } else { Err("boom") }
+            })
+            .await?;
+        assert_eq!(res.is_ok(), succeeds);
+    }
+
+    op.commit().await?;
+
+    assert_eq!(probe.pre(), vec!["item-1", "item-3"]);
+    assert_eq!(probe.post(), vec!["item-1", "item-3"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn absorbed_hooks_keep_parent_registration_order() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let probe = Probe::default();
+
+    // A merging hook registered before the loop anchors its type's position...
+    op.add_commit_hook(probe.hook("pre-loop")).unwrap();
+    // ...ahead of a non-merging hook registered after it.
+    op.add_commit_hook(probe.standalone_hook("standalone"))
+        .unwrap();
+
+    op.with_savepoint(async |op| {
+        op.add_commit_hook(probe.hook("from-savepoint")).unwrap();
+        Ok::<_, anyhow::Error>(())
+    })
+    .await?
+    .unwrap();
+
+    op.commit().await?;
+
+    // The absorbed hook merges into the pre-loop instance, so it runs at that
+    // (earlier) position rather than appending after the standalone hook.
+    assert_eq!(
+        probe.pre(),
+        vec!["pre-loop", "from-savepoint", "standalone"]
+    );
+    assert_eq!(
+        probe.post(),
+        vec!["pre-loop", "from-savepoint", "standalone"]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn commit_hook_getter_reads_through_to_parent() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let probe = Probe::default();
+
+    op.add_commit_hook(probe.hook("parent")).unwrap();
+
+    op.with_savepoint(async |op| {
+        // Nothing staged yet: the parent's accumulated state is visible.
+        let seen = op.commit_hook::<MergingProbeHook>().expect("parent hook");
+        assert_eq!(seen.labels, vec!["parent"]);
+
+        op.add_commit_hook(probe.hook("staged")).unwrap();
+
+        // Once staged, the staged instance shadows the parent's until release.
+        let seen = op.commit_hook::<MergingProbeHook>().expect("staged hook");
+        assert_eq!(seen.labels, vec!["staged"]);
+
+        Ok::<_, anyhow::Error>(())
+    })
+    .await?
+    .unwrap();
+
+    // After release the two are one hook.
+    let merged = op.commit_hook::<MergingProbeHook>().expect("merged hook");
+    assert_eq!(merged.labels, vec!["parent", "staged"]);
+
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn later_items_see_earlier_items_accumulated_hook_state() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let probe = Probe::default();
+
+    op.with_savepoint(async |op| {
+        assert!(op.commit_hook::<MergingProbeHook>().is_none());
+        op.add_commit_hook(probe.hook("item-1")).unwrap();
+        Ok::<_, anyhow::Error>(())
+    })
+    .await?
+    .unwrap();
+
+    op.with_savepoint(async |op| {
+        let seen = op
+            .commit_hook::<MergingProbeHook>()
+            .expect("item-1's hook is visible after its release");
+        assert_eq!(seen.labels, vec!["item-1"]);
+        Ok::<_, anyhow::Error>(())
+    })
+    .await?
+    .unwrap();
+
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn failed_item_unwinds_its_writes_and_leaves_transaction_usable() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let prefix = format!("sp-{}", new_id());
+    let clashing_id = new_id();
+
+    let mut op = DbOp::init(&pool).await?;
+
+    // Item 1 succeeds.
+    op.with_savepoint(async |op| insert_item_in_op(op, clashing_id, &format!("{prefix}-a")).await)
+        .await?
+        .unwrap();
+
+    // Item 2 writes, then hits a duplicate-key violation — the kind of error
+    // that poisons a transaction and would otherwise take the whole batch down.
+    let res = op
+        .with_savepoint(async |op| {
+            insert_item_in_op(op, new_id(), &format!("{prefix}-b")).await?;
+            insert_item_in_op(op, clashing_id, &format!("{prefix}-c")).await
+        })
+        .await?;
+    assert!(res.is_err());
+
+    // Item 3 proves the transaction survived the poisoning error.
+    op.with_savepoint(async |op| insert_item_in_op(op, new_id(), &format!("{prefix}-d")).await)
+        .await?
+        .unwrap();
+
+    op.commit().await?;
+
+    // The failed item's *first* write is gone too — savepoint scope, not
+    // statement scope.
+    assert_eq!(
+        labels(&pool, &prefix).await?,
+        vec![format!("{prefix}-a"), format!("{prefix}-d")]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn batch_loop_collects_per_item_outcomes() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let prefix = format!("sp-{}", new_id());
+    let probe = Probe::default();
+
+    // Two distinct items plus a repeat of the first id — the repeat is the
+    // "poison pill" that must fail alone.
+    let first_id = new_id();
+    let items = vec![(first_id, "a"), (first_id, "b"), (new_id(), "c")];
+
+    let mut op = DbOp::init(&pool).await?;
+    let mut outcomes = Vec::with_capacity(items.len());
+
+    for (id, suffix) in items {
+        let label = format!("{prefix}-{suffix}");
+        // `?` on the outer Result: an infra failure aborts the batch.
+        let res = op
+            .with_savepoint(async |op| {
+                insert_item_in_op(op, id, &label).await?;
+                op.add_commit_hook(probe.hook(&label)).unwrap();
+                Ok::<_, sqlx::Error>(())
+            })
+            .await?;
+
+        // The verdict is recorded outside the savepoint, where it is final.
+        outcomes.push((suffix, res.is_ok()));
+    }
+
+    op.commit().await?;
+
+    assert_eq!(outcomes, vec![("a", true), ("b", false), ("c", true)]);
+    assert_eq!(
+        labels(&pool, &prefix).await?,
+        vec![format!("{prefix}-a"), format!("{prefix}-c")]
+    );
+    assert_eq!(
+        probe.post(),
+        vec![format!("{prefix}-a"), format!("{prefix}-c")]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn closure_may_mutate_captured_state() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let mut attempted = Vec::new();
+
+    for label in ["item-1", "item-2"] {
+        op.with_savepoint(async |op| {
+            attempted.push(label);
+            sqlx::query!("SELECT 1 as one")
+                .fetch_one(op.as_executor())
+                .await?;
+            Ok::<_, sqlx::Error>(())
+        })
+        .await?
+        .unwrap();
+    }
+
+    op.commit().await?;
+
+    assert_eq!(attempted, vec!["item-1", "item-2"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn savepoint_inherits_cached_time() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let time = "2021-01-01T00:00:00Z".parse::<chrono::DateTime<chrono::Utc>>()?;
+    let mut op = DbOp::init(&pool).await?.with_time(time);
+
+    op.with_savepoint(async |op| {
+        assert_eq!(op.maybe_now(), Some(time));
+        Ok::<_, anyhow::Error>(())
+    })
+    .await?
+    .unwrap();
+
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn explicit_savepoint_release_and_rollback() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let prefix = format!("sp-{}", new_id());
+    let mut op = DbOp::init(&pool).await?;
+
+    let mut sp = op.begin_savepoint().await?;
+    insert_item_in_op(&mut sp, new_id(), &format!("{prefix}-kept")).await?;
+    sp.release().await?;
+
+    let mut sp = op.begin_savepoint().await?;
+    insert_item_in_op(&mut sp, new_id(), &format!("{prefix}-undone")).await?;
+    sp.rollback().await?;
+
+    // Dropping without finishing rolls back too.
+    {
+        let mut sp = op.begin_savepoint().await?;
+        insert_item_in_op(&mut sp, new_id(), &format!("{prefix}-dropped")).await?;
+    }
+
+    op.commit().await?;
+
+    assert_eq!(
+        labels(&pool, &prefix).await?,
+        vec![format!("{prefix}-kept")]
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds `DbOp::with_savepoint` / `begin_savepoint`, returning a `SavepointOp` that scopes work to a database `SAVEPOINT`. This makes it possible to process a batch of items in one transaction — one `COMMIT`, one WAL flush — while still isolating each item's failure, instead of one transaction per item or one poisoned transaction taking the whole batch down.

Motivated by the `job` crate's `BatchedJobRunner` (see [lana-bank#8200](https://github.com/GaloyMoney/lana-bank/pull/8200)): several adopters there run all items in one shared `op` with **no** per-item rollback, because — per that PR's own comment — "`DbOp` has no nested-transaction API, and commit hooks (outbox publishes, job notifies) accumulate un-scoped on the op, so a savepoint rollback could not unwind them." This PR closes that gap.

## Why this wasn't just `op.begin()`

The DB mechanics already existed — sqlx's nested transactions compile to `SAVEPOINT` / `RELEASE SAVEPOINT` / `ROLLBACK TO SAVEPOINT`. The blocker was commit hooks. Two naive routes both break the hook contract:

- **A nested `DbOp`** runs its own hook set to completion on commit, so `post_commit` fires at `RELEASE` — announcing side effects while the *outer* transaction is still uncommitted — and `on_rollback` fires while the outer transaction is still alive, violating its documented "no lock contention" guarantee.
- **Raw `SAVEPOINT` SQL** on the parent connection, with hooks registered on the parent as usual, leaves a failed item's hooks in the parent's buffer — so the eventual commit publishes events for rows that were rolled back.

## The fix: savepoint semantics for the hook buffer

`SavepointOp` stages hook registrations privately instead of adding them to the parent:

- **`release()`** issues `RELEASE SAVEPOINT`, then folds the staged hooks into the parent's buffer through the *ordinary* registration/merge path — indistinguishable from having registered them on the parent directly (batch-wide merging, `commit_hook::<H>()` read-through to earlier items' accumulated state).
- **`rollback()`** issues `ROLLBACK TO SAVEPOINT` and drops the staged hooks — a failed item contributes zero hook state to match its zero database state.

No hook callback ever runs at a savepoint boundary. `pre_commit` still runs once, at the parent's `commit()`, over the final merged set; `post_commit` still only fires after a durable `COMMIT`; `on_rollback` still only fires when the whole transaction is gone.

```rust
let mut op = DbOp::init(&pool).await?;
let mut outcomes = Vec::with_capacity(items.len());

for item in items {
    // outer `?`: savepoint machinery itself failed — abandon the whole op
    let res = op
        .with_savepoint(async |op| self.process_in_op(op, item).await)
        .await?;

    // inner Result: the item's own outcome, already cleanly rolled back if Err
    outcomes.push(match res {
        Ok(()) => Outcome::Complete,
        Err(e) => Outcome::Retry(e),
    });
}

op.commit().await?;
```

## Caveats (documented in the book page)

- Savepoints do **not** release Postgres locks — those are held until the transaction ends. This buys error isolation, not lock-contention relief.
- Host-side mutations inside the closure do not unwind with the savepoint — record outcomes through the closure's `Ok`/`Err`, not by mutating captured state before a later statement might fail.
- One level of savepoint nesting is supported (what a batch loop needs); nesting `with_savepoint` inside a `SavepointOp` is not.

## Testing

12 new tests in `tests/savepoint.rs` cover: hook fold-on-release / drop-on-rollback, batch-wide merging across savepoints, `commit_hook::<H>()` read-through, registration-order preservation when absorbing into a parent with pre-existing hooks, cached-time propagation, the explicit `begin_savepoint`/`release`/`rollback`/drop forms, and — the actual regression this exists to fix — a duplicate-key violation mid-batch that would otherwise poison the whole transaction, proven to only roll back its own item while the transaction stays usable for subsequent items.

Uses a dedicated `savepoint_items` fixture table (new migration) rather than the shared `users` table, since raw-SQL test writes to an event-sourced fixture table left orphan rows that broke an unrelated hydration-based test (`repo_crud::list_for_filters`).

- `nix flake check`: all checks passed
- `cargo nextest run --workspace`: 335/335 passed
- `cargo test --doc`: passed
- `mdbook build book`: passed

## Docs

New `book/src/savepoints.md`, linked from `SUMMARY.md` and cross-referenced from `db-op.md` and `transactions.md`. Module docs in `src/operation/hooks.rs` note the savepoint interaction with the existing hook-ordering contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction and commit-hook semantics for batch runners; behavior is heavily tested but adopters must handle the dual Result and not record outcomes inside savepoint closures incorrectly.
> 
> **Overview**
> Adds **`DbOp::with_savepoint`** / **`begin_savepoint`** (and the same on **`DbOpWithTime`**) so a batch can run in **one** transaction while each item’s failure rolls back only its own writes.
> 
> The closure gets a **`SavepointOp`** that implements **`AtomicOperation`**, so existing `*_in_op` code works unchanged. **`with_savepoint`** returns **`Result<Result<T, E>, sqlx::Error>`** — outer errors mean abandon the op; inner errors are per-item outcomes after a clean rollback.
> 
> **Commit hooks are staged** on savepoints: **release** folds staged hooks into the parent via **`CommitHooks::absorb_staged`** (same merge/order rules as direct registration); **rollback** drops them so rolled-back rows don’t still publish outbox/events. Hook lifecycle still runs only at the parent **`commit()`**.
> 
> Docs: new **`book/src/savepoints.md`**, cross-links from transactions/db-op; hook module notes savepoint behavior. Tests in **`tests/savepoint.rs`** (poisoning, hook staging, batch outcomes) plus a **`savepoint_items`** migration fixture table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8244d471e17adfcd283b024415d6c90d229bffcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->