### PR TITLE
feat(operation): re-entrant commit-hook registration in HookOperation

### DIFF
--- a/src/operation/hooks.rs
+++ b/src/operation/hooks.rs
@@ -36,11 +36,35 @@
 //!    registrations fold into that position.
 //! 3. [`CommitHook::post_commit()`] hooks run in the same order as their
 //!    [`CommitHook::pre_commit()`] counterparts (registration order).
-//! 4. The hook set is frozen when `commit()` starts (hooks cannot register further
-//!    hooks), so ordering is fully determined before the first `pre_commit` runs.
+//! 4. A hook's `pre_commit` may itself register further hooks — see
+//!    [`AtomicOperation::add_commit_hook()`] on the [`HookOperation`] it is handed.
+//!    Those join the **tail of the same commit pass** rather than freezing the set
+//!    before the first `pre_commit` runs. See "Re-entrant Registration" below.
 //!
 //! Registration order is a determinism guarantee, not a priority mechanism — there
 //! is no way to reorder hooks independently of the order in which they were added.
+//!
+//! # Re-entrant Registration
+//!
+//! [`AtomicOperation::add_commit_hook()`] succeeds on the [`HookOperation`] passed to
+//! a `pre_commit` that is running as part of a real commit pass — a hook can register
+//! more hooks, and they join the pass instead of being silently dropped or forced to
+//! run outside the commit lifecycle:
+//!
+//! - A newly-registered hook merges into a **still-pending** hook of the same type,
+//!   keeping that hook's queue position — indistinguishable from having registered it
+//!   there directly. An **already-executed** hook of that type is never a merge
+//!   target (its `pre_commit` already ran), so registering that type again after its
+//!   own execution always starts a fresh instance, which runs its own `pre_commit`
+//!   later in the same pass.
+//! - A bound ([`MAX_HOOK_GENERATIONS`] re-entrant generations) guards against a
+//!   registration cycle (A registers B, B registers A, …), which would otherwise grow
+//!   the queue forever inside an open transaction. Exceeding it fails the commit
+//!   loudly instead of hanging.
+//! - This only applies to a real commit pass. [`CommitHook::force_execute_pre_commit()`]
+//!   — the escape hatch for ops that don't support hooks at all — still returns
+//!   `Err` from `add_commit_hook`, because there is no pass for a registered hook to
+//!   join; its `post_commit`/`on_rollback` would simply never run.
 //!
 //! # Savepoints
 //!
@@ -180,6 +204,7 @@
 
 use std::{
     any::{Any, TypeId},
+    collections::VecDeque,
     future::Future,
     pin::Pin,
 };
@@ -264,18 +289,53 @@ pub trait CommitHook: Send + 'static + Sized {
 
 /// Wrapper around a database connection passed to [`CommitHook::pre_commit()`].
 ///
-/// Implements [`AtomicOperation`] to allow executing database queries within the transaction.
+/// Implements [`AtomicOperation`] to allow executing database queries within the
+/// transaction. Whether it also supports registering *further* commit hooks depends
+/// on how it was constructed — see the `staged` field below and "Re-entrant
+/// Registration" in the [module docs](self).
 pub struct HookOperation<'c> {
     now: Option<chrono::DateTime<chrono::Utc>>,
     conn: &'c mut db::Connection,
+    /// Hooks registered by the `pre_commit` currently holding this op, staged for
+    /// the enclosing commit pass to fold into its own not-yet-executed tail once
+    /// that `pre_commit` returns.
+    ///
+    /// `Some` when this op was constructed by [`CommitHooks::execute_pre`] (a real
+    /// commit pass is running and can fold staged hooks in). `None` on the
+    /// [`force_execute_pre_commit`] path — there is no pass to fold into, so
+    /// registration there must keep failing, so callers take their
+    /// immediate-execution fallback instead of silently losing a hook's
+    /// `post_commit`/`on_rollback`.
+    ///
+    /// [`force_execute_pre_commit`]: CommitHook::force_execute_pre_commit
+    staged: Option<CommitHooks>,
 }
 
 impl<'c> HookOperation<'c> {
+    /// Force-execute path: no commit pass to fold into, so registering further
+    /// hooks stays unsupported.
     fn new(op: &'c mut impl AtomicOperation) -> Self {
         Self {
             now: op.maybe_now(),
             conn: op.connection(),
+            staged: None,
         }
+    }
+
+    /// Commit-pass path: hooks registered while this op is threaded through
+    /// [`CommitHooks::execute_pre`] accumulate here.
+    fn staging(op: &'c mut impl AtomicOperation) -> Self {
+        Self {
+            now: op.maybe_now(),
+            conn: op.connection(),
+            staged: Some(CommitHooks::new()),
+        }
+    }
+
+    /// Takes whatever the `pre_commit` that just returned staged, leaving a fresh
+    /// empty buffer behind for the next hook. `None` on the force-execute path.
+    fn drain_staged(&mut self) -> Option<CommitHooks> {
+        Some(std::mem::take(self.staged.as_mut()?))
     }
 }
 
@@ -286,6 +346,24 @@ impl<'c> AtomicOperation for HookOperation<'c> {
 
     fn connection(&mut self) -> &mut db::Connection {
         self.conn
+    }
+
+    fn add_commit_hook<H: CommitHook>(&mut self, hook: H) -> Result<(), H> {
+        match self.staged.as_mut() {
+            Some(staged) => {
+                staged.add(hook);
+                Ok(())
+            }
+            None => Err(hook),
+        }
+    }
+
+    fn commit_hook<H: CommitHook>(&self) -> Option<&H> {
+        self.staged.as_ref()?.get_last::<H>()
+    }
+
+    fn supports_hooks(&self) -> bool {
+        self.staged.is_some()
     }
 }
 
@@ -412,23 +490,54 @@ impl CommitHooks {
 
     /// Runs each hook's `pre_commit` in registration order.
     ///
+    /// Re-entrant: a hook may register further hooks via
+    /// [`AtomicOperation::add_commit_hook`] on the [`HookOperation`] it is handed.
+    /// Those join the **tail of this same pass** — merged into a still-pending hook
+    /// of the same type (keeping that hook's position), or appended fresh if no
+    /// pending hook of that type remains (an already-executed hook is never a merge
+    /// target). [`MAX_HOOK_GENERATIONS`] bounds the resulting chain against a
+    /// registration cycle. See the [module docs](self#re-entrant-registration).
+    ///
     /// On failure the already-executed hooks travel back **with** the error (as
     /// a [`PostCommitHooks`]) instead of being dropped, so the caller can fire
     /// their [`CommitHook::on_rollback`] after rolling the transaction back.
-    /// Hooks after the failing one never ran their `pre_commit`, produced no
-    /// effects, and are simply dropped.
+    /// Hooks after the failing one — pending or not yet staged — never ran their
+    /// `pre_commit`, produced no effects, and are simply dropped.
     pub(super) async fn execute_pre(
         self,
         op: &mut impl AtomicOperation,
     ) -> Result<PostCommitHooks, (sqlx::Error, PostCommitHooks)> {
-        let mut op = HookOperation::new(op);
-        let mut post_hooks = Vec::with_capacity(self.hooks.len());
+        let mut op = HookOperation::staging(op);
+        let mut pending: VecDeque<(TypeId, Box<dyn DynHook>, u8)> = self
+            .hooks
+            .into_iter()
+            .map(|(type_id, hook)| (type_id, hook, 0))
+            .collect();
+        let mut post_hooks = Vec::with_capacity(pending.len());
 
-        for (_, hook) in self.hooks {
+        while let Some((_, hook, generation)) = pending.pop_front() {
             match hook.pre_commit_boxed(op).await {
-                Ok((new_op, hook)) => {
-                    op = new_op;
+                Ok((mut new_op, hook)) => {
                     post_hooks.push(hook);
+
+                    // Fold whatever that `pre_commit` staged into the tail of this
+                    // same pass, through the same registration/merge path
+                    // `absorb_staged` uses for released savepoints.
+                    if let Some(staged) = new_op.drain_staged() {
+                        let next_generation = generation.saturating_add(1);
+                        for (type_id, staged_hook) in staged.hooks {
+                            if let Err(error) = push_or_merge_pending(
+                                &mut pending,
+                                type_id,
+                                staged_hook,
+                                next_generation,
+                            ) {
+                                return Err((error, PostCommitHooks { hooks: post_hooks }));
+                            }
+                        }
+                    }
+
+                    op = new_op;
                 }
                 Err(error) => {
                     return Err((error, PostCommitHooks { hooks: post_hooks }));
@@ -444,6 +553,47 @@ impl Default for CommitHooks {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Maximum number of re-entrant "generations" a single commit pass will execute.
+/// Generation 0 is the hook set registered on the operation before `commit()`
+/// starts; a hook staged by a generation-*N* hook's `pre_commit` is generation
+/// *N*+1. Bounds a registration cycle (A registers B, B registers A, …), which
+/// would otherwise grow the queue forever inside an open transaction — see the
+/// [module docs](self#re-entrant-registration).
+pub const MAX_HOOK_GENERATIONS: u8 = 8;
+
+/// Merges `hook` into a still-pending hook of the same type — keeping that hook's
+/// queue position and generation — or appends it fresh at `generation`. The
+/// deferred-execution counterpart of [`CommitHooks::push_or_merge`]: only hooks that
+/// have not yet run their `pre_commit` are eligible merge targets, so a type that
+/// already executed this pass always gets a fresh instance rather than retroactively
+/// absorbing new work into a hook whose `pre_commit` already returned.
+///
+/// Errors if the fresh instance would exceed [`MAX_HOOK_GENERATIONS`] — the loud,
+/// bounded failure mode for a registration cycle instead of an unbounded queue
+/// inside an open transaction.
+fn push_or_merge_pending(
+    pending: &mut VecDeque<(TypeId, Box<dyn DynHook>, u8)>,
+    type_id: TypeId,
+    mut hook: Box<dyn DynHook>,
+    generation: u8,
+) -> Result<(), sqlx::Error> {
+    if let Some((_, existing, _)) = pending.iter_mut().rev().find(|(t, _, _)| *t == type_id)
+        && existing.try_merge(hook.as_mut())
+    {
+        return Ok(());
+    }
+
+    if generation > MAX_HOOK_GENERATIONS {
+        return Err(sqlx::Error::Protocol(format!(
+            "commit hook registration exceeded the maximum of {MAX_HOOK_GENERATIONS} \
+             re-entrant generations in one commit pass — likely a registration cycle"
+        )));
+    }
+
+    pending.push_back((type_id, hook, generation));
+    Ok(())
 }
 
 pub struct PostCommitHooks {

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -2,7 +2,7 @@ mod helpers;
 
 use es_entity::operation::{
     AtomicOperation, DbOp, OpWithTime,
-    hooks::{CommitHook, HookOperation, PreCommitRet},
+    hooks::{CommitHook, HookOperation, MAX_HOOK_GENERATIONS, PreCommitRet},
 };
 use sqlx::Connection;
 use std::sync::{Arc, Mutex};
@@ -900,6 +900,421 @@ async fn on_rollback_runs_after_transaction_is_rolled_back() -> anyhow::Result<(
          proving the operation's transaction had already rolled back (releasing the lock) \
          before on_rollback fired"
     );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Re-entrant registration tests
+// ===========================================================================
+
+/// A hook whose `pre_commit` registers a fresh [`NonMergingGetterHook`]-shaped
+/// child (non-mergeable) via [`AtomicOperation::add_commit_hook`] on the
+/// [`HookOperation`] it is handed.
+#[derive(Debug)]
+struct ChildHook {
+    label: &'static str,
+    pre_order: Arc<Mutex<Vec<&'static str>>>,
+    post_order: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl CommitHook for ChildHook {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.pre_order.lock().unwrap().push(self.label);
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.post_order.lock().unwrap().push(self.label);
+    }
+}
+
+#[derive(Debug)]
+struct RegistersChild {
+    label: &'static str,
+    child_label: &'static str,
+    pre_order: Arc<Mutex<Vec<&'static str>>>,
+    post_order: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl CommitHook for RegistersChild {
+    async fn pre_commit(
+        self,
+        mut op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.pre_order.lock().unwrap().push(self.label);
+        op.add_commit_hook(ChildHook {
+            label: self.child_label,
+            pre_order: self.pre_order.clone(),
+            post_order: self.post_order.clone(),
+        })
+        .expect("a real commit pass must accept re-entrant registration");
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.post_order.lock().unwrap().push(self.label);
+    }
+}
+
+#[tokio::test]
+async fn reentrant_hook_runs_pre_and_post_commit_in_the_same_pass() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre_order = Arc::new(Mutex::new(Vec::new()));
+    let post_order = Arc::new(Mutex::new(Vec::new()));
+
+    op.add_commit_hook(RegistersChild {
+        label: "parent",
+        child_label: "child",
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    // The re-entrantly registered child joins the tail of the same pass: it
+    // runs its own pre_commit before the single COMMIT, and its post_commit
+    // after — exactly like a hook registered on the operation directly.
+    assert_eq!(*pre_order.lock().unwrap(), vec!["parent", "child"]);
+    assert_eq!(*post_order.lock().unwrap(), vec!["parent", "child"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn reentrant_hook_merges_into_a_still_pending_same_type_hook() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre_order = Arc::new(Mutex::new(Vec::new()));
+    let post_order = Arc::new(Mutex::new(Vec::new()));
+
+    #[derive(Debug)]
+    struct RegistersMergeable {
+        label: &'static str,
+        staged_labels: Vec<&'static str>,
+        pre_order: Arc<Mutex<Vec<&'static str>>>,
+        post_order: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl CommitHook for RegistersMergeable {
+        async fn pre_commit(
+            self,
+            mut op: HookOperation<'_>,
+        ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+            self.pre_order.lock().unwrap().push(self.label);
+            op.add_commit_hook(MergingOrderProbe {
+                labels: self.staged_labels.clone(),
+                pre_order: self.pre_order.clone(),
+                post_order: self.post_order.clone(),
+            })
+            .expect("a real commit pass must accept re-entrant registration");
+            PreCommitRet::ok(self, op)
+        }
+
+        fn post_commit(self) {
+            self.post_order.lock().unwrap().push(self.label);
+        }
+    }
+
+    // "first" runs before the native MergingOrderProbe and re-entrantly stages
+    // one of the same type. The native one is still pending at that point, so
+    // the staged instance merges into it — one execution, at the native
+    // hook's own (later) queue position — instead of a second, separate one.
+    op.add_commit_hook(RegistersMergeable {
+        label: "first",
+        staged_labels: vec!["staged"],
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+    op.add_commit_hook(MergingOrderProbe {
+        labels: vec!["native"],
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    assert_eq!(
+        *pre_order.lock().unwrap(),
+        vec!["first", "native", "staged"]
+    );
+    assert_eq!(
+        *post_order.lock().unwrap(),
+        vec!["first", "native", "staged"]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn reentrant_hook_of_an_already_executed_type_appends_a_fresh_instance() -> anyhow::Result<()>
+{
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre_order = Arc::new(Mutex::new(Vec::new()));
+    let post_order = Arc::new(Mutex::new(Vec::new()));
+
+    #[derive(Debug)]
+    struct RegistersMergeable {
+        label: &'static str,
+        staged_labels: Vec<&'static str>,
+        pre_order: Arc<Mutex<Vec<&'static str>>>,
+        post_order: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl CommitHook for RegistersMergeable {
+        async fn pre_commit(
+            self,
+            mut op: HookOperation<'_>,
+        ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+            self.pre_order.lock().unwrap().push(self.label);
+            op.add_commit_hook(MergingOrderProbe {
+                labels: self.staged_labels.clone(),
+                pre_order: self.pre_order.clone(),
+                post_order: self.post_order.clone(),
+            })
+            .expect("a real commit pass must accept re-entrant registration");
+            PreCommitRet::ok(self, op)
+        }
+
+        fn post_commit(self) {
+            self.post_order.lock().unwrap().push(self.label);
+        }
+    }
+
+    // The native MergingOrderProbe now runs FIRST and has already executed
+    // by the time "second" re-entrantly stages one of the same type — an
+    // already-executed hook is never a merge target, so the staged instance
+    // starts a fresh execution of its own at the tail instead of vanishing
+    // into (or reopening) the one that already ran.
+    op.add_commit_hook(MergingOrderProbe {
+        labels: vec!["native"],
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+    op.add_commit_hook(RegistersMergeable {
+        label: "second",
+        staged_labels: vec!["staged"],
+        pre_order: pre_order.clone(),
+        post_order: post_order.clone(),
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    assert_eq!(
+        *pre_order.lock().unwrap(),
+        vec!["native", "second", "staged"]
+    );
+    assert_eq!(
+        *post_order.lock().unwrap(),
+        vec!["native", "second", "staged"]
+    );
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ForcePathProbe {
+    supports_hooks_result: Arc<Mutex<Option<bool>>>,
+    add_hook_result: Arc<Mutex<Option<bool>>>,
+}
+
+impl CommitHook for ForcePathProbe {
+    async fn pre_commit(
+        self,
+        mut op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        *self.supports_hooks_result.lock().unwrap() = Some(op.supports_hooks());
+        let registered = op
+            .add_commit_hook(NonMergingGetterHook { label: "child" })
+            .is_ok();
+        *self.add_hook_result.lock().unwrap() = Some(registered);
+        PreCommitRet::ok(self, op)
+    }
+}
+
+#[tokio::test]
+async fn force_execute_path_still_refuses_reentrant_registration() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut tx = pool.begin().await?; // bare sqlx::Transaction: no hook support at all
+
+    let supports_hooks_result = Arc::new(Mutex::new(None));
+    let add_hook_result = Arc::new(Mutex::new(None));
+
+    ForcePathProbe {
+        supports_hooks_result: supports_hooks_result.clone(),
+        add_hook_result: add_hook_result.clone(),
+    }
+    .force_execute_pre_commit(&mut tx)
+    .await?;
+
+    // The force-execute escape hatch has no commit pass for a registered
+    // hook to join, so it must keep refusing — a caller that gets `Err` from
+    // `add_commit_hook` needs to take its own immediate-execution fallback,
+    // not have the hook silently accepted and its post_commit/on_rollback
+    // never run.
+    assert_eq!(*supports_hooks_result.lock().unwrap(), Some(false));
+    assert_eq!(*add_hook_result.lock().unwrap(), Some(false));
+
+    tx.rollback().await?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct StagesFailingChild {
+    label: &'static str,
+    child_label: &'static str,
+    pre_order: Arc<Mutex<Vec<&'static str>>>,
+    post_order: Arc<Mutex<Vec<&'static str>>>,
+    rollback_order: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl CommitHook for StagesFailingChild {
+    async fn pre_commit(
+        self,
+        mut op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.pre_order.lock().unwrap().push(self.label);
+        op.add_commit_hook(RollbackProbe {
+            label: self.child_label,
+            fail_pre: true,
+            pre_order: self.pre_order.clone(),
+            post_order: self.post_order.clone(),
+            rollback_order: self.rollback_order.clone(),
+        })
+        .expect("a real commit pass must accept re-entrant registration");
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.post_order.lock().unwrap().push(self.label);
+    }
+
+    fn on_rollback(self) {
+        self.rollback_order.lock().unwrap().push(self.label);
+    }
+}
+
+#[tokio::test]
+async fn reentrant_failure_rolls_back_and_notifies_the_staging_parent() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let pre = Arc::new(Mutex::new(Vec::new()));
+    let post = Arc::new(Mutex::new(Vec::new()));
+    let rollback = Arc::new(Mutex::new(Vec::new()));
+
+    op.add_commit_hook(RollbackProbe {
+        label: "a",
+        fail_pre: false,
+        pre_order: pre.clone(),
+        post_order: post.clone(),
+        rollback_order: rollback.clone(),
+    })
+    .unwrap();
+    // "parent" re-entrantly stages "child", whose pre_commit fails.
+    op.add_commit_hook(StagesFailingChild {
+        label: "parent",
+        child_label: "child",
+        pre_order: pre.clone(),
+        post_order: post.clone(),
+        rollback_order: rollback.clone(),
+    })
+    .unwrap();
+
+    let result = op.commit().await;
+    assert!(
+        result.is_err(),
+        "commit must fail because the re-entrantly staged child fails pre_commit"
+    );
+
+    // 'a' and 'parent' ran pre_commit natively; 'child' ran too (re-entrantly
+    // staged, at the tail) and is the one whose pre_commit failed.
+    assert_eq!(*pre.lock().unwrap(), vec!["a", "parent", "child"]);
+    // Everyone whose pre_commit already completed is notified of the
+    // rollback — including 'parent', the hook that staged the failing
+    // child, exactly as it would be for a hook registered on the operation
+    // directly. 'child' is consumed by its own failure and signals (or, here,
+    // doesn't) from that branch instead.
+    assert_eq!(*rollback.lock().unwrap(), vec!["a", "parent"]);
+    assert!(post.lock().unwrap().is_empty());
+
+    Ok(())
+}
+
+/// Stages a fresh instance of itself, one generation deeper, every time it
+/// runs — an unbroken re-registration cycle.
+#[derive(Debug)]
+struct CyclicHook {
+    generation: u8,
+    executions: Arc<Mutex<Vec<u8>>>,
+    rollback_order: Arc<Mutex<Vec<u8>>>,
+}
+
+impl CommitHook for CyclicHook {
+    async fn pre_commit(
+        self,
+        mut op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.executions.lock().unwrap().push(self.generation);
+        // Not `.expect(..)`: past the generation bound this returns `Err`
+        // instead, which is fine to ignore here — `commit()` itself is what
+        // surfaces the failure.
+        let _ = op.add_commit_hook(CyclicHook {
+            generation: self.generation + 1,
+            executions: self.executions.clone(),
+            rollback_order: self.rollback_order.clone(),
+        });
+        PreCommitRet::ok(self, op)
+    }
+
+    fn on_rollback(self) {
+        self.rollback_order.lock().unwrap().push(self.generation);
+    }
+}
+
+#[tokio::test]
+async fn reentrant_registration_cycle_is_bounded_and_rolls_back() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let executions = Arc::new(Mutex::new(Vec::new()));
+    let rollback_order = Arc::new(Mutex::new(Vec::new()));
+
+    op.add_commit_hook(CyclicHook {
+        generation: 0,
+        executions: executions.clone(),
+        rollback_order: rollback_order.clone(),
+    })
+    .unwrap();
+
+    let result = op.commit().await;
+    assert!(
+        result.is_err(),
+        "an unbroken re-registration cycle must fail loudly instead of hanging"
+    );
+
+    // Generations 0..=MAX_HOOK_GENERATIONS all executed (each stages the
+    // next); the one that would exceed the bound is rejected at registration
+    // time and never gets a chance to run.
+    let expected_generations: Vec<u8> = (0..=MAX_HOOK_GENERATIONS).collect();
+    assert_eq!(*executions.lock().unwrap(), expected_generations);
+    // Every generation that did execute is notified of the rollback, in the
+    // same (registration/execution) order.
+    assert_eq!(*rollback_order.lock().unwrap(), expected_generations);
 
     Ok(())
 }


### PR DESCRIPTION
## What

`CommitHook::pre_commit` can now register further commit hooks on the `HookOperation` it is
handed. They join the **tail of the same commit pass** instead of being refused —
`CommitHooks::execute_pre` is now a work queue: after each hook's `pre_commit` returns, it
drains whatever that hook staged and folds it in through the existing merge/append path —
merging into a still-pending hook of the same type (keeping its position), or appending fresh
if that type already executed this pass. A `MAX_HOOK_GENERATIONS` bound (8) guards against a
registration cycle, failing the commit loudly instead of hanging inside an open transaction.

`HookOperation::new` — the `force_execute_pre_commit` escape hatch for ops that don't support
hooks at all (e.g. a bare `sqlx::Transaction`) — is unchanged and still refuses registration:
there is no commit pass for a hookless publish to join.

## Why

Unblocks cross-outbox event reposting (obix's `PostPersistHook` design): a hook that
re-publishes into a second outbox from inside another outbox's `pre_commit` previously held
only a `HookOperation`, whose `add_commit_hook` always returned `Err`. The caller fell back to
the immediate-execute path, which drops the destination hook's `post_commit` (no in-process
forwarding, degraded to a per-publish in-tx `NOTIFY`) and `on_rollback` (no reactive gap-fill
compensation on transaction failure). With this change the destination outbox's hook runs
through the full lifecycle — normal persist, `post_commit`, `on_rollback` — in the same
transaction and single `COMMIT`, with **no change required to the obix publish path**.

Full design: `es-entity-dev/handoff-reentrant-commit-hook-registration.md` (drua library).

## How

- `HookOperation` gains an optional `staged: Option<CommitHooks>` buffer — `Some` only when
  constructed by `CommitHooks::execute_pre` (a real commit pass), `None` on the force-execute
  path. `add_commit_hook` / `commit_hook` / `supports_hooks` key off it.
- `CommitHooks::execute_pre` drains each hook's staged buffer after its `pre_commit` returns
  and folds it into the not-yet-executed tail via a new `push_or_merge_pending`, tracking a
  generation per queue entry (0 = registered before `commit()`, N+1 = staged by a
  generation-N hook) to bound cycles.
- Merge targets are **pending hooks only** — an already-executed hook of that type is never a
  merge target, so a repeated type past its own execution always starts a fresh instance. This
  is also what makes the cycle guard sound: a cycle always finds its predecessor already
  executed, so it always appends at the next generation until the bound trips.
- Module docs updated (`# Hook Ordering` item 4, new `# Re-entrant Registration` section).

## Tests

Six new tests in `tests/hooks.rs`:
- `reentrant_hook_runs_pre_and_post_commit_in_the_same_pass`
- `reentrant_hook_merges_into_a_still_pending_same_type_hook`
- `reentrant_hook_of_an_already_executed_type_appends_a_fresh_instance`
- `force_execute_path_still_refuses_reentrant_registration`
- `reentrant_failure_rolls_back_and_notifies_the_staging_parent`
- `reentrant_registration_cycle_is_bounded_and_rolls_back`

`nix flake check` (fmt/clippy `-D warnings`/audit/deny) ✅ · `cargo nextest run --workspace` vs
live PG: **367/367** ✅ · `cargo test --doc --workspace` ✅

No API breaks (one private field, two private constructors, an internal loop restructure). One
behavioral note for the changelog: any existing implementor that calls `add_commit_hook` inside
its own `pre_commit` and relied on the `Err` to trigger an immediate-work fallback will now
silently defer instead — worth a scan across consumers (obix's `publish_ephemeral_in_op` is
this shape; deferral is benign there) before this lands in a release those consumers pick up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transactional commit-hook semantics (re-entrant registration and queue execution); hooks that previously relied on `add_commit_hook` failing in `pre_commit` will now defer instead of immediate fallback, though the change is bounded and heavily tested.
> 
> **Overview**
> **Commit hooks can now register additional hooks from inside `pre_commit`** on the `HookOperation` they receive. Those hooks run in the **same commit pass** (before the single `COMMIT`), with full `post_commit` / `on_rollback` lifecycle—instead of `add_commit_hook` always failing and forcing immediate-execution fallbacks that skip post-commit work.
> 
> `CommitHooks::execute_pre` is reworked as a **work queue**: after each hook’s `pre_commit` returns, staged hooks are drained and folded into the pending tail via `push_or_merge_pending` (same merge rules as savepoint absorption, but only **still-pending** hooks are merge targets). Re-entrant depth is capped by **`MAX_HOOK_GENERATIONS` (8)**; exceeding it fails the commit with a protocol error instead of an infinite loop inside an open transaction.
> 
> The **`force_execute_pre_commit`** path is unchanged: `HookOperation` has no staging buffer there, so registration still returns `Err`. Module docs add a “Re-entrant Registration” section and update hook-ordering rule 4.
> 
> Six integration tests cover same-pass execution, merge vs fresh instance, force path refusal, rollback propagation, and cycle bounding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc22530ccf03c930c7f0c846e9be6998c6386f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->