### PR TITLE
feat(operation): runs_after commit-hook ordering

### DIFF
--- a/src/operation/hooks.rs
+++ b/src/operation/hooks.rs
@@ -41,8 +41,23 @@
 //!    Those join the **tail of the same commit pass** rather than freezing the set
 //!    before the first `pre_commit` runs. See "Re-entrant Registration" below.
 //!
-//! Registration order is a determinism guarantee, not a priority mechanism — there
-//! is no way to reorder hooks independently of the order in which they were added.
+//! Registration order is the base order; [`CommitHook::runs_after()`] is the one
+//! sanctioned refinement — it can only *delay* a hook until still-pending instances
+//! of its declared dependency types have executed, never advance it:
+//!
+//! 5. A hook may declare hook **types** it must run after via
+//!    [`CommitHook::runs_after()`]. While any still-pending instance of a declared
+//!    type remains in the queue, the hook is deferred to the back and re-checked
+//!    later; once no declared type is still pending it runs. This is evaluated
+//!    dynamically on every attempt, so it composes with re-entrant staging — a
+//!    dependency staged mid-pass re-blocks a hook that already deferred past it.
+//! 6. Among hooks with no unsatisfied `runs_after` dependency, registration order
+//!    (points 1-3 above) is preserved. Execution remains fully deterministic.
+//! 7. A dependency type that never registers, or whose instances have all already
+//!    executed, imposes no constraint — deferral is vacuous in both cases.
+//! 8. Declared dependencies that cannot all be satisfied (a cycle, direct or
+//!    transitive) fail the commit loudly with a protocol error instead of hanging —
+//!    see [`CommitHook::runs_after()`].
 //!
 //! # Re-entrant Registration
 //!
@@ -65,6 +80,12 @@
 //!   — the escape hatch for ops that don't support hooks at all — still returns
 //!   `Err` from `add_commit_hook`, because there is no pass for a registered hook to
 //!   join; its `post_commit`/`on_rollback` would simply never run.
+//! - A hook deferred by [`CommitHook::runs_after()`] is still **pending**, so it
+//!   remains a merge target for re-entrant staging exactly like any other
+//!   not-yet-executed hook. This is what lets a producer's `pre_commit` stage work
+//!   into a consumer hook that declared `runs_after` the producer's type: the
+//!   consumer is waiting (deferred) rather than gone, so the staged instance merges
+//!   into it — one execution — instead of starting a fresh generation.
 //!
 //! # Savepoints
 //!
@@ -223,7 +244,8 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 ///
 /// Hooks registered on the same operation execute in registration order — see the
 /// [module-level documentation](self#hook-ordering) for the full ordering contract
-/// and a complete example.
+/// and a complete example. [`runs_after()`](Self::runs_after) lets a hook refine
+/// that order by declaring dependency types it must run after.
 pub trait CommitHook: Send + 'static + Sized {
     /// Called before the transaction commits. Can perform database operations.
     ///
@@ -271,6 +293,27 @@ pub trait CommitHook: Send + 'static + Sized {
     /// Returns `true` if merged (other will be dropped), `false` if not (both execute separately).
     fn merge(&mut self, _other: &mut Self) -> bool {
         false
+    }
+
+    /// Hook types (by `TypeId`) whose still-pending instances must run their
+    /// [`pre_commit`](Self::pre_commit) before this hook's.
+    ///
+    /// Consulted each time this hook reaches the front of the commit pass's
+    /// queue: if any *still-pending* hook in the pass has a type in this list,
+    /// this hook is deferred behind it and retried after other hooks execute.
+    /// A listed type that never registered on the operation — or whose
+    /// instances have all already executed — imposes no constraint.
+    ///
+    /// Declared per instance but effectively per type: instances that merge
+    /// keep the merge target's list, so all instances of one logical hook
+    /// should return the same list.
+    ///
+    /// Mutually-dependent hooks (A after B and B after A, directly or
+    /// transitively) cannot make progress; the commit fails loudly with a
+    /// protocol error and the transaction rolls back. Never list your own
+    /// type.
+    fn runs_after(&self) -> &[TypeId] {
+        &[]
     }
 
     /// Execute the hook immediately, bypassing the hook system.
@@ -396,6 +439,8 @@ trait DynHook: Send {
 
     fn try_merge(&mut self, other: &mut dyn DynHook) -> bool;
 
+    fn runs_after(&self) -> &[TypeId];
+
     fn as_any(&self) -> &dyn Any;
 
     fn as_any_mut(&mut self) -> &mut dyn Any;
@@ -426,6 +471,12 @@ impl<H: CommitHook> DynHook for H {
             .downcast_mut::<H>()
             .expect("hook type mismatch");
         self.merge(other_h)
+    }
+
+    fn runs_after(&self) -> &[TypeId] {
+        // UFCS is REQUIRED: `self.runs_after()` is ambiguous here because H
+        // implements both CommitHook and (this very) DynHook.
+        CommitHook::runs_after(self)
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -503,6 +554,13 @@ impl CommitHooks {
     /// their [`CommitHook::on_rollback`] after rolling the transaction back.
     /// Hooks after the failing one — pending or not yet staged — never ran their
     /// `pre_commit`, produced no effects, and are simply dropped.
+    ///
+    /// A hook whose [`CommitHook::runs_after()`] names a still-pending type is
+    /// deferred to the back of the queue instead of executing — see the
+    /// [module docs](self#hook-ordering). Declared dependencies that can never
+    /// all be satisfied (a cycle) are detected when every remaining hook has been
+    /// deferred once in a row without any execution in between, and fail the
+    /// commit loudly instead of spinning inside an open transaction.
     pub(super) async fn execute_pre(
         self,
         op: &mut impl AtomicOperation,
@@ -514,8 +572,36 @@ impl CommitHooks {
             .map(|(type_id, hook)| (type_id, hook, 0))
             .collect();
         let mut post_hooks = Vec::with_capacity(pending.len());
+        let mut deferred_streak = 0usize;
 
-        while let Some((_, hook, generation)) = pending.pop_front() {
+        while let Some((type_id, hook, generation)) = pending.pop_front() {
+            // Deferral: a hook waits while any still-pending hook of a declared
+            // dependency type exists. Evaluated dynamically on every pop, so it
+            // composes with re-entrant staging (a dep staged mid-pass re-blocks
+            // a hook that already deferred past it).
+            let blocked = hook
+                .runs_after()
+                .iter()
+                .any(|dep| pending.iter().any(|(t, _, _)| t == dep));
+            if blocked {
+                pending.push_back((type_id, hook, generation));
+                deferred_streak += 1;
+                if deferred_streak >= pending.len() {
+                    // Every remaining hook deferred consecutively without any
+                    // execution in between → the declared dependencies form a
+                    // cycle. Fail loudly instead of spinning inside an open
+                    // transaction.
+                    let error = sqlx::Error::Protocol(format!(
+                        "commit hook runs_after dependencies form a cycle among \
+                         {} pending hooks — no hook can execute",
+                        pending.len()
+                    ));
+                    return Err((error, PostCommitHooks { hooks: post_hooks }));
+                }
+                continue;
+            }
+            deferred_streak = 0;
+
             match hook.pre_commit_boxed(op).await {
                 Ok((mut new_op, hook)) => {
                     post_hooks.push(hook);

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -5,7 +5,10 @@ use es_entity::operation::{
     hooks::{CommitHook, HookOperation, MAX_HOOK_GENERATIONS, PreCommitRet},
 };
 use sqlx::Connection;
-use std::sync::{Arc, Mutex};
+use std::{
+    any::TypeId,
+    sync::{Arc, Mutex},
+};
 
 #[derive(Debug)]
 struct FullCommitHook {
@@ -1315,6 +1318,373 @@ async fn reentrant_registration_cycle_is_bounded_and_rolls_back() -> anyhow::Res
     // Every generation that did execute is notified of the rollback, in the
     // same (registration/execution) order.
     assert_eq!(*rollback_order.lock().unwrap(), expected_generations);
+
+    Ok(())
+}
+
+// ===========================================================================
+// runs_after ordering tests
+// ===========================================================================
+//
+// `runs_after` matches on `TypeId`, so each test hook kind below is its own
+// struct (HookA / HookB / HookC) rather than a shared parameterized type —
+// `deps` is built at construction time (`vec![TypeId::of::<HookA>()]`), never
+// relied on as a `const`. `pre_commit` pushes `"pre:X"`, `post_commit` pushes
+// `"post:X"`, `on_rollback` pushes `"rollback:X"` onto a shared log.
+
+#[derive(Debug)]
+struct HookA {
+    log: Arc<Mutex<Vec<&'static str>>>,
+    deps: Vec<TypeId>,
+}
+
+impl CommitHook for HookA {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.log.lock().unwrap().push("pre:A");
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.log.lock().unwrap().push("post:A");
+    }
+
+    fn on_rollback(self) {
+        self.log.lock().unwrap().push("rollback:A");
+    }
+
+    fn runs_after(&self) -> &[TypeId] {
+        &self.deps
+    }
+}
+
+#[derive(Debug)]
+struct HookB {
+    log: Arc<Mutex<Vec<&'static str>>>,
+    deps: Vec<TypeId>,
+}
+
+impl CommitHook for HookB {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.log.lock().unwrap().push("pre:B");
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.log.lock().unwrap().push("post:B");
+    }
+
+    fn on_rollback(self) {
+        self.log.lock().unwrap().push("rollback:B");
+    }
+
+    fn runs_after(&self) -> &[TypeId] {
+        &self.deps
+    }
+}
+
+#[derive(Debug)]
+struct HookC {
+    log: Arc<Mutex<Vec<&'static str>>>,
+    deps: Vec<TypeId>,
+}
+
+impl CommitHook for HookC {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.log.lock().unwrap().push("pre:C");
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.log.lock().unwrap().push("post:C");
+    }
+
+    fn on_rollback(self) {
+        self.log.lock().unwrap().push("rollback:C");
+    }
+
+    fn runs_after(&self) -> &[TypeId] {
+        &self.deps
+    }
+}
+
+#[tokio::test]
+async fn runs_after_defers_until_dependency_executes() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let log = Arc::new(Mutex::new(Vec::new()));
+
+    // B is registered first but declares runs_after A: it must defer until
+    // A's still-pending instance executes, even though A registered later.
+    op.add_commit_hook(HookB {
+        log: log.clone(),
+        deps: vec![TypeId::of::<HookA>()],
+    })
+    .unwrap();
+    op.add_commit_hook(HookA {
+        log: log.clone(),
+        deps: vec![],
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        vec!["pre:A", "pre:B", "post:A", "post:B"]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn runs_after_vacuous_when_dependency_absent() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let log = Arc::new(Mutex::new(Vec::new()));
+
+    // B declares runs_after A, but A is never registered on this operation —
+    // the dependency imposes no constraint and registration order holds.
+    op.add_commit_hook(HookB {
+        log: log.clone(),
+        deps: vec![TypeId::of::<HookA>()],
+    })
+    .unwrap();
+    op.add_commit_hook(HookC {
+        log: log.clone(),
+        deps: vec![],
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        vec!["pre:B", "pre:C", "post:B", "post:C"]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn runs_after_dependency_already_executed_does_not_defer() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let log = Arc::new(Mutex::new(Vec::new()));
+
+    // A registers (and executes) first; B's dependency is already satisfied
+    // by the time B reaches the front of the queue, so no deferral occurs.
+    op.add_commit_hook(HookA {
+        log: log.clone(),
+        deps: vec![],
+    })
+    .unwrap();
+    op.add_commit_hook(HookB {
+        log: log.clone(),
+        deps: vec![TypeId::of::<HookA>()],
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        vec!["pre:A", "pre:B", "post:A", "post:B"]
+    );
+
+    Ok(())
+}
+
+/// Mergeable hook that declares `runs_after` a `Producer`. Records the event
+/// list it saw at each `pre_commit` call so the test can assert it ran
+/// exactly once (merged) rather than as two separate generations.
+#[derive(Debug)]
+struct Consumer {
+    events: Vec<&'static str>,
+    deps: Vec<TypeId>,
+    pre_commit_calls: Arc<Mutex<Vec<Vec<&'static str>>>>,
+}
+
+impl CommitHook for Consumer {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.pre_commit_calls
+            .lock()
+            .unwrap()
+            .push(self.events.clone());
+        PreCommitRet::ok(self, op)
+    }
+
+    fn merge(&mut self, other: &mut Self) -> bool {
+        self.events.append(&mut other.events);
+        true
+    }
+
+    fn runs_after(&self) -> &[TypeId] {
+        &self.deps
+    }
+}
+
+/// Stages a fresh `Consumer` from its own `pre_commit` — the obix cross-outbox
+/// repost shape this design exists for.
+#[derive(Debug)]
+struct Producer {
+    log: Arc<Mutex<Vec<&'static str>>>,
+    consumer_deps: Vec<TypeId>,
+    consumer_calls: Arc<Mutex<Vec<Vec<&'static str>>>>,
+}
+
+impl CommitHook for Producer {
+    async fn pre_commit(
+        self,
+        mut op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.log.lock().unwrap().push("pre:Producer");
+        op.add_commit_hook(Consumer {
+            events: vec!["staged"],
+            deps: self.consumer_deps.clone(),
+            pre_commit_calls: self.consumer_calls.clone(),
+        })
+        .expect("a real commit pass must accept re-entrant registration");
+        PreCommitRet::ok(self, op)
+    }
+}
+
+#[tokio::test]
+async fn reentrant_stage_merges_into_deferred_pending_hook() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let consumer_calls = Arc::new(Mutex::new(Vec::new()));
+    let consumer_deps = vec![TypeId::of::<Producer>()];
+
+    // Consumer registers FIRST (deps=[Producer]) and so defers; Producer
+    // registers second and, from its own pre_commit, re-entrantly stages
+    // another Consumer instance. Because the original Consumer is deferred
+    // (not yet executed), it is still a merge target: the staged instance
+    // folds into it instead of starting a fresh generation.
+    op.add_commit_hook(Consumer {
+        events: vec!["own"],
+        deps: consumer_deps.clone(),
+        pre_commit_calls: consumer_calls.clone(),
+    })
+    .unwrap();
+    op.add_commit_hook(Producer {
+        log: log.clone(),
+        consumer_deps,
+        consumer_calls: consumer_calls.clone(),
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    assert_eq!(*log.lock().unwrap(), vec!["pre:Producer"]);
+
+    let calls = consumer_calls.lock().unwrap();
+    assert_eq!(
+        calls.len(),
+        1,
+        "Consumer's pre_commit must run exactly once — merged into the \
+         deferred pending instance, not a fresh generation"
+    );
+    assert_eq!(calls[0], vec!["own", "staged"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn runs_after_cycle_errors_loudly() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let log = Arc::new(Mutex::new(Vec::new()));
+
+    // C has no dependency and runs to completion. A and B mutually depend on
+    // each other and can never both be satisfied.
+    op.add_commit_hook(HookC {
+        log: log.clone(),
+        deps: vec![],
+    })
+    .unwrap();
+    op.add_commit_hook(HookA {
+        log: log.clone(),
+        deps: vec![TypeId::of::<HookB>()],
+    })
+    .unwrap();
+    op.add_commit_hook(HookB {
+        log: log.clone(),
+        deps: vec![TypeId::of::<HookA>()],
+    })
+    .unwrap();
+
+    let result = op.commit().await;
+    match result {
+        Err(sqlx::Error::Protocol(msg)) => {
+            assert!(
+                msg.contains("cycle"),
+                "error message should mention the cycle, got: {msg}"
+            );
+        }
+        other => panic!("expected sqlx::Error::Protocol, got: {other:?}"),
+    }
+
+    // C's pre_commit had already completed, so it is notified of the
+    // rollback. A and B never ran their pre_commit (they were only ever
+    // popped for the (failed) deferral check), so they log nothing at all —
+    // no pre, no rollback, per the existing on_rollback contract.
+    assert_eq!(*log.lock().unwrap(), vec!["pre:C", "rollback:C"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn runs_after_chain_orders_transitively() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+
+    let log = Arc::new(Mutex::new(Vec::new()));
+
+    // C -> B -> A, registered in reverse dependency order.
+    op.add_commit_hook(HookC {
+        log: log.clone(),
+        deps: vec![TypeId::of::<HookB>()],
+    })
+    .unwrap();
+    op.add_commit_hook(HookB {
+        log: log.clone(),
+        deps: vec![TypeId::of::<HookA>()],
+    })
+    .unwrap();
+    op.add_commit_hook(HookA {
+        log: log.clone(),
+        deps: vec![],
+    })
+    .unwrap();
+
+    op.commit().await?;
+
+    let pre: Vec<&'static str> = log
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|entry| entry.starts_with("pre:"))
+        .copied()
+        .collect();
+    assert_eq!(pre, vec!["pre:A", "pre:B", "pre:C"]);
 
     Ok(())
 }


### PR DESCRIPTION
## What

Lets a `CommitHook` declare hook **types** it must run after: `execute_pre` defers such a hook to the back of the queue while any **still-pending** instance of a declared type exists.

```rust
fn runs_after(&self) -> &[TypeId] {
    &[]
}
```

One new defaulted method on `CommitHook` (mirrored on the private `DynHook` trait via UFCS). `&[TypeId]`, not `Vec`, because the check runs on every pop, including re-checks after deferral — must be alloc-free; implementors own the storage.

Handoff (implemented 1:1): [`es-entity-dev/handoff-commit-hook-runs-after-ordering.md`](https://github.com/GaloyMoney/drua-library/blob/main/spaces/es-entity-dev/handoff-commit-hook-runs-after-ordering.md)

## Why

With 0.12.9's re-entrant registration, obix's cross-outbox repost works correctly regardless of hook registration order — but the *cost* depends on an accident of application call order. When the consumer-side outbox hook has already executed by the time the producer's `pre_commit` re-entrantly stages a repost, that repost can't merge into an already-executed hook, so it starts a fresh generation: an extra INSERT round trip, an extra `post_commit`, and one generation burned of `MAX_HOOK_GENERATIONS`.

`runs_after` lets the consumer declare "run after the producer's hook type" once, at wiring time, so a same-pass repost always merges into the still-pending consumer instance instead of sometimes appending a fresh generation. Correctness was unaffected either way — this is efficiency plus generation headroom.

## Semantics

- **Dynamic deferral, not a compile-time DAG.** Checked on every pop against the *live* pending set (not a precomputed topological sort), so a dependency staged mid-pass by a re-entrant hook correctly re-blocks a hook that had already deferred past it.
- **Refines, never conflicts with, 0.11.7's registration-order guarantee.** Among hooks with no unsatisfied `runs_after` dependency, registration order holds exactly as before. `runs_after` can only *delay* a hook, never advance it.
- **Vacuous when unresolvable.** A declared dependency type that never registers on the operation, or whose instances have all already executed, imposes no constraint.
- **Cycle detection, not deadlock.** If every remaining hook in the queue gets deferred once in a row without any execution in between, that's a cycle (direct or transitive) — the commit fails loudly with `sqlx::Error::Protocol` instead of spinning inside an open transaction. The existing rollback-then-`on_rollback` path handles cleanup: hooks that had already executed are notified, hooks that never got to run their `pre_commit` are simply dropped.

### Composition with prior work

- **0.11.7 (registration order):** `runs_after` is a refinement layered on top, evaluated only in `execute_pre`'s pop loop. `push_or_merge` / the registration buffer stay pure registration order, untouched.
- **0.12.4 (`on_rollback`):** untouched. Deferral only affects `pre_commit` ordering; `on_rollback` still fires in execution order over whatever already-executed set exists when a later hook fails.
- **0.12.8 (savepoints):** untouched. `absorb_staged`/`push_or_merge` (registration-time folding of a released savepoint's staged hooks into the parent op) run before `execute_pre` ever sees the set, so `runs_after` resolves after savepoint staging, not against it.
- **0.12.9 (re-entrant registration, #200):** composes for free — a hook deferred by `runs_after` is still **pending**, so it remains a valid merge target for a dependency's re-entrantly staged hook of the same type. This is exactly the motivating obix case (see tests below).

## Tests (`tests/hooks.rs`)

- `runs_after_defers_until_dependency_executes`
- `runs_after_vacuous_when_dependency_absent`
- `runs_after_dependency_already_executed_does_not_defer`
- `reentrant_stage_merges_into_deferred_pending_hook` — the motivating obix cross-outbox case: a `Consumer` (mergeable, `runs_after` a `Producer`) registered first defers; `Producer`'s `pre_commit` re-entrantly stages a fresh `Consumer` instance; asserts the original `Consumer`'s `pre_commit` runs **exactly once** with both event batches merged, not as a second generation.
- `runs_after_cycle_errors_loudly`
- `runs_after_chain_orders_transitively`

## Downstream ripple (not in this PR)

- **obix** — `Outbox::persist_after` (+ optional `republish_into` sugar) builds on this; sequenced to land after this ships (`obix-dev/handoff-outbox-persist-after-ordering.md`).
- **job** — savepoint-batch-isolation is unaffected (savepoint staging path untouched, see above).
- **cala / lana-bank** consumers of the cross-outbox repost pattern are the ultimate beneficiaries once obix adopts this.

## Semver

Additive defaulted trait method; executor behavior only changes for hooks that override `runs_after`. Fits the 0.12.x line, consistent with how 0.12.4 (`on_rollback`) and 0.12.9 (re-entrant registration) landed.

## Verification

- `nix develop -c cargo fmt` — clean
- `nix flake check` (fmt / clippy `--all-features -- --deny warnings` / audit / deny) — **all checks passed**, verified as a fresh rebuild (not cached)
- `nix run .#nextest` requires the live process-compose Postgres, not available in this sandbox — **CI will run the full nextest suite**, including the new `runs_after` tests and all existing registration-order (0.11.7), savepoint (0.12.8), and `on_rollback` (0.12.4) tests, to confirm nothing regressed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the commit `pre_commit` scheduling path for all operations, but behavior is unchanged for hooks that do not override `runs_after`; incorrect dependency cycles fail the commit loudly rather than hanging.
> 
> **Overview**
> Adds **`CommitHook::runs_after()`** so a hook can declare hook **types** (`TypeId`) whose still-pending instances must finish `pre_commit` before it runs. **`execute_pre`** now defers blocked hooks to the queue tail and re-checks on every pop (including after re-entrant staging), so registration order still applies when no dependency is unsatisfied.
> 
> **Cycle detection:** if every remaining hook defers once without any execution, the commit fails with **`sqlx::Error::Protocol`** instead of spinning inside an open transaction; rollback/`on_rollback` behavior for hooks that already ran stays the same.
> 
> Deferred hooks remain **pending**, so re-entrantly staged hooks of the same type can still **merge** into them (the motivating cross-outbox repost case). Docs and **`tests/hooks.rs`** cover deferral, vacuous deps, chains, cycles, and merge-into-deferred.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaac373e7729fe79328cfb3c557b9cb42430f6cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->