### PR TITLE
feat(macros): batch nested-child persistence across the whole parent batch

### DIFF
--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -53,15 +53,23 @@ impl ToTokens for CreateAllFn<'_> {
         let entity = self.entity;
         let create_error = &self.create_error;
 
-        let nested = self.nested_fn_names.iter().map(|f| {
-            quote! {
-                self.#f(op, &mut entity).await?;
-            }
-        });
-        let maybe_mut_entity = if self.nested_fn_names.is_empty() {
-            quote! { entity }
+        // Nested creation is batched once across the whole hydrated parent
+        // batch (not once per parent), so it runs as its own pass after every
+        // parent is hydrated, gathering `&mut` refs into every parent just
+        // for that pass.
+        let nested_phase = if self.nested_fn_names.is_empty() {
+            quote! {}
         } else {
-            quote! { mut entity }
+            let nested = self.nested_fn_names.iter().map(|f| {
+                quote! {
+                    self.#f(op, &mut entity_refs).await?;
+                }
+            });
+            quote! {
+                let mut entity_refs: Vec<&mut #entity> = entities.iter_mut().collect();
+                #(#nested)*
+                drop(entity_refs);
+            }
         };
 
         let table_name = self.table_name;
@@ -163,6 +171,40 @@ impl ToTokens for CreateAllFn<'_> {
             quote! {}
         };
 
+        // The post-hydrate/post-persist pass only exists to run these two
+        // hooks (nested creation is already batched by `nested_phase`
+        // above), so it — and the `n_events` bookkeeping it needs — is
+        // skipped entirely when neither hook is configured: an empty loop
+        // would just be dead weight (and an unused-variable warning under
+        // `-D warnings`).
+        let post_checks_phase =
+            if self.post_hydrate_error.is_some() || self.post_persist_error.is_some() {
+                quote! {
+                    let mut n_events_by_entity: Vec<usize> = Vec::new();
+                    for (events, n_events) in all_events.into_iter().zip(n_persisted) {
+                        let entity = Self::hydrate_entity(events)?;
+                        entities.push(entity);
+                        n_events_by_entity.push(n_events);
+                    }
+
+                    #nested_phase
+
+                    for (entity, n_events) in entities.iter().zip(n_events_by_entity) {
+                        #post_hydrate_check
+                        #post_persist_check
+                    }
+                }
+            } else {
+                quote! {
+                    for (events, _n_events) in all_events.into_iter().zip(n_persisted) {
+                        let entity = Self::hydrate_entity(events)?;
+                        entities.push(entity);
+                    }
+
+                    #nested_phase
+                }
+            };
+
         tokens.append_all(quote! {
             pub async fn create_all(
                 &self,
@@ -186,9 +228,9 @@ impl ToTokens for CreateAllFn<'_> {
                 let __result: Result<Vec<#entity>, #create_error> = async {
                     use es_entity::prelude::sqlx::{Arguments, Row};
 
-                    let mut res = Vec::new();
+                    let mut entities = Vec::new();
                     if new_entities.is_empty() {
-                        return Ok(res);
+                        return Ok(entities);
                     }
 
                     let mut __query_args = sqlx::postgres::PgArguments::default();
@@ -239,17 +281,9 @@ impl ToTokens for CreateAllFn<'_> {
                         }
                     }
 
-                    for (events, n_events) in all_events.into_iter().zip(n_persisted) {
-                        let #maybe_mut_entity = Self::hydrate_entity(events)?;
+                    #post_checks_phase
 
-                        #(#nested)*
-
-                        #post_hydrate_check
-                        #post_persist_check
-                        res.push(entity);
-                    }
-
-                    Ok(res)
+                    Ok(entities)
                 }.await;
 
                 #error_recording
@@ -319,9 +353,9 @@ mod tests {
                 let __result: Result<Vec<Entity>, EntityCreateError> = async {
                     use es_entity::prelude::sqlx::{Arguments, Row};
 
-                    let mut res = Vec::new();
+                    let mut entities = Vec::new();
                     if new_entities.is_empty() {
-                        return Ok(res);
+                        return Ok(entities);
                     }
 
                     let mut __query_args = sqlx::postgres::PgArguments::default();
@@ -391,13 +425,12 @@ mod tests {
                         }
                     }
 
-                    for (events, n_events) in all_events.into_iter().zip(n_persisted) {
+                    for (events, _n_events) in all_events.into_iter().zip(n_persisted) {
                         let entity = Self::hydrate_entity(events)?;
-
-                        res.push(entity);
+                        entities.push(entity);
                     }
 
-                    Ok(res)
+                    Ok(entities)
                 }.await;
 
                 __result

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -55,7 +55,7 @@ impl ToTokens for CreateFn<'_> {
 
         let nested = self.nested_fn_names.iter().map(|f| {
             quote! {
-                self.#f(op, &mut entity).await?;
+                self.#f(op, &mut [&mut entity]).await?;
             }
         });
         let maybe_mut_entity = if self.nested_fn_names.is_empty() {

--- a/es-entity-macros/src/repo/nested.rs
+++ b/es-entity-macros/src/repo/nested.rs
@@ -31,31 +31,57 @@ impl ToTokens for Nested<'_> {
         let find_include_deleted_fn_name = self.field.find_nested_include_deleted_fn_name();
 
         tokens.append_all(quote! {
-            async fn #create_fn_name<OP, P>(&self, op: &mut OP, entity: &mut P) -> Result<(), <#nested_repo_ty as es_entity::EsRepo>::CreateError>
+            // Batches every parent's new children into a single
+            // `create_all_in_op` call on the child repo — one statement for
+            // the whole parent batch, not one per parent — then redistributes
+            // the hydrated children back to their owning parent by count.
+            //
+            // Takes `&mut [&mut P]` rather than `&mut [P]` so a caller that
+            // already holds scattered `&mut P` borrows (this same fn one
+            // level up the nesting, recursing into grandchildren) can pass
+            // them straight through without needing contiguous storage.
+            async fn #create_fn_name<OP, P>(&self, op: &mut OP, entities: &mut [&mut P]) -> Result<(), <#nested_repo_ty as es_entity::EsRepo>::CreateError>
                 where
                     P: es_entity::Parent<<#nested_repo_ty as EsRepo>::Entity>,
                     OP: es_entity::AtomicOperation
             {
-                let new_children = entity.new_children_mut();
-                if new_children.is_empty() {
+                let counts: Vec<usize> = entities
+                    .iter_mut()
+                    .map(|entity| entity.new_children_mut().len())
+                    .collect();
+                if counts.iter().all(|n| *n == 0) {
                     return Ok(());
                 }
 
-                let new_children = new_children.drain(..).collect();
-                let children = self.#repo_field.create_all_in_op(op, new_children).await?;
-                entity.inject_children(children);
+                let new_children: Vec<_> = entities
+                    .iter_mut()
+                    .flat_map(|entity| entity.new_children_mut().drain(..))
+                    .collect();
+
+                let mut children = self.#repo_field.create_all_in_op(op, new_children).await?.into_iter();
+                for (entity, n) in entities.iter_mut().zip(counts) {
+                    entity.inject_children(children.by_ref().take(n));
+                }
                 Ok(())
             }
 
-            async fn #update_fn_name<OP, P>(&self, op: &mut OP, entity: &mut P) -> Result<(), #parent_modify_error>
+            // Gathers every parent's already-persisted children into a single
+            // `update_all_mut_in_op` call on the child repo — one statement
+            // for the whole parent batch, not one per child per parent — then
+            // batches new children via `#create_fn_name`.
+            async fn #update_fn_name<OP, P>(&self, op: &mut OP, entities: &mut [&mut P]) -> Result<(), #parent_modify_error>
                 where
                     P: es_entity::Parent<<#nested_repo_ty as EsRepo>::Entity>,
                     OP: es_entity::AtomicOperation
             {
-                for entity in entity.iter_persisted_children_mut() {
-                    self.#repo_field.update_in_op(op, entity).await?;
+                let persisted: Vec<_> = entities
+                    .iter_mut()
+                    .flat_map(|entity| entity.iter_persisted_children_mut())
+                    .collect();
+                if !persisted.is_empty() {
+                    self.#repo_field.update_all_mut_in_op(op, persisted).await?;
                 }
-                self.#create_fn_name(op, entity).await?;
+                self.#create_fn_name(op, entities).await?;
                 Ok(())
             }
 
@@ -126,31 +152,44 @@ mod tests {
         cursor.to_tokens(&mut tokens);
 
         let expected = quote! {
-            async fn create_nested_users_in_op<OP, P>(&self, op: &mut OP, entity: &mut P) -> Result<(), <UserRepo as es_entity::EsRepo>::CreateError>
+            async fn create_nested_users_in_op<OP, P>(&self, op: &mut OP, entities: &mut [&mut P]) -> Result<(), <UserRepo as es_entity::EsRepo>::CreateError>
                 where
                     P: es_entity::Parent<<UserRepo as EsRepo>::Entity>,
                     OP: es_entity::AtomicOperation
             {
-                let new_children = entity.new_children_mut();
-                if new_children.is_empty() {
+                let counts: Vec<usize> = entities
+                    .iter_mut()
+                    .map(|entity| entity.new_children_mut().len())
+                    .collect();
+                if counts.iter().all(|n| *n == 0) {
                     return Ok(());
                 }
 
-                let new_children = new_children.drain(..).collect();
-                let children = self.users.create_all_in_op(op, new_children).await?;
-                entity.inject_children(children);
+                let new_children: Vec<_> = entities
+                    .iter_mut()
+                    .flat_map(|entity| entity.new_children_mut().drain(..))
+                    .collect();
+
+                let mut children = self.users.create_all_in_op(op, new_children).await?.into_iter();
+                for (entity, n) in entities.iter_mut().zip(counts) {
+                    entity.inject_children(children.by_ref().take(n));
+                }
                 Ok(())
             }
 
-            async fn update_nested_users_in_op<OP, P>(&self, op: &mut OP, entity: &mut P) -> Result<(), ParentModifyError>
+            async fn update_nested_users_in_op<OP, P>(&self, op: &mut OP, entities: &mut [&mut P]) -> Result<(), ParentModifyError>
                 where
                     P: es_entity::Parent<<UserRepo as EsRepo>::Entity>,
                     OP: es_entity::AtomicOperation
             {
-                for entity in entity.iter_persisted_children_mut() {
-                    self.users.update_in_op(op, entity).await?;
+                let persisted: Vec<_> = entities
+                    .iter_mut()
+                    .flat_map(|entity| entity.iter_persisted_children_mut())
+                    .collect();
+                if !persisted.is_empty() {
+                    self.users.update_all_mut_in_op(op, persisted).await?;
                 }
-                self.create_nested_users_in_op(op, entity).await?;
+                self.create_nested_users_in_op(op, entities).await?;
                 Ok(())
             }
 

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -46,25 +46,82 @@ impl<'a> From<&'a RepositoryOptions> for UpdateAllFn<'a> {
     }
 }
 
+/// Which shape of parent collection a generated bulk-update function
+/// operates on.
+///
+/// `update_all_in_op` is the top-level, caller-facing batch API: it owns a
+/// contiguous `&mut [Entity]`. `update_all_mut_in_op` is the shape needed to
+/// batch *nested children across many parents*: each parent owns its own
+/// children (in its own `HashMap`), so gathering "every persisted child that
+/// needs updating, across the whole parent batch" can only ever produce a
+/// `Vec` of scattered `&mut Entity` borrows, never a contiguous slice.
+///
+/// Both variants share the exact same SQL-building logic below; only the
+/// outer signature and how `entities` is iterated differ, via `iter_ref` /
+/// `iter_mut_ref`. `Vec<&mut Entity>::iter_mut()` yields `&mut &mut Entity`
+/// (one level of indirection too many — it breaks the generic
+/// `Self::extract_events(entity)` call, which needs `Entity: EsEntity` to
+/// unify against a concrete `&mut Entity`, not `&mut &mut Entity`), so the
+/// `RefVec` adapters reborrow down to a single level with `.map(|e| &mut
+/// **e)` / `.map(|e| &**e)`, making the entity-loop bodies below identical
+/// text for both modes.
+enum BatchMode {
+    OwnedSlice,
+    RefVec,
+}
+
 impl ToTokens for UpdateAllFn<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append_all(self.build(BatchMode::OwnedSlice));
+        tokens.append_all(self.build(BatchMode::RefVec));
+    }
+}
+
+impl UpdateAllFn<'_> {
+    fn build(&self, mode: BatchMode) -> TokenStream {
         let entity = self.entity;
         let modify_error = &self.modify_error;
 
-        let nested = self.nested_fn_names.iter().map(|f| {
-            quote! {
-                self.#f(op, entity).await?;
-            }
-        });
+        let (fn_name, entities_param, iter_ref, iter_mut_ref) = match mode {
+            BatchMode::OwnedSlice => (
+                quote::format_ident!("update_all_in_op"),
+                quote! { entities: &mut [#entity] },
+                quote! { entities.iter() },
+                quote! { entities.iter_mut() },
+            ),
+            BatchMode::RefVec => (
+                quote::format_ident!("update_all_mut_in_op"),
+                quote! { mut entities: Vec<&mut #entity> },
+                quote! { entities.iter().map(|e| &**e) },
+                quote! { entities.iter_mut().map(|e| &mut **e) },
+            ),
+        };
 
+        // Every nested field is batched once across the *whole* `entities`
+        // batch — not once per parent — so the whole nested phase is a
+        // handful of calls (one per nested field), never a loop over
+        // `entities`. `OwnedSlice` doesn't already hold `&mut` borrows, so it
+        // gathers them into a temporary `Vec` first; `RefVec` already is
+        // that `Vec` and is reused directly.
         let nested_phase = if self.nested_fn_names.is_empty() {
             None
         } else {
-            let nested = nested.collect::<Vec<_>>();
-            Some(quote! {
-                for entity in entities.iter_mut() {
-                    #(#nested)*
+            let nested_calls = self.nested_fn_names.iter().map(|f| match mode {
+                BatchMode::OwnedSlice => quote! {
+                    self.#f(op, &mut __nested_refs).await?;
+                },
+                BatchMode::RefVec => quote! {
+                    self.#f(op, &mut entities).await?;
+                },
+            });
+            let setup = matches!(mode, BatchMode::OwnedSlice).then(|| {
+                quote! {
+                    let mut __nested_refs: Vec<&mut #entity> = entities.iter_mut().collect();
                 }
+            });
+            Some(quote! {
+                #setup
+                #(#nested_calls)*
             })
         };
 
@@ -150,7 +207,7 @@ impl ToTokens for UpdateAllFn<'_> {
                         .first()
                         .ok_or(sqlx::Error::RowNotFound)
                         .and_then(|row| row.try_get("recorded_at"))?;
-                    for entity in entities.iter_mut() {
+                    for entity in #iter_mut_ref {
                         let events = Self::extract_events(entity);
                         if events.any_new() {
                             events.mark_new_events_persisted_at(recorded_at);
@@ -163,7 +220,7 @@ impl ToTokens for UpdateAllFn<'_> {
                 None,
                 None,
                 quote! {
-                    let mut all_event_refs: Vec<_> = entities.iter_mut()
+                    let mut all_event_refs: Vec<_> = #iter_mut_ref
                         .filter_map(|entity| {
                             let events = Self::extract_events(entity);
                             if events.any_new() { Some(events) } else { None }
@@ -204,7 +261,11 @@ impl ToTokens for UpdateAllFn<'_> {
         let (instrument_attr, error_recording) = {
             let entity_name = entity.to_string();
             let repo_name = &self.repo_name_snake;
-            let span_name = format!("{}.update_all", repo_name);
+            let span_suffix = match mode {
+                BatchMode::OwnedSlice => "update_all",
+                BatchMode::RefVec => "update_all_mut",
+            };
+            let span_name = format!("{}.{}", repo_name, span_suffix);
             (
                 quote! {
                     #[tracing::instrument(name = #span_name, skip_all, fields(entity = #entity_name, count = entities.len(), error = tracing::field::Empty, exception.message = tracing::field::Empty, exception.type = tracing::field::Empty))]
@@ -229,22 +290,28 @@ impl ToTokens for UpdateAllFn<'_> {
             quote! {}
         };
 
-        tokens.append_all(quote! {
-            pub async fn update_all(
-                &self,
-                entities: &mut [#entity]
-            ) -> Result<usize, #modify_error> {
-                let mut op = self.begin_op().await?;
-                let res = self.update_all_in_op(&mut op, entities).await?;
-                op.commit().await?;
-                Ok(res)
+        let standalone_wrapper = matches!(mode, BatchMode::OwnedSlice).then(|| {
+            quote! {
+                pub async fn update_all(
+                    &self,
+                    entities: &mut [#entity]
+                ) -> Result<usize, #modify_error> {
+                    let mut op = self.begin_op().await?;
+                    let res = self.update_all_in_op(&mut op, entities).await?;
+                    op.commit().await?;
+                    Ok(res)
+                }
             }
+        });
+
+        quote! {
+            #standalone_wrapper
 
             #instrument_attr
-            pub async fn update_all_in_op<OP>(
+            pub async fn #fn_name<OP>(
                 &self,
                 op: &mut OP,
-                entities: &mut [#entity]
+                #entities_param
             ) -> Result<usize, #modify_error>
             where
                 OP: es_entity::AtomicOperation
@@ -262,7 +329,7 @@ impl ToTokens for UpdateAllFn<'_> {
                     #event_collection_vars
 
                     let mut has_new_events = false;
-                    for entity in entities.iter() {
+                    for entity in #iter_ref {
                         if !entity.events().any_new() {
                             continue;
                         }
@@ -279,7 +346,7 @@ impl ToTokens for UpdateAllFn<'_> {
                     #persist_tokens
 
                     let mut total_events = 0usize;
-                    for entity in entities.iter_mut() {
+                    for entity in #iter_mut_ref {
                         if let Some(&n_events) = n_persisted.get(&entity.id) {
                             if n_events > 0 {
                                 #post_persist_check
@@ -294,7 +361,7 @@ impl ToTokens for UpdateAllFn<'_> {
                 #error_recording
                 __result
             }
-        });
+        }
     }
 }
 
@@ -441,6 +508,100 @@ mod tests {
 
                 __result
             }
+
+            pub async fn update_all_mut_in_op<OP>(
+                &self,
+                op: &mut OP,
+                mut entities: Vec<&mut Entity>
+            ) -> Result<usize, EntityModifyError>
+            where
+                OP: es_entity::AtomicOperation
+            {
+                let __result: Result<usize, EntityModifyError> = async {
+                    use es_entity::prelude::sqlx::Row;
+
+                    if entities.is_empty() {
+                        return Ok(0);
+                    }
+
+                    let mut id_collection = Vec::new();
+                    let mut name_collection = Vec::new();
+
+                    let mut all_ids: Vec<&EntityId> = Vec::new();
+                    let mut all_sequences: Vec<i32> = Vec::new();
+                    let mut all_types = Vec::new();
+                    let mut all_serialized = Vec::new();
+                    let mut n_persisted: std::collections::HashMap<EntityId, usize> = std::collections::HashMap::new();
+
+                    let mut has_new_events = false;
+                    for entity in entities.iter().map(|e| &**e) {
+                        if !entity.events().any_new() {
+                            continue;
+                        }
+                        has_new_events = true;
+
+                        let id = &entity.id;
+                        let name = &entity.name;
+                        id_collection.push(id);
+                        name_collection.push(name);
+                        let offset = entity.events().len_persisted() + 1;
+                        let types = entity.events().new_event_types();
+                        let serialized = entity.events().serialize_new_events();
+
+                        let n_new = serialized.len();
+                        all_types.extend(types);
+                        all_serialized.extend(serialized);
+                        all_ids.extend(std::iter::repeat(&entity.id).take(n_new));
+                        all_sequences.extend((offset..).take(n_new).map(|i| i as i32));
+                        n_persisted.insert(entity.id.clone(), n_new);
+                    }
+
+                    if !has_new_events {
+                        return Ok(0);
+                    }
+
+                    let expected_events = all_ids.len();
+                    let rows = sqlx::query("WITH updated AS (UPDATE entities SET name = unnested.name FROM UNNEST($1, $2) AS unnested(id, name) WHERE entities.id = unnested.id RETURNING entities.id) INSERT INTO entity_events (id, recorded_at, sequence, event_type, event) SELECT unnested.id, COALESCE($3, NOW()), unnested.sequence, unnested.event_type, unnested.event FROM UNNEST($4, $5::INT[], $6::TEXT[], $7::JSONB[]) AS unnested(id, sequence, event_type, event) JOIN updated ON updated.id = unnested.id RETURNING recorded_at")
+                        .bind(id_collection)
+                        .bind(name_collection)
+                        .bind(op.maybe_now())
+                        .bind(&all_ids)
+                        .bind(&all_sequences)
+                        .bind(&all_types)
+                        .bind(&all_serialized)
+                        .fetch_all(op.as_executor())
+                        .await
+                        .map_err(Self::classify_write_error)?;
+
+                    if rows.len() != expected_events {
+                        return Err(EntityModifyError::ConcurrentModification);
+                    }
+
+                    let recorded_at = rows
+                        .first()
+                        .ok_or(sqlx::Error::RowNotFound)
+                        .and_then(|row| row.try_get("recorded_at"))?;
+                    for entity in entities.iter_mut().map(|e| &mut **e) {
+                        let events = Self::extract_events(entity);
+                        if events.any_new() {
+                            events.mark_new_events_persisted_at(recorded_at);
+                        }
+                    }
+
+                    let mut total_events = 0usize;
+                    for entity in entities.iter_mut().map(|e| &mut **e) {
+                        if let Some(&n_events) = n_persisted.get(&entity.id) {
+                            if n_events > 0 {
+                                total_events += n_events;
+                            }
+                        }
+                    }
+
+                    Ok(total_events)
+                }.await;
+
+                __result
+            }
         };
 
         assert_eq!(tokens.to_string(), expected.to_string());
@@ -526,6 +687,60 @@ mod tests {
 
                     let mut total_events = 0usize;
                     for entity in entities.iter_mut() {
+                        if let Some(&n_events) = n_persisted.get(&entity.id) {
+                            if n_events > 0 {
+                                total_events += n_events;
+                            }
+                        }
+                    }
+
+                    Ok(total_events)
+                }.await;
+
+                __result
+            }
+
+            pub async fn update_all_mut_in_op<OP>(
+                &self,
+                op: &mut OP,
+                mut entities: Vec<&mut Entity>
+            ) -> Result<usize, EntityModifyError>
+            where
+                OP: es_entity::AtomicOperation
+            {
+                let __result: Result<usize, EntityModifyError> = async {
+                    use es_entity::prelude::sqlx::Row;
+
+                    if entities.is_empty() {
+                        return Ok(0);
+                    }
+
+                    let mut has_new_events = false;
+                    for entity in entities.iter().map(|e| &**e) {
+                        if !entity.events().any_new() {
+                            continue;
+                        }
+                        has_new_events = true;
+                    }
+
+                    if !has_new_events {
+                        return Ok(0);
+                    }
+
+                    let mut all_event_refs: Vec<_> = entities.iter_mut().map(|e| &mut **e)
+                        .filter_map(|entity| {
+                            let events = Self::extract_events(entity);
+                            if events.any_new() { Some(events) } else { None }
+                        })
+                        .collect();
+                    let n_persisted = Self::extract_concurrent_modification(
+                        self.persist_events_batch(op, &mut all_event_refs).await,
+                        EntityModifyError::ConcurrentModification,
+                    )?;
+                    drop(all_event_refs);
+
+                    let mut total_events = 0usize;
+                    for entity in entities.iter_mut().map(|e| &mut **e) {
                         if let Some(&n_events) = n_persisted.get(&entity.id) {
                             if n_events > 0 {
                                 total_events += n_events;

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -53,7 +53,7 @@ impl ToTokens for UpdateFn<'_> {
 
         let nested = self.nested_fn_names.iter().map(|f| {
             quote! {
-                self.#f(op, entity).await?;
+                self.#f(op, &mut [&mut *entity]).await?;
             }
         });
 

--- a/migrations/20260822000000_grandchildren_batch_test.sql
+++ b/migrations/20260822000000_grandchildren_batch_test.sql
@@ -1,0 +1,52 @@
+-- Three-level nesting (parent -> child -> grandchild), used to prove nested
+-- batching composes to arbitrary depth (see tests/nested_grandchildren.rs).
+
+CREATE TABLE gc_parents (
+  id UUID PRIMARY KEY,
+  deleted BOOL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE gc_parent_events (
+  id UUID NOT NULL REFERENCES gc_parents(id),
+  sequence INT NOT NULL,
+  event_type VARCHAR NOT NULL,
+  event JSONB NOT NULL,
+  context JSONB DEFAULT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(id, sequence)
+);
+
+CREATE TABLE gc_children (
+  id UUID PRIMARY KEY,
+  parent_id UUID NOT NULL REFERENCES gc_parents(id),
+  deleted BOOL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE gc_child_events (
+  id UUID NOT NULL REFERENCES gc_children(id),
+  sequence INT NOT NULL,
+  event_type VARCHAR NOT NULL,
+  event JSONB NOT NULL,
+  context JSONB DEFAULT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(id, sequence)
+);
+
+CREATE TABLE gc_grandchildren (
+  id UUID PRIMARY KEY,
+  child_id UUID NOT NULL REFERENCES gc_children(id),
+  deleted BOOL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE gc_grandchild_events (
+  id UUID NOT NULL REFERENCES gc_grandchildren(id),
+  sequence INT NOT NULL,
+  event_type VARCHAR NOT NULL,
+  event JSONB NOT NULL,
+  context JSONB DEFAULT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(id, sequence)
+);

--- a/tests/nested_batch_statement_count.rs
+++ b/tests/nested_batch_statement_count.rs
@@ -1,0 +1,212 @@
+#![cfg(feature = "instrument")]
+//! Proves that `update_all_in_op`'s nested-children phase vectorizes across
+//! the *whole* parent batch instead of degrading to one child-repo call per
+//! parent.
+//!
+//! Every generated bulk repo fn (`create_all_in_op`, `update_all_mut_in_op`)
+//! issues exactly one SQL statement for its whole input batch — that's the
+//! entire point of the `UNNEST`-based codegen these functions build (see
+//! `es-entity-macros/src/repo/{create_all_fn,update_all_fn}.rs`). So counting
+//! how many times a child repo's bulk fn is *called* while updating a batch
+//! of parents is an exact proxy for how many SQL statements that phase
+//! issues: one span per call, one statement per span. A `tracing_subscriber`
+//! `Layer` recording `on_new_span` calls gives us that count directly, per
+//! the generated `#[tracing::instrument]` span on each bulk fn (gated behind
+//! this crate's own `instrument` feature, hence `#![cfg(feature =
+//! "instrument")]` on this whole file).
+
+mod entities;
+mod helpers;
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use entities::order::*;
+use es_entity::*;
+use helpers::init_pool;
+use sqlx::PgPool;
+use tracing_subscriber::layer::SubscriberExt;
+
+#[derive(EsRepo, Debug)]
+#[es_repo(entity = "Order", delete = "soft")]
+pub struct Orders {
+    pool: PgPool,
+
+    #[es_repo(nested)]
+    items: OrderItems,
+}
+
+impl Orders {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool: pool.clone(),
+            items: OrderItems::new(pool),
+        }
+    }
+}
+
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "OrderItem",
+    delete = "soft",
+    columns(order_id(ty = "OrderId", update(persist = false), parent))
+)]
+pub struct OrderItems {
+    pool: PgPool,
+}
+
+impl OrderItems {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[derive(Clone, Default)]
+struct SpanCounts(Arc<Mutex<HashMap<String, usize>>>);
+
+impl SpanCounts {
+    fn count(&self, name: &str) -> usize {
+        self.0.lock().unwrap().get(name).copied().unwrap_or(0)
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for SpanCounts {
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        _id: &tracing::span::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        *self
+            .0
+            .lock()
+            .unwrap()
+            .entry(attrs.metadata().name().to_string())
+            .or_insert(0) += 1;
+    }
+}
+
+async fn create_order_with_items(
+    orders: &Orders,
+    n_items: usize,
+) -> anyhow::Result<(OrderId, Vec<OrderItemId>)> {
+    let order_id = OrderId::new();
+    let mut order = orders
+        .create(NewOrderBuilder::default().id(order_id).build().unwrap())
+        .await?;
+
+    let mut item_ids = Vec::new();
+    for i in 0..n_items {
+        let item_id = OrderItemId::new();
+        item_ids.push(item_id);
+        order.add_item(
+            NewOrderItemBuilder::default()
+                .id(item_id)
+                .order_id(order_id)
+                .product_name(format!("item-{i}"))
+                .quantity(1)
+                .price(9.99)
+                .build()
+                .unwrap(),
+        );
+    }
+    orders.update(&mut order).await?;
+
+    Ok((order_id, item_ids))
+}
+
+/// N parents, each with M already-persisted children being updated and one
+/// brand-new child being added in the same `update_all_in_op` call: the
+/// persisted-child updates should collapse into a single
+/// `order_items.update_all_mut` call, and the new-child creates into a
+/// single `order_items.create_all` call — not one of each per parent.
+#[tokio::test]
+async fn update_all_batches_nested_children_across_parents() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    let orders = Orders::new(pool);
+
+    const N_PARENTS: usize = 5;
+    const M_PERSISTED_ITEMS: usize = 2;
+
+    let mut order_ids = Vec::new();
+    for _ in 0..N_PARENTS {
+        let (order_id, _items) = create_order_with_items(&orders, M_PERSISTED_ITEMS).await?;
+        order_ids.push(order_id);
+    }
+
+    // Load every order fresh (with its persisted items populated), mutate one
+    // persisted item and add one brand-new item per order, then flush every
+    // parent through a single `update_all_in_op` call.
+    let mut loaded = orders.find_all::<Order>(&order_ids).await?;
+    let mut batch: Vec<Order> = order_ids
+        .iter()
+        .map(|id| loaded.remove(id).expect("order was loaded"))
+        .collect();
+
+    for order in batch.iter_mut() {
+        order
+            .update_item_quantity("item-0", 42)
+            .expect("item-0 exists");
+        order.add_item(
+            NewOrderItemBuilder::default()
+                .id(OrderItemId::new())
+                .order_id(order.id)
+                .product_name("new-item")
+                .quantity(1)
+                .price(1.23)
+                .build()
+                .unwrap(),
+        );
+    }
+
+    let counts = SpanCounts::default();
+    let subscriber = tracing_subscriber::registry().with(counts.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // `Order` itself never gains new events here (only its nested `items`
+    // do), so `n_events` — which counts *parent*-level events — is
+    // legitimately 0; the nested phase runs unconditionally regardless, and
+    // the span counts plus the reload below are what confirm it actually
+    // persisted.
+    orders.update_all(&mut batch).await?;
+
+    assert_eq!(
+        counts.count("order_items.update_all_mut"),
+        1,
+        "persisted-child updates across all {N_PARENTS} parents should collapse into one \
+         order_items.update_all_mut call, not one per parent"
+    );
+    assert_eq!(
+        counts.count("order_items.create_all"),
+        1,
+        "new-child creates across all {N_PARENTS} parents should collapse into one \
+         order_items.create_all call, not one per parent"
+    );
+    // Sanity: the per-child path this replaces would have been visible as
+    // `order_items.update` (singular), once per persisted child touched.
+    assert_eq!(
+        counts.count("order_items.update"),
+        0,
+        "the batched path should never fall back to the per-child update_in_op"
+    );
+
+    // Confirm the writes actually landed, distributed back to the right
+    // parents (not just that the statement count looks right).
+    let mut reloaded = orders.find_all::<Order>(&order_ids).await?;
+    for order_id in &order_ids {
+        let order = reloaded.remove(order_id).expect("order reloaded");
+        assert_eq!(order.n_items(), M_PERSISTED_ITEMS + 1, "order {order_id}");
+        let item0 = order
+            .find_item_with_name("item-0")
+            .expect("item-0 still present");
+        assert_eq!(item0.quantity, 42, "order {order_id}'s item-0 was updated");
+        assert!(
+            order.find_item_with_name("new-item").is_some(),
+            "order {order_id}'s new item was created"
+        );
+    }
+
+    Ok(())
+}

--- a/tests/nested_grandchildren.rs
+++ b/tests/nested_grandchildren.rs
@@ -1,0 +1,454 @@
+#![cfg(feature = "instrument")]
+//! Proves nested batching composes to arbitrary depth: a three-level
+//! parent -> child -> grandchild hierarchy, where the grandchild phase
+//! (gathered *across every child of every parent* in one
+//! `update_all_in_op` call on the top-level parent repo) collapses to a
+//! single statement per grandchild repo fn, exactly like the one-level case
+//! in `nested_batch_statement_count.rs`.
+//!
+//! The mechanism has no depth-specific code: `create_nested_*_in_op` /
+//! `update_nested_*_in_op` always take `&mut [&mut P]` and the middle
+//! (`GcChild`) repo's own `update_all_mut_in_op` runs its *own* nested phase
+//! the same way any other bulk fn does — so this is exercising the exact
+//! same generated code path as the one-level test, just nested one level
+//! deeper.
+
+mod helpers;
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use derive_builder::Builder;
+use es_entity::*;
+use helpers::init_pool;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use tracing_subscriber::layer::SubscriberExt;
+
+es_entity::entity_id! { GcParentId, GcChildId, GcGrandchildId }
+
+// ─── Grandchild ─────────────────────────────────────────────────────────
+#[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "GcGrandchildId")]
+pub enum GcGrandchildEvent {
+    Initialized {
+        id: GcGrandchildId,
+        child_id: GcChildId,
+        note: String,
+    },
+    NoteUpdated {
+        note: String,
+    },
+}
+
+#[derive(EsEntity, Builder)]
+#[builder(pattern = "owned", build_fn(error = "EntityHydrationError"))]
+pub struct GcGrandchild {
+    pub id: GcGrandchildId,
+    pub child_id: GcChildId,
+    pub note: String,
+    events: EntityEvents<GcGrandchildEvent>,
+}
+
+impl GcGrandchild {
+    pub fn update_note(&mut self, note: impl Into<String>) {
+        let note = note.into();
+        self.note = note.clone();
+        self.events.push(GcGrandchildEvent::NoteUpdated { note });
+    }
+}
+
+impl TryFromEvents<GcGrandchildEvent> for GcGrandchild {
+    fn try_from_events(
+        events: EntityEvents<GcGrandchildEvent>,
+    ) -> Result<Self, EntityHydrationError> {
+        let mut builder = GcGrandchildBuilder::default();
+        for event in events.iter_all() {
+            match event {
+                GcGrandchildEvent::Initialized { id, child_id, note } => {
+                    builder = builder.id(*id).child_id(*child_id).note(note.clone());
+                }
+                GcGrandchildEvent::NoteUpdated { note } => {
+                    builder = builder.note(note.clone());
+                }
+            }
+        }
+        builder.events(events).build()
+    }
+}
+
+#[derive(Debug, Clone, Builder)]
+pub struct NewGcGrandchild {
+    pub id: GcGrandchildId,
+    pub child_id: GcChildId,
+    #[builder(setter(into))]
+    pub note: String,
+}
+
+impl NewGcGrandchild {
+    pub fn builder() -> NewGcGrandchildBuilder {
+        NewGcGrandchildBuilder::default()
+    }
+}
+
+impl IntoEvents<GcGrandchildEvent> for NewGcGrandchild {
+    fn into_events(self) -> EntityEvents<GcGrandchildEvent> {
+        EntityEvents::init(
+            self.id,
+            vec![GcGrandchildEvent::Initialized {
+                id: self.id,
+                child_id: self.child_id,
+                note: self.note,
+            }],
+        )
+    }
+}
+
+// ─── Child ──────────────────────────────────────────────────────────────
+#[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "GcChildId")]
+pub enum GcChildEvent {
+    Initialized {
+        id: GcChildId,
+        parent_id: GcParentId,
+    },
+}
+
+#[derive(EsEntity, Builder)]
+#[builder(pattern = "owned", build_fn(error = "EntityHydrationError"))]
+pub struct GcChild {
+    pub id: GcChildId,
+    pub parent_id: GcParentId,
+    events: EntityEvents<GcChildEvent>,
+
+    #[es_entity(nested)]
+    #[builder(default)]
+    grandchildren: Nested<GcGrandchild>,
+}
+
+impl GcChild {
+    pub fn add_grandchild(&mut self, new: NewGcGrandchild) {
+        self.grandchildren.add_new(new);
+    }
+
+    pub fn update_grandchild_note(&mut self, note: impl Into<String>) {
+        let note = note.into();
+        let child = self
+            .grandchildren
+            .iter_persisted_mut()
+            .next()
+            .expect("child has a persisted grandchild");
+        child.update_note(note);
+    }
+
+    pub fn n_grandchildren(&self) -> usize {
+        self.grandchildren.len_persisted()
+    }
+}
+
+impl TryFromEvents<GcChildEvent> for GcChild {
+    fn try_from_events(events: EntityEvents<GcChildEvent>) -> Result<Self, EntityHydrationError> {
+        let mut builder = GcChildBuilder::default();
+        for event in events.iter_all() {
+            match event {
+                GcChildEvent::Initialized { id, parent_id } => {
+                    builder = builder.id(*id).parent_id(*parent_id);
+                }
+            }
+        }
+        builder.events(events).build()
+    }
+}
+
+#[derive(Debug, Clone, Builder)]
+pub struct NewGcChild {
+    pub id: GcChildId,
+    pub parent_id: GcParentId,
+}
+
+impl IntoEvents<GcChildEvent> for NewGcChild {
+    fn into_events(self) -> EntityEvents<GcChildEvent> {
+        EntityEvents::init(
+            self.id,
+            vec![GcChildEvent::Initialized {
+                id: self.id,
+                parent_id: self.parent_id,
+            }],
+        )
+    }
+}
+
+// ─── Parent ─────────────────────────────────────────────────────────────
+#[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "GcParentId")]
+pub enum GcParentEvent {
+    Initialized { id: GcParentId },
+}
+
+#[derive(EsEntity, Builder)]
+#[builder(pattern = "owned", build_fn(error = "EntityHydrationError"))]
+pub struct GcParent {
+    pub id: GcParentId,
+    events: EntityEvents<GcParentEvent>,
+
+    #[es_entity(nested)]
+    #[builder(default)]
+    children: Nested<GcChild>,
+}
+
+impl GcParent {
+    pub fn add_child(&mut self, new: NewGcChild) {
+        self.children.add_new(new);
+    }
+
+    pub fn persisted_children_mut(&mut self) -> impl Iterator<Item = &mut GcChild> {
+        self.children.iter_persisted_mut()
+    }
+}
+
+impl TryFromEvents<GcParentEvent> for GcParent {
+    fn try_from_events(events: EntityEvents<GcParentEvent>) -> Result<Self, EntityHydrationError> {
+        let mut builder = GcParentBuilder::default();
+        for event in events.iter_all() {
+            match event {
+                GcParentEvent::Initialized { id } => {
+                    builder = builder.id(*id);
+                }
+            }
+        }
+        builder.events(events).build()
+    }
+}
+
+#[derive(Debug, Clone, Builder)]
+pub struct NewGcParent {
+    pub id: GcParentId,
+}
+
+impl IntoEvents<GcParentEvent> for NewGcParent {
+    fn into_events(self) -> EntityEvents<GcParentEvent> {
+        EntityEvents::init(self.id, vec![GcParentEvent::Initialized { id: self.id }])
+    }
+}
+
+// ─── Repos ──────────────────────────────────────────────────────────────
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "GcGrandchild",
+    tbl = "gc_grandchildren",
+    events_tbl = "gc_grandchild_events",
+    delete = "soft",
+    columns(child_id(ty = "GcChildId", update(persist = false), parent))
+)]
+pub struct GcGrandchildren {
+    pool: PgPool,
+}
+
+impl GcGrandchildren {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "GcChild",
+    tbl = "gc_children",
+    events_tbl = "gc_child_events",
+    delete = "soft",
+    columns(parent_id(ty = "GcParentId", update(persist = false), parent))
+)]
+pub struct GcChildren {
+    pool: PgPool,
+
+    #[es_repo(nested)]
+    grandchildren: GcGrandchildren,
+}
+
+impl GcChildren {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool: pool.clone(),
+            grandchildren: GcGrandchildren::new(pool),
+        }
+    }
+}
+
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "GcParent",
+    tbl = "gc_parents",
+    events_tbl = "gc_parent_events",
+    delete = "soft"
+)]
+pub struct GcParents {
+    pool: PgPool,
+
+    #[es_repo(nested)]
+    children: GcChildren,
+}
+
+impl GcParents {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool: pool.clone(),
+            children: GcChildren::new(pool),
+        }
+    }
+}
+
+// ─── Span counting ──────────────────────────────────────────────────────
+#[derive(Clone, Default)]
+struct SpanCounts(Arc<Mutex<HashMap<String, usize>>>);
+
+impl SpanCounts {
+    fn count(&self, name: &str) -> usize {
+        self.0.lock().unwrap().get(name).copied().unwrap_or(0)
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for SpanCounts {
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        _id: &tracing::span::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        *self
+            .0
+            .lock()
+            .unwrap()
+            .entry(attrs.metadata().name().to_string())
+            .or_insert(0) += 1;
+    }
+}
+
+/// 2 parents x 2 children x 1 persisted grandchild each: mutating every
+/// grandchild's note and adding a new grandchild under every child, then
+/// flushing the whole tree through a single top-level `update_all_in_op`
+/// call, should collapse the grandchild phase to one `update_all_mut` call
+/// and one `create_all` call on the grandchild repo — not one per child
+/// (there are 4 children) and not one per parent (there are 2).
+#[tokio::test]
+async fn grandchild_batching_composes_across_the_whole_tree() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    let parents_repo = GcParents::new(pool.clone());
+    let children_repo = GcChildren::new(pool);
+
+    const N_PARENTS: usize = 2;
+    const N_CHILDREN_PER_PARENT: usize = 2;
+
+    let mut parent_ids = Vec::new();
+    for _ in 0..N_PARENTS {
+        let parent_id = GcParentId::new();
+        let mut parent = parents_repo
+            .create(NewGcParentBuilder::default().id(parent_id).build()?)
+            .await?;
+        for _ in 0..N_CHILDREN_PER_PARENT {
+            let child_id = GcChildId::new();
+            parent.add_child(
+                NewGcChildBuilder::default()
+                    .id(child_id)
+                    .parent_id(parent_id)
+                    .build()?,
+            );
+        }
+        parents_repo.update(&mut parent).await?;
+        parent_ids.push(parent_id);
+    }
+
+    // Give every persisted child one persisted grandchild, via the child
+    // repo directly (children were just created above).
+    let mut all_children = children_repo
+        .find_all::<GcChild>(
+            &sqlx::query_scalar!(
+                "SELECT id AS \"id: GcChildId\" FROM gc_children WHERE parent_id = ANY($1) ORDER BY id",
+                &parent_ids as &[GcParentId],
+            )
+            .fetch_all(&children_repo.pool().clone())
+            .await?,
+        )
+        .await?;
+    let mut children_vec: Vec<GcChild> = all_children.drain().map(|(_, c)| c).collect();
+    assert_eq!(children_vec.len(), N_PARENTS * N_CHILDREN_PER_PARENT);
+    for child in children_vec.iter_mut() {
+        child.add_grandchild(
+            NewGcGrandchild::builder()
+                .id(GcGrandchildId::new())
+                .child_id(child.id)
+                .note("initial")
+                .build()?,
+        );
+    }
+    children_repo.update_all(&mut children_vec).await?;
+
+    // Reload the whole tree, mutate every grandchild's note and add a new
+    // grandchild under every child, then flush it all through one
+    // top-level `update_all_in_op` call.
+    let mut loaded = parents_repo.find_all::<GcParent>(&parent_ids).await?;
+    let mut batch: Vec<GcParent> = parent_ids
+        .iter()
+        .map(|id| loaded.remove(id).expect("parent was loaded"))
+        .collect();
+
+    for parent in batch.iter_mut() {
+        for child in parent.persisted_children_mut() {
+            assert_eq!(
+                child.n_grandchildren(),
+                1,
+                "child should have its seeded grandchild"
+            );
+            child.update_grandchild_note("updated");
+            child.add_grandchild(
+                NewGcGrandchild::builder()
+                    .id(GcGrandchildId::new())
+                    .child_id(child.id)
+                    .note("new")
+                    .build()?,
+            );
+        }
+    }
+
+    let counts = SpanCounts::default();
+    let subscriber = tracing_subscriber::registry().with(counts.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    parents_repo.update_all(&mut batch).await?;
+
+    assert_eq!(
+        counts.count("gc_grandchildren.update_all_mut"),
+        1,
+        "grandchild note updates across every child of every parent should collapse into one \
+         gc_grandchildren.update_all_mut call"
+    );
+    assert_eq!(
+        counts.count("gc_grandchildren.create_all"),
+        1,
+        "new grandchildren across every child of every parent should collapse into one \
+         gc_grandchildren.create_all call"
+    );
+    // The child level itself batches too: one update_all_mut for the
+    // (unchanged, but visited) persisted children, none of the old
+    // per-entity fallbacks.
+    assert_eq!(counts.count("gc_children.update"), 0);
+    assert_eq!(counts.count("gc_grandchildren.update"), 0);
+
+    // Functional correctness, not just statement counts.
+    let reloaded = parents_repo.find_all::<GcParent>(&parent_ids).await?;
+    for (_, mut parent) in reloaded {
+        for child in parent.persisted_children_mut() {
+            assert_eq!(
+                child.n_grandchildren(),
+                2,
+                "one updated + one new grandchild"
+            );
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Premise-check

Confirmed true on current `main` before making any change:

- `update_all_fn.rs` nested phase was a per-parent loop calling
  `update_nested_<field>_in_op(op, entity)` once per parent.
- `nested.rs`'s `update_nested_<field>_in_op` was itself per-child:
  `for entity in entity.iter_persisted_children_mut() { self.repo.update_in_op(op, entity).await?; }`
  — fully unbatched, one statement per persisted child per parent.
- `create_nested_<field>_in_op` did call `create_all_in_op` (one `UNNEST`
  insert), but scoped to a single parent's new children — so N parents each
  produced their own insert instead of one shared insert.

**`create_all` finding (was unchecked by the prior analysis):** same shape.
`create_all_fn.rs`'s hydration loop called `self.create_nested_<field>_in_op(op, &mut entity)`
once per newly-hydrated parent, inside the loop — so `create_all`'s nested
phase was exactly as unbatched as `update_all`'s, just less visible because
"create N parents with children" is a rarer call pattern than "update N
parents, some of which touch existing children." Not already vectorized;
now fixed the same way as `update_all`.

## The fix

- `create_nested_<field>_in_op` / `update_nested_<field>_in_op` now take
  `entities: &mut [&mut P]` — a *batch* of parents — instead of a single
  `entity: &mut P`. New children across the whole batch are drained into one
  `Vec<New>` and flushed with one `create_all_in_op` call; the returned
  `Vec<Child>` is redistributed back to each parent by count (order is
  preserved end-to-end, so this is just index-math, not identity matching).
  Persisted children across the whole batch are gathered into one
  `Vec<&mut Child>` via `entities.iter_mut().flat_map(|e| e.iter_persisted_children_mut())`
  — the standard "flatten nested mutable borrows" pattern — and flushed with
  one call to a new `update_all_mut_in_op`.
- **New generated method: `update_all_mut_in_op(op, entities: Vec<&mut Entity>)`**,
  alongside the existing `update_all_in_op(op, entities: &mut [Entity])`.
  This is the actual answer to the borrow-checker hazard: gathered children
  live scattered across many parents' own `HashMap`s, so they can *never*
  be collected into one contiguous `&mut [Entity]` — only into a `Vec<&mut Entity>`
  of disjoint borrows. Both functions share the exact same SQL-building
  code; only how `entities` is iterated (and the outer signature) differs
  — a `Vec<&mut Entity>::iter_mut()` yields `&mut &mut Entity`, one level of
  indirection too many for the generic `Self::extract_events(entity)` call,
  so the `RefVec` mode's iteration is `.iter_mut().map(|e| &mut **e)` to
  reborrow back down to a single level. Everything else in the function
  body is textually identical between the two modes.
- `update_all_in_op`'s own nested phase (top-level, not just the internal
  recursion) is vectorized the same way — a direct caller batching parents
  with nested children gets the fix too, not just the internal recursive
  path.

## Hazards

1. **Borrow checker.** Real, but not in the way I originally expected: gathering
   `&mut` children across parents via `flat_map` over `iter_mut()` is the
   standard sound pattern and just works. The actual forcing function was the
   *outer* signature — `update_all_in_op` takes ownership of a contiguous
   `&mut [Entity]`, which a `Vec<&mut Entity>` of scattered children can never
   be coerced into. That's why `update_all_mut_in_op` exists as a distinct
   generated method (see above) rather than reusing `update_all_in_op`
   unchanged. `create_all_in_op` needed no such split — it already takes
   owned `Vec<New>` in and returns owned `Vec<Entity>` out, no lifetime issue.

2. **Event/statement ordering — flagging, not deciding.** Per-entity event
   sequence numbers are unaffected (sequences are computed from each event
   stream's own `len_persisted()`, independent of DB write order or batch
   membership). What *does* change: previously each parent's children were
   written by their own statement, in parent order, each getting its own
   `NOW()`. Now every parent's children of a given type share **one**
   statement and **one** `recorded_at` timestamp, and cross-parent
   interleaving in the events table is no longer statement-ordered by
   parent. If any downstream consumer of the event log — I understand lana's
   data-warehouse relay feeding FFIEC-051 reporting is one — depends on
   cross-entity insertion order or per-parent `recorded_at` granularity
   rather than per-entity sequence, that assumption is affected. This is a
   product/compliance call, not an engineering one; flagging per the brief.

3. **Error attribution — no new degradation, but changed scope.** es-entity's
   typed `ConstraintViolation { column, value, inner }` already carries the
   offending value in the *existing* `create_all_in_op`/`update_all_in_op`
   bulk paths (a single duplicate/violating id in a 500-row batch still
   surfaces its own id) — that guarantee is unchanged by this PR, and now
   extends to nested children too. `ConcurrentModification` is and always
   was a bare unit variant with no payload, so it never identified *which*
   entity lost a race — vectorizing doesn't remove information that wasn't
   there. What genuinely changes: under the `instrument` feature, each
   per-child `update_in_op` used to get its own span carrying that child's
   id — that per-id tracing breadcrumb is gone for the batched phase,
   replaced by one span with a `count` field, exactly mirroring what
   `update_all_in_op`/`create_all_in_op` already accepted for the top-level
   batch. This is the same trade-off the codebase already made, not a new
   category of loss.

4. **Recursion / grandchildren — composes to arbitrary depth, verified.**
   The nested-fn signature is uniformly `entities: &mut [&mut P]` everywhere
   (both `OwnedSlice`-mode top-level callers and `RefVec`-mode
   `update_all_mut_in_op` build this the same way — a `&mut [P]` collects
   into a temporary `Vec<&mut P>` first; a `Vec<&mut P>` is reborrowed
   directly), so a child repo's own `update_all_mut_in_op` runs its own
   nested phase for grandchildren through the exact same code path, no
   depth-specific logic anywhere. Verified end-to-end with a real 3-level
   parent → child → grandchild integration test
   (`tests/nested_grandchildren.rs`): mutating every grandchild across every
   child of every parent and flushing through one top-level `update_all_in_op`
   collapses to one `update_all_mut` + one `create_all` call on the
   *grandchild* repo, not one per child (4) or per parent (2).

5. **Idempotency / "no new events" semantics — preserved exactly.** The
   batched function reuses the identical per-entity `any_new()` filtering
   logic; entities with no new events are simply excluded from the query
   arrays, same as the per-child path's early `if !any_new() { return Ok(0) }`.
   No behavior change, just applied across a union of children from
   multiple parents instead of one parent at a time.

6. **Consumers (cala, job, obix, lana).** No public signature changes to
   existing methods — `create_all`/`create_all_in_op`/`update_all`/`update_all_in_op`
   keep their exact signatures and return types. Purely additive:
   `update_all_mut_in_op` is a new public method. The only signature change
   is to `create_nested_<field>_in_op`/`update_nested_<field>_in_op`, which
   are private (non-`pub`) generated helpers — not part of the public API
   surface, so nothing outside the generated `impl` block can reference them
   by name. Net: safe as a `feat`, not a breaking change.

## Verification

Statement-count test written first and confirmed red against the old
per-parent code before going green against the fix (`git stash` of the
macro changes + rerun, for both new tests):

- `tests/nested_batch_statement_count.rs` — 5 parents, each with 2 persisted
  children (1 touched) + 1 new child, flushed through one `update_all` call.
  - **Before:** `order_items.update` (per-child) x 10 calls (5 of them
    issuing real SQL, 5 no-ops) + `order_items.create_all` x 5 calls = **10
    real SQL statements**, scaling as O(N) parents.
  - **After:** `order_items.update_all_mut` x 1 + `order_items.create_all`
    x 1 = **2 SQL statements**, O(1) regardless of N.
- `tests/nested_grandchildren.rs` — 2 parents x 2 children x 1 grandchild
  each, mutating every grandchild's note and adding a new one per child,
  flushed through one top-level `update_all_in_op` call.
  - **Before:** fails (`update_all_mut` never called on the grandchild repo
    — old code has no such function).
  - **After:** grandchild repo sees exactly 1 `update_all_mut` + 1
    `create_all` call across the whole 2x2x1 tree.

Statement counts are measured by counting invocations of the generated bulk
repo functions via a `tracing_subscriber` span-counting `Layer` (gated
behind this crate's own `instrument` feature) — each such function issues
exactly one SQL statement by construction of the `UNNEST`-based codegen, so
call count is an exact proxy for statement count. Both new tests are
`#![cfg(feature = "instrument")]`; run them with
`cargo nextest run --features instrument --test nested_batch_statement_count --test nested_grandchildren`.
Note: `cargo nextest run --workspace --features instrument` currently fails
for unrelated pre-existing reasons — several `es-entity-macros` unit tests
hardcode expected output assuming the `instrument` feature is *off*
(confirmed on unmodified `main`) — so run the new tests scoped to their
`--test` targets as above, not via `--workspace`.

Full workspace verification (matching CI's `nix run .#nextest` exactly —
`cargo nextest run --workspace`, default features): **373/373 passed**,
including all existing nested/forgettable/update_all/create_all coverage.
`cargo build --workspace --all-targets` clean with default features, with
`--features instrument`, and with `--features instrument,tracing-context,event-context,graphql,json-schema`.
Targeted `cargo clippy -D warnings` clean on `es-entity-macros` and on every
touched/new test target. `cargo fmt` applied.

(Pre-existing, unrelated: `cargo clippy --all-features` fails on
`tests/index_catalog_verification.rs` and `tests/hooks.rs` — confirmed via
`git log` that I haven't touched either file; a clippy-version drift issue,
not something this PR should fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches generated create/update persistence for nested entities: children now share one SQL statement and one `recorded_at` per type across the parent batch, which can change event-log interleaving versus the old per-parent writes. Public `create_all`/`update_all` signatures are unchanged.
> 
> **Overview**
> Nested persistence on `create_all` / `update_all` no longer loops per parent. Generated `create_nested_*` / `update_nested_*` helpers now take `&mut [&mut P]`, drain every parent’s new children into one `create_all_in_op`, and gather persisted children into one new `update_all_mut_in_op` (`Vec<&mut Entity>` — needed because nested children are not a contiguous slice). Hydrated children are redistributed by count.
> 
> Single-entity `create` / `update` wrap the entity as a one-element batch. Nested batching composes recursively (grandchildren use the same path). Existing public APIs are unchanged; `update_all_mut_in_op` is additive.
> 
> **Note:** children of a given type now share one statement and one `recorded_at` across parents, so cross-entity event-table order is no longer parent-statement-ordered.
> 
> Tests (`nested_batch_statement_count`, `nested_grandchildren`) assert one child `update_all_mut` + one `create_all` for a multi-parent tree, including three-level nesting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f198a63d7709b4678f9f9e64adc2ec5e7e20a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->