### PR TITLE
feat(macros): multi-column repo scopes

### DIFF
--- a/book/src/repo-list-for-filters.md
+++ b/book/src/repo-list-for-filters.md
@@ -78,7 +78,7 @@ SELECT id FROM user_documents
 
 A multi-filter combination gets a specialized sargable query only when a matching **composite index physically exists** — because sargable and catch-all SQL differ only when there is an index to ride. The derive discovers your indexes by parsing the committed migration `.sql` files at compile time (the migrations directory is the source of truth, exactly as `sqlx::migrate!` reads it), so there is nothing to declare and no per-repo flag: a combination filtering on the (order-insensitive) columns `C` and paginating by sort column `S` is specialized iff some index's leading key columns are a permutation of `C` immediately followed by `S`. Everything else uses the catch-all COALESCE query above (correct, just not sargable). Adding a `CREATE INDEX` migration is the single, PR-visible way to expand the specialized surface — build cost tracks your real indexes, never `2^N`.
 
-For scoped repos the scope column is auto-prefixed: the scoped (`Only`) arm looks for `(scope_col, C…, S)` and the unscoped (`All`) arm for `(C…, S)`, matched independently against the catalog.
+For scoped repos each scope column is auto-prefixed: each column's dispatch arm looks for `(scope_col, C…, S)` and the unscoped (`All`) arm for `(C…, S)`, matched independently against the catalog per dimension — a repo may have partner-led composite indexes but no customer-led ones, in which case the partner arm specializes while the customer arm falls back.
 
 Single-filter (`list_for_{col}_by_{sort}`) and no-filter (`list_by_{sort}`) queries, and all cursor pagination, are always emitted as a single unified query regardless of the catalog — sargable when the matching `(…, id)` index exists, harmlessly equivalent when it does not.
 

--- a/book/src/scoped-repositories.md
+++ b/book/src/scoped-repositories.md
@@ -43,6 +43,41 @@ There is deliberately **no** `From<Option<PartnerId>>`: mapping `None` to
 `All` would turn a stray `None` into silent all-scope access. All-scope reads
 must be written explicitly — `CustomerScope::All` is greppable and auditable.
 
+### Overriding the variant name
+
+The default variant name is UpperCamel of the column name. When that reads
+awkwardly, or you'd rather the enum spell out the principal kind than the
+column, override it with `scope(variant = "...")`:
+
+```rust,ignore
+#[derive(EsRepo)]
+#[es_repo(
+    entity = "CreditFacility",
+    columns(
+        partner_id(ty = "PartnerId", scope(variant = "Partner")),
+        customer_id(ty = "CustomerId", scope),
+        status(ty = "String"),
+    )
+)]
+pub struct CreditFacilities {
+    pool: PgPool,
+}
+
+// generates:
+pub enum CreditFacilityScope {
+    All,
+    Partner(PartnerId),        // overridden — reads "as a partner", not "by partner_id"
+    CustomerId(CustomerId),    // default — UpperCamel of the column name
+}
+```
+
+The override only renames the enum variant and its `From` impl target — the
+underlying SQL conjunct is still keyed off the real column (`partner_id = $n`).
+Overridden and defaulted scope columns compose freely on the same repo.
+Variant names, whether defaulted or overridden, must still be pairwise
+distinct and may not collide with the reserved `All` variant (see
+"Validation rules" below).
+
 ## Tenancy roots: `id(scope)`
 
 The tenancy-root entity itself — the `Partner` in a partner-scoped system —
@@ -262,8 +297,10 @@ The macro rejects at compile time:
 - scope columns whose Rust types are not pairwise distinct (the generated
   `From<T>` conversions dispatch on type, so two same-typed scope columns
   would produce conflicting impls)
-- scope columns whose UpperCamel variant names collide with each other or
-  with the reserved `All` variant
+- scope columns whose variant names collide with each other or with the
+  reserved `All` variant — whether the name is the UpperCamel default or an
+  explicit `scope(variant = "...")` override
+- a `scope(variant = "...")` value that isn't a valid Rust identifier
 - an `Option<T>` or `nullable`-annotated scope column (nullable scope columns
   are not supported — every row must belong to exactly one scope, in every
   dimension)

--- a/book/src/scoped-repositories.md
+++ b/book/src/scoped-repositories.md
@@ -99,18 +99,41 @@ pub struct Partners {
 ```
 
 The id column is macro-owned — its type comes from the repo-level `id`
-attribute and `find_by`/`list_by` are always on — so `id(scope)` is the only
-accepted entry; anything else (`ty`, `find_by = ...`) is a compile error.
+attribute and `find_by`/`list_by` are always on — so the only accepted
+entries are `id(scope)` and its variant-override form,
+`id(scope(variant = "..."))`; anything else (`ty`, `find_by = ...`) is a
+compile error.
 
 The generated surface is the ordinary scoped one: a `PartnerScope` enum and a
-leading scope argument on every read. Since the `id` column's scope variant is
-named `Id`, every query under `Id(p)` carries an `id = p` conjunct, so reads
-collapse to **self-or-nothing**: `find_by_id(Id(a), b)` is `NotFound` unless
-`a == b`, `find_all` intersects down to at most the own row, and every list
-returns the own row or nothing. Unlike ordinary scope columns, the id column
-keeps its point-read — under `Id(_)` it is simply double-specified, composing
-exactly like a caller filter on the scope column (see below). No scope-led
-composite index is needed: the primary key already serves the `Id` arm.
+leading scope argument on every read. Since the `id` column's scope variant
+defaults to `Id`, every query under `Id(p)` carries an `id = p` conjunct, so
+reads collapse to **self-or-nothing**: `find_by_id(Id(a), b)` is `NotFound`
+unless `a == b`, `find_all` intersects down to at most the own row, and every
+list returns the own row or nothing. Unlike ordinary scope columns, the id
+column keeps its point-read — under `Id(_)` it is simply double-specified,
+composing exactly like a caller filter on the scope column (see below). No
+scope-led composite index is needed: the primary key already serves the `Id`
+arm.
+
+Like an ordinary scope column, the default `Id` variant name can be
+overridden:
+
+```rust,ignore
+#[derive(EsRepo)]
+#[es_repo(
+    entity = "Partner",
+    columns(
+        id(scope(variant = "Tenant")),
+        name(ty = "String", list_by),
+    )
+)]
+pub struct Partners {
+    pool: PgPool,
+}
+
+// generates PartnerScope::Tenant(PartnerId) instead of PartnerScope::Id(PartnerId);
+// everything else (self-or-nothing collapse, no extra index needed, `All`) is unchanged.
+```
 
 ```rust,ignore
 // authz-derived scope: a tenant subject reads itself or nothing,

--- a/book/src/scoped-repositories.md
+++ b/book/src/scoped-repositories.md
@@ -26,16 +26,17 @@ pub struct Customers {
 
 `partner_id` remains an ordinary persisted column — it is populated on
 `create` from the `NewCustomer`'s field like any other column. The `scope`
-marker additionally generates an entity-named scope enum:
+marker additionally generates an entity-named scope enum, with one variant
+per scope column (UpperCamel of the column name):
 
 ```rust,ignore
 pub enum CustomerScope {
-    All,               // no filter — reads across all scopes
-    Only(PartnerId),   // restricts every read to this scope value
+    All,                     // no filter — reads across all scopes
+    PartnerId(PartnerId),    // restricts every read to this scope value
 }
 
-impl From<PartnerId> for CustomerScope { /* => Only */ }
-impl From<&PartnerId> for CustomerScope { /* => Only */ }
+impl From<PartnerId> for CustomerScope { /* => PartnerId */ }
+impl From<&PartnerId> for CustomerScope { /* => PartnerId */ }
 ```
 
 There is deliberately **no** `From<Option<PartnerId>>`: mapping `None` to
@@ -67,14 +68,14 @@ attribute and `find_by`/`list_by` are always on — so `id(scope)` is the only
 accepted entry; anything else (`ty`, `find_by = ...`) is a compile error.
 
 The generated surface is the ordinary scoped one: a `PartnerScope` enum and a
-leading scope argument on every read. Under `Only(p)` every query carries an
-`id = p` conjunct, so reads collapse to **self-or-nothing**:
-`find_by_id(Only(a), b)` is `NotFound` unless `a == b`, `find_all` intersects
-down to at most the own row, and every list returns the own row or nothing.
-Unlike ordinary scope columns, the id column keeps its point-read — under
-`Only` it is simply double-specified, composing exactly like a caller filter
-on the scope column (see below). No scope-led composite index is needed: the
-primary key already serves the `Only` arm.
+leading scope argument on every read. Since the `id` column's scope variant is
+named `Id`, every query under `Id(p)` carries an `id = p` conjunct, so reads
+collapse to **self-or-nothing**: `find_by_id(Id(a), b)` is `NotFound` unless
+`a == b`, `find_all` intersects down to at most the own row, and every list
+returns the own row or nothing. Unlike ordinary scope columns, the id column
+keeps its point-read — under `Id(_)` it is simply double-specified, composing
+exactly like a caller filter on the scope column (see below). No scope-led
+composite index is needed: the primary key already serves the `Id` arm.
 
 ```rust,ignore
 // authz-derived scope: a tenant subject reads itself or nothing,
@@ -89,7 +90,7 @@ Every generated read function gains a leading `scope: impl Into<{Entity}Scope>`
 argument:
 
 ```rust,ignore
-customers.find_by_id(partner_id, id).await?;              // Into => Only
+customers.find_by_id(partner_id, id).await?;              // Into => PartnerId
 customers.find_by_id(CustomerScope::All, id).await?;      // explicit escape hatch
 customers.maybe_find_by_email(partner_id, email).await?;
 customers.find_all::<Customer>(partner_id, &ids).await?;
@@ -99,18 +100,18 @@ customers.list_for_filters(partner_id, filters, sort, args).await?;
 customers.find_by_id(id).await?;  // does not exist — compile error
 ```
 
-At runtime each function dispatches between two static, compile-time-checked
-SQL variants:
+At runtime each function dispatches between static, compile-time-checked SQL
+variants — one per scope column plus `All`:
 
 - `All` executes exactly the SQL an unscoped repo would.
-- `Only(value)` executes a variant with an additional `partner_id = $n`
-  conjunct in every `WHERE` clause.
+- Each column's variant (e.g. `PartnerId(value)`) executes a variant with an
+  additional `partner_id = $n` conjunct in every `WHERE` clause.
 
-Both arms are plain equality predicates — sargable against a scope-column-led
-index (see below). Under `Only`, a row from another scope behaves exactly like
-a missing row: `find_by_*` returns `NotFound`, `maybe_find_by_*` returns
-`None`, `find_all` silently omits the id, and lists never contain the row.
-**Missing and not-yours look identical.**
+Every arm is a plain equality predicate — sargable against a scope-column-led
+index (see below). Under any scoped variant, a row from another scope behaves
+exactly like a missing row: `find_by_*` returns `NotFound`, `maybe_find_by_*`
+returns `None`, `find_all` silently omits the id, and lists never contain the
+row. **Missing and not-yours look identical.**
 
 ## The bound view: `repo.scoped(scope)`
 
@@ -135,6 +136,56 @@ naturally request-scoped: it cannot be stored beyond the repo borrow, which
 keeps a bound all-access or tenant view from quietly outliving the request
 that justified it.
 
+## Multiple scope dimensions
+
+More than one column may be marked `scope`. This models systems with several
+independent principal kinds reading the same entity — e.g. an admin API, a
+partner API, and a customer API over the same `CreditFacility` rows:
+
+```rust,ignore
+#[derive(EsRepo)]
+#[es_repo(
+    entity = "CreditFacility",
+    columns(
+        partner_id(ty = "PartnerId", scope),
+        customer_id(ty = "CustomerId", scope),
+        status(ty = "String", list_for(by(created_at))),
+    )
+)]
+pub struct CreditFacilities { pool: PgPool }
+
+// generates:
+pub enum CreditFacilityScope {
+    All,                       // admin — audited escape hatch
+    PartnerId(PartnerId),      // partner API
+    CustomerId(CustomerId),    // customer API
+}
+```
+
+The dimensions are **disjunctive**: a single read is scoped by exactly one
+column or by `All` — never by more than one column at once. Each dimension
+gets its own dispatch arm carrying only that column's conjunct; there is no
+combined `PartnerId`-and-`CustomerId` variant. If a future consumer needs a
+read scoped by *both* dimensions simultaneously (e.g. "a partner acting on
+behalf of one specific customer"), that is out of scope for this feature and
+would need a dedicated combined variant.
+
+Every read fn's dispatch grows linearly with the number of scope columns —
+N scope columns plus `All` means N+1 static, compile-time-checked query
+variants, all still plain sargable equalities.
+
+Each scope dimension needs its **own** scope-led composite index; they are
+matched against the physical index catalog independently (see "Index
+requirements" below). A repo may have partner-led composite indexes but no
+customer-led ones yet — the partner dimension's `list_for_filters` arm
+specializes while the customer dimension's arm honestly falls back to the
+non-sargable `COALESCE` query until its indexes exist.
+
+Scope column Rust types must be pairwise distinct (the generated `From<T>`
+conversions dispatch on type — two same-typed scope columns would produce
+conflicting impls) and their UpperCamel variant names must not collide with
+each other or with the reserved `All` variant.
+
 ## Writes are custody-guarded
 
 `create`, `create_all`, `update`, `update_all` and `delete` keep their
@@ -158,7 +209,7 @@ ids. Replaying a cursor minted under a different scope yields well-defined
 
 By default the scope column generates no query surface of its own — every
 read is already filtered by it, and per-scope listing *is* the ordinary
-scoped `list_by_*(Only(value), ..)`. But some callers legitimately filter by
+scoped `list_by_*(PartnerId(value), ..)`. But some callers legitimately filter by
 the scope column *through the normal query surface*: an all-access admin
 listing that narrows to one tenant, for example. The scope value itself
 (typically authz-derived) must never be touched by caller input — the
@@ -176,17 +227,17 @@ and includes `partner_id: Option<PartnerId>` in the generated `Filters`
 struct. The caller value **composes** with the scope — it can narrow, never
 widen:
 
-| Scope     | Caller value | Result                                            |
-|-----------|--------------|---------------------------------------------------|
-| `All`     | none         | unfiltered                                        |
-| `All`     | `p`          | `WHERE partner_id = p`                            |
-| `Only(a)` | none         | `WHERE partner_id = a`                            |
-| `Only(a)` | `b`          | `WHERE partner_id = b AND partner_id = a` — **empty unless `a == b`** |
+| Scope           | Caller value | Result                                            |
+|-----------------|--------------|----------------------------------------------------|
+| `All`           | none         | unfiltered                                        |
+| `All`           | `p`          | `WHERE partner_id = p`                            |
+| `PartnerId(a)`  | none         | `WHERE partner_id = a`                            |
+| `PartnerId(a)`  | `b`          | `WHERE partner_id = b AND partner_id = a` — **empty unless `a == b`** |
 
-Under `Only`, the column is simply double-specified — once as the caller's
-filter, once as the scope conjunct, exactly like any other filter column. A
-mismatching caller value is a contradictory predicate that honestly returns
-an empty result (`NotFound`/`None` for `find_by_*`) instead of being
+Under a scoped variant, the column is simply double-specified — once as the
+caller's filter, once as the scope conjunct, exactly like any other filter
+column. A mismatching caller value is a contradictory predicate that honestly
+returns an empty result (`NotFound`/`None` for `find_by_*`) instead of being
 silently ignored — a caller filter can narrow but never widen the scope.
 Both predicates are plain equalities, so the query stays sargable against a
 scope-led index.
@@ -208,9 +259,14 @@ self.repo
 
 The macro rejects at compile time:
 
-- more than one `scope` column per repo
+- scope columns whose Rust types are not pairwise distinct (the generated
+  `From<T>` conversions dispatch on type, so two same-typed scope columns
+  would produce conflicting impls)
+- scope columns whose UpperCamel variant names collide with each other or
+  with the reserved `All` variant
 - an `Option<T>` or `nullable`-annotated scope column (nullable scope columns
-  are not supported — every row must belong to exactly one scope)
+  are not supported — every row must belong to exactly one scope, in every
+  dimension)
 - a `Forgettable<T>` scope column
 - `scope` on nested repos — children are custody-guarded via their (scoped)
   parent
@@ -221,20 +277,23 @@ to `false`, and the scope argument replaces them.
 
 ## Index requirements
 
-The `Only` arm adds a leading equality on the scope column to every read, so
-composite indexes should lead with it:
+Each scoped variant's arm adds a leading equality on its scope column to every
+read, so composite indexes should lead with it:
 
 ```sql
--- list_by_created_at under Only(p)
+-- list_by_created_at under PartnerId(p)
 CREATE INDEX ON customers (partner_id, created_at DESC, id DESC);
 
--- list_for_status_by_created_at under Only(p)
+-- list_for_status_by_created_at under PartnerId(p)
 CREATE INDEX ON customers (partner_id, status, created_at DESC, id DESC);
 
--- find_by_email under Only(p)
+-- find_by_email under PartnerId(p)
 CREATE INDEX ON customers (partner_id, email);
 ```
 
-Plain single-column indexes keep working (Postgres can still apply the scope
-conjunct as an index qual or filter), but scope-led composites let the
-paginated lists ride the index order with an early-exit `LIMIT`.
+With multiple scope dimensions, each one needs its own composites — a
+customer-scoped read rides a `(customer_id, ...)`-led index, independent of
+whatever partner-led indexes exist. Plain single-column indexes keep working
+(Postgres can still apply the scope conjunct as an index qual or filter), but
+scope-led composites let the paginated lists ride the index order with an
+early-exit `LIMIT`.

--- a/es-entity-macros/src/repo/find_all_fn.rs
+++ b/es-entity-macros/src/repo/find_all_fn.rs
@@ -130,15 +130,17 @@ impl ToTokens for FindAllFn<'_> {
             None => (quote! {}, quote! {}, quote! {}),
         };
         let fetch_call = if let Some(scope) = &self.scope {
-            let scoped_query = format!(
-                "SELECT id FROM {} WHERE id = ANY($1) AND {}",
-                self.table_name,
-                scope.predicate(2),
-            );
-            let scoped_es_query_call = make_es_query(&scoped_query, &scope.arg_tokens());
             scope.dispatch(
                 quote! { #es_query_call.fetch_n(op, ids.len()).await? },
-                quote! { #scoped_es_query_call.fetch_n(op, ids.len()).await? },
+                |col| {
+                    let scoped_query = format!(
+                        "SELECT id FROM {} WHERE id = ANY($1) AND {}",
+                        self.table_name,
+                        col.predicate(2),
+                    );
+                    let scoped_es_query_call = make_es_query(&scoped_query, &col.arg_tokens());
+                    quote! { #scoped_es_query_call.fetch_n(op, ids.len()).await? }
+                },
             )
         } else {
             quote! { #es_query_call.fetch_n(op, ids.len()).await? }

--- a/es-entity-macros/src/repo/find_by_fn.rs
+++ b/es-entity-macros/src/repo/find_by_fn.rs
@@ -219,23 +219,22 @@ impl ToTokens for FindByFn<'_> {
                     quote! { fetch_optional }
                 };
                 let fetch_optional_call = if let Some(scope) = &self.scope {
-                    let scoped_query = format!(
-                        r#"SELECT id FROM {} WHERE {} {} $1 AND {}{}"#,
-                        self.table_name,
-                        column_name,
-                        filter_op,
-                        scope.predicate(2),
-                        if delete == DeleteOption::No {
-                            self.delete.not_deleted_condition()
-                        } else {
-                            ""
-                        }
-                    );
-                    let scoped_es_query_call = make_es_query(&scoped_query, &scope.arg_tokens());
-                    scope.dispatch(
-                        quote! { #es_query_call.#fetch_method(op).await? },
-                        quote! { #scoped_es_query_call.#fetch_method(op).await? },
-                    )
+                    scope.dispatch(quote! { #es_query_call.#fetch_method(op).await? }, |col| {
+                        let scoped_query = format!(
+                            r#"SELECT id FROM {} WHERE {} {} $1 AND {}{}"#,
+                            self.table_name,
+                            column_name,
+                            filter_op,
+                            col.predicate(2),
+                            if delete == DeleteOption::No {
+                                self.delete.not_deleted_condition()
+                            } else {
+                                ""
+                            }
+                        );
+                        let scoped_es_query_call = make_es_query(&scoped_query, &col.arg_tokens());
+                        quote! { #scoped_es_query_call.#fetch_method(op).await? }
+                    })
                 } else {
                     quote! { #es_query_call.#fetch_method(op).await? }
                 };

--- a/es-entity-macros/src/repo/list_by_fn.rs
+++ b/es-entity-macros/src/repo/list_by_fn.rs
@@ -3,7 +3,10 @@ use darling::ToTokens;
 use proc_macro2::{Span, TokenStream};
 use quote::{TokenStreamExt, quote};
 
-use super::{options::*, scope::ScopeInfo};
+use super::{
+    options::*,
+    scope::{ScopeCol, ScopeInfo},
+};
 
 /// Assemble the unified cursor query: the per-state cursor predicates emitted
 /// as `UNION ALL` branches in a single static query.
@@ -516,7 +519,7 @@ impl ToTokens for ListByFn<'_> {
                 }
             };
 
-            let build_query_arms = |scope: Option<&ScopeInfo>| -> TokenStream {
+            let build_query_arms = |scope: Option<&ScopeCol>| -> TokenStream {
                 let mut query_arms = TokenStream::new();
                 let offset = if scope.is_some() { 1 } else { 0 };
                 for ascending in [true, false] {
@@ -568,16 +571,18 @@ impl ToTokens for ListByFn<'_> {
                 None => (quote! {}, quote! {}, quote! {}),
             };
             let match_expr = if let Some(scope) = &self.scope {
-                let scoped_query_arms = build_query_arms(Some(scope));
                 scope.dispatch(
                     quote! {
                         match direction {
                             #query_arms
                         }
                     },
-                    quote! {
-                        match direction {
-                            #scoped_query_arms
+                    |col| {
+                        let scoped_query_arms = build_query_arms(Some(col));
+                        quote! {
+                            match direction {
+                                #scoped_query_arms
+                            }
                         }
                     },
                 )

--- a/es-entity-macros/src/repo/list_for_filters_fn.rs
+++ b/es-entity-macros/src/repo/list_for_filters_fn.rs
@@ -7,7 +7,7 @@ use super::{
     combo_cursor::ComboCursor,
     list_by_fn::{CursorStruct, assemble_union_select, not_deleted_predicate},
     options::*,
-    scope::ScopeInfo,
+    scope::{ScopeCol, ScopeInfo},
 };
 
 /// Runtime `Some`-ness state of one filter column. Each state that reaches
@@ -343,16 +343,21 @@ impl<'a> ListForFiltersFn<'a> {
     /// specialized sargable query — decided purely by the physical index
     /// catalog (derived from the migrations). A combination is specialized iff
     /// some composite index's leading key columns are a permutation of the
-    /// equality columns (the scope column, when present, plus every constrained
-    /// filter — `= $k` *and* `IS NULL` states both constrain the column)
-    /// immediately followed by the sort column. Everything else falls back to
-    /// the correct (non-sargable) `COALESCE` query. No arity cap: build cost
-    /// tracks declared indexes, not `3^n` combinations.
+    /// equality columns (the scope arm's column, when present, plus every
+    /// constrained filter — `= $k` *and* `IS NULL` states both constrain the
+    /// column) immediately followed by the sort column. Everything else falls
+    /// back to the correct (non-sargable) `COALESCE` query. No arity cap:
+    /// build cost tracks declared indexes, not `3^n` combinations.
+    ///
+    /// Each scope-column arm is checked independently against the index
+    /// catalog: a repo may have partner-led composite indexes but no
+    /// customer-led ones, in which case the partner arm specializes while
+    /// the customer arm honestly falls back.
     fn is_specialized_combo(
         &self,
         combo: &[FilterState],
         by_column: &Column,
-        scope: Option<&ScopeInfo>,
+        scope: Option<&ScopeCol>,
     ) -> bool {
         let mut equality_cols: Vec<String> = Vec::new();
         if let Some(scope) = scope {
@@ -540,9 +545,9 @@ impl<'a> ListForFiltersFn<'a> {
         // combination, sargable only where a matching composite index exists.
         // The filter predicates (COALESCE / apply-flag forms) are the leading
         // conjuncts shared by every unified-cursor `UNION ALL` branch.
-        // Parameterized over the scope: the scoped variant binds the scope
+        // Parameterized over the scope: each scope-column arm binds its
         // column at `$1` and shifts every other parameter by one.
-        let build_fallback = |scope: Option<&ScopeInfo>| -> (String, String, TokenStream) {
+        let build_fallback = |scope: Option<&ScopeCol>| -> (String, String, TokenStream) {
             let scope_offset: u32 = if scope.is_some() { 1 } else { 0 };
             let mut param_idx = 1u32 + scope_offset;
             let where_fragments: Vec<String> = self
@@ -630,10 +635,10 @@ impl<'a> ListForFiltersFn<'a> {
         // combination x cursor state x direction). Every present filter
         // compiles to a sargable `col = $k` (or `col IS NULL`) predicate and
         // the cursor predicate is either omitted (page 1) or a bare row
-        // comparison. Parameterized over the scope: the scoped variant binds
-        // the scope column at `$1` and shifts every other parameter by one.
+        // comparison. Parameterized over the scope: each scope-column arm
+        // binds its column at `$1` and shifts every other parameter by one.
         let build_specialized_arms =
-            |scope: Option<&ScopeInfo>| -> (TokenStream, TokenStream, bool) {
+            |scope: Option<&ScopeCol>| -> (TokenStream, TokenStream, bool) {
                 let mut asc_arms = TokenStream::new();
                 let mut desc_arms = TokenStream::new();
                 let mut all_combos_specialized = true;
@@ -776,24 +781,26 @@ impl<'a> ListForFiltersFn<'a> {
             None => (quote! {}, quote! {}, quote! {}),
         };
         let match_expr = if let Some(scope) = &self.scope {
-            let (scoped_asc_arms, scoped_desc_arms, scoped_all_specialized) =
-                build_specialized_arms(Some(scope));
-            let (scoped_asc_query, scoped_desc_query, scoped_fallback_args) =
-                build_fallback(Some(scope));
-            let (scoped_asc_fallback, scoped_desc_fallback) = build_fallback_arms(
-                &scoped_asc_query,
-                &scoped_desc_query,
-                &scoped_fallback_args,
-                scoped_all_specialized,
-            );
             scope.dispatch(
                 direction_match(&asc_arms, &asc_fallback_arm, &desc_arms, &desc_fallback_arm),
-                direction_match(
-                    &scoped_asc_arms,
-                    &scoped_asc_fallback,
-                    &scoped_desc_arms,
-                    &scoped_desc_fallback,
-                ),
+                |col| {
+                    let (scoped_asc_arms, scoped_desc_arms, scoped_all_specialized) =
+                        build_specialized_arms(Some(col));
+                    let (scoped_asc_query, scoped_desc_query, scoped_fallback_args) =
+                        build_fallback(Some(col));
+                    let (scoped_asc_fallback, scoped_desc_fallback) = build_fallback_arms(
+                        &scoped_asc_query,
+                        &scoped_desc_query,
+                        &scoped_fallback_args,
+                        scoped_all_specialized,
+                    );
+                    direction_match(
+                        &scoped_asc_arms,
+                        &scoped_asc_fallback,
+                        &scoped_desc_arms,
+                        &scoped_desc_fallback,
+                    )
+                },
             )
         } else {
             direction_match(&asc_arms, &asc_fallback_arm, &desc_arms, &desc_fallback_arm)

--- a/es-entity-macros/src/repo/list_for_fn.rs
+++ b/es-entity-macros/src/repo/list_for_fn.rs
@@ -5,7 +5,7 @@ use quote::{TokenStreamExt, quote};
 use super::{
     list_by_fn::{CursorStruct, assemble_union_select, not_deleted_predicate},
     options::*,
-    scope::ScopeInfo,
+    scope::{ScopeCol, ScopeInfo},
 };
 
 pub struct ListForFn<'a> {
@@ -210,7 +210,7 @@ impl ToTokens for ListForFn<'_> {
                 }
             };
 
-            let build_query_arms = |scope: Option<&ScopeInfo>| -> TokenStream {
+            let build_query_arms = |scope: Option<&ScopeCol>| -> TokenStream {
                 let mut query_arms = TokenStream::new();
                 let offset = if scope.is_some() { 2 } else { 1 };
                 for ascending in [true, false] {
@@ -264,16 +264,18 @@ impl ToTokens for ListForFn<'_> {
                 None => (quote! {}, quote! {}, quote! {}),
             };
             let match_expr = if let Some(scope) = &self.scope {
-                let scoped_query_arms = build_query_arms(Some(scope));
                 scope.dispatch(
                     quote! {
                         match direction {
                             #query_arms
                         }
                     },
-                    quote! {
-                        match direction {
-                            #scoped_query_arms
+                    |col| {
+                        let scoped_query_arms = build_query_arms(Some(col));
+                        quote! {
+                            match direction {
+                                #scoped_query_arms
+                            }
                         }
                     },
                 )

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -553,11 +553,13 @@ mod tests {
             .expect("scoped repo should derive")
             .to_string();
         assert!(tokens.contains("pub enum UserScope"));
+        assert!(tokens.contains("PartnerId (PartnerId)"));
+        assert!(!tokens.contains("Only"));
         // every read fn takes the scope argument
         assert!(tokens.contains("fn find_by_id (& self , scope : impl Into < UserScope >"));
         assert!(tokens.contains("(& self , scope : impl Into < UserScope > , ids"));
         assert!(tokens.contains("fn list_by_created_at (& self , scope : impl Into < UserScope >"));
-        // the Only arm filters by the scope column, the All arm does not
+        // the PartnerId arm filters by the scope column, the All arm does not
         assert!(tokens.contains("WHERE id = $1 AND partner_id = $2"));
         assert!(tokens.contains("WHERE id = $1\""));
         // no find_by fns are generated for the scope column itself
@@ -624,13 +626,43 @@ mod tests {
     }
 
     #[test]
-    fn two_scope_columns_is_error() {
+    fn multi_scoped_repo_is_ok() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[es_repo(
+                entity = "Facility",
+                columns(
+                    partner_id(ty = "PartnerId", scope),
+                    customer_id(ty = "CustomerId", scope),
+                    name(ty = "String")
+                )
+            )]
+            struct Facilities {
+                pool: sqlx::PgPool,
+            }
+        };
+        let tokens = derive(input)
+            .expect("multi-scoped repo should derive")
+            .to_string();
+        assert!(tokens.contains("pub enum FacilityScope"));
+        assert!(tokens.contains("PartnerId (PartnerId)"));
+        assert!(tokens.contains("CustomerId (CustomerId)"));
+        // one dispatch arm per dimension, each with only its own conjunct
+        assert!(tokens.contains("WHERE id = $1 AND partner_id = $2"));
+        assert!(tokens.contains("WHERE id = $1 AND customer_id = $2"));
+        assert!(!tokens.contains("partner_id = $2 AND customer_id"));
+        // From impls for both id types
+        assert!(tokens.contains("impl From < PartnerId > for FacilityScope"));
+        assert!(tokens.contains("impl From < CustomerId > for FacilityScope"));
+    }
+
+    #[test]
+    fn same_type_scope_columns_is_error() {
         let input: syn::DeriveInput = parse_quote! {
             #[es_repo(
                 entity = "User",
                 columns(
                     partner_id(ty = "PartnerId", scope),
-                    customer_id(ty = "CustomerId", scope)
+                    other_partner_id(ty = "PartnerId", scope)
                 )
             )]
             struct Users {
@@ -639,7 +671,7 @@ mod tests {
         };
         let err = derive(input).unwrap_err();
         assert!(
-            err.to_string().contains("only one scope column"),
+            err.to_string().contains("same Rust type"),
             "unexpected error: {err}"
         );
     }

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -684,6 +684,30 @@ mod tests {
     }
 
     #[test]
+    fn id_scope_variant_override_is_ok() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[es_repo(
+                entity = "Partner",
+                columns(id(scope(variant = "Tenant")), name(ty = "String", list_by))
+            )]
+            struct Partners {
+                pool: sqlx::PgPool,
+            }
+        };
+        let tokens = derive(input)
+            .expect("id(scope(variant = ...)) repo should derive")
+            .to_string();
+        assert!(tokens.contains("pub enum PartnerScope"));
+        // the id column's overridden variant name replaces the default `Id`...
+        assert!(tokens.contains("Tenant (PartnerId)"));
+        assert!(!tokens.contains("Id (PartnerId)"));
+        assert!(tokens.contains("impl From < PartnerId > for PartnerScope"));
+        assert!(tokens.contains("PartnerScope :: Tenant (__scope_val)"));
+        // every query carries the id conjunct under the overridden variant
+        assert!(tokens.contains("WHERE id = $1 AND id = $2"));
+    }
+
+    #[test]
     fn same_type_scope_columns_is_error() {
         let input: syn::DeriveInput = parse_quote! {
             #[es_repo(

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -656,6 +656,34 @@ mod tests {
     }
 
     #[test]
+    fn scope_variant_override_is_ok() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[es_repo(
+                entity = "Facility",
+                columns(
+                    partner_id(ty = "PartnerId", scope(variant = "Partner")),
+                    customer_id(ty = "CustomerId", scope),
+                    name(ty = "String")
+                )
+            )]
+            struct Facilities {
+                pool: sqlx::PgPool,
+            }
+        };
+        let tokens = derive(input)
+            .expect("overridden-variant scoped repo should derive")
+            .to_string();
+        assert!(tokens.contains("pub enum FacilityScope"));
+        // overridden column uses the custom variant name...
+        assert!(tokens.contains("Partner (PartnerId)"));
+        assert!(!tokens.contains("PartnerId (PartnerId)"));
+        // ...while the un-overridden column keeps the default
+        assert!(tokens.contains("CustomerId (CustomerId)"));
+        assert!(tokens.contains("impl From < PartnerId > for FacilityScope"));
+        assert!(tokens.contains("FacilityScope :: Partner (__scope_val)"));
+    }
+
+    #[test]
     fn same_type_scope_columns_is_error() {
         let input: syn::DeriveInput = parse_quote! {
             #[es_repo(

--- a/es-entity-macros/src/repo/options/columns.rs
+++ b/es-entity-macros/src/repo/options/columns.rs
@@ -4,11 +4,13 @@ use quote::quote;
 #[derive(Default)]
 pub struct Columns {
     all: Vec<Column>,
-    /// Set by an `id(scope)` entry in `columns(...)`: marks the implicit
-    /// `id` column as the repo's scope column (applied in
-    /// [`Self::set_id_column`]). Used by tenancy-root repos whose rows' scope
-    /// value is their own id.
-    id_scope: bool,
+    /// Set by an `id(scope)` / `id(scope(variant = "..."))` entry in
+    /// `columns(...)`: marks the implicit `id` column as the repo's scope
+    /// column (applied in [`Self::set_id_column`]). Used by tenancy-root
+    /// repos whose rows' scope value is their own id. Defaults the enum
+    /// variant to `Id`; `variant = "..."` overrides it, same as an ordinary
+    /// scope column.
+    id_scope_opts: Option<ScopeOpts>,
 }
 
 impl Columns {
@@ -17,7 +19,7 @@ impl Columns {
         let all = columns.into_iter().collect();
         let mut res = Columns {
             all,
-            id_scope: false,
+            id_scope_opts: None,
         };
         res.set_id_column(id);
         res
@@ -25,7 +27,7 @@ impl Columns {
 
     pub fn set_id_column(&mut self, ty: &syn::Ident) {
         let mut id_column = Column::for_id(syn::parse_str(&ty.to_string()).unwrap());
-        id_column.opts.scope_opts = self.id_scope.then(ScopeOpts::default);
+        id_column.opts.scope_opts = self.id_scope_opts.take();
         let mut all = vec![Column::for_created_at(), id_column];
         all.append(&mut self.all);
         self.all = all;
@@ -484,40 +486,53 @@ impl Columns {
 
 impl FromMeta for Columns {
     fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
-        let mut id_scope = false;
+        let mut id_scope_opts: Option<ScopeOpts> = None;
         let mut all = Vec::new();
         for item in items {
             if let darling::ast::NestedMeta::Meta(meta) = item
                 && meta.path().is_ident("id")
             {
-                if id_scope {
+                if id_scope_opts.is_some() {
                     return Err(darling::Error::custom("duplicate `id` column").with_span(meta));
                 }
-                id_scope = id_scope_from_meta(meta)?;
+                id_scope_opts = Some(id_scope_from_meta(meta)?);
                 continue;
             }
             all.push(Column::from_nested_meta(item)?);
         }
-        Ok(Columns { all, id_scope })
+        Ok(Columns { all, id_scope_opts })
     }
 }
 
 /// The implicit `id` column is macro-owned — its type comes from the
 /// repo-level `id` attribute and `find_by`/`list_by` are always on — so the
-/// only supported entry is the `id(scope)` marker.
-fn id_scope_from_meta(meta: &syn::Meta) -> darling::Result<bool> {
-    let err =
-        || darling::Error::custom("the `id` column only supports `id(scope)`").with_span(meta);
+/// only supported entries are the `id(scope)` marker and its
+/// `id(scope(variant = "..."))` override form (identical to an ordinary
+/// scope column's `scope`/`scope(variant = "...")`).
+fn id_scope_from_meta(meta: &syn::Meta) -> darling::Result<ScopeOpts> {
+    let err = || {
+        darling::Error::custom(
+            "the `id` column only supports `id(scope)` or `id(scope(variant = \"...\"))`",
+        )
+        .with_span(meta)
+    };
     let syn::Meta::List(list) = meta else {
         return Err(err());
     };
-    let inner: syn::punctuated::Punctuated<syn::Ident, syn::Token![,]> = list
+    let inner: syn::punctuated::Punctuated<syn::Meta, syn::Token![,]> = list
         .parse_args_with(syn::punctuated::Punctuated::parse_terminated)
         .map_err(|_| err())?;
-    if inner.len() != 1 || inner[0] != "scope" {
+    if inner.len() != 1 {
         return Err(err());
     }
-    Ok(true)
+    let scope_meta = &inner[0];
+    if !scope_meta.path().is_ident("scope") {
+        return Err(err());
+    }
+    match scope_meta {
+        syn::Meta::Path(_) | syn::Meta::List(_) => ScopeOpts::from_meta(scope_meta),
+        syn::Meta::NameValue(_) => Err(err()),
+    }
 }
 
 #[derive(PartialEq)]
@@ -1276,6 +1291,54 @@ mod tests {
         assert!(scope.opts.find_by());
         assert!(scope.opts.list_by());
         assert!(columns.validate_scope().is_ok());
+        // bare `id(scope)` defaults the variant to `Id`.
+        assert_eq!(scope.scope_variant().to_string(), "Id");
+    }
+
+    #[test]
+    fn id_scope_variant_override_is_parsed_and_used() {
+        let input: syn::Meta =
+            parse_quote!(columns(id(scope(variant = "Tenant")), name = "String"));
+        let mut columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        columns.set_id_column(&parse_quote!(TestId));
+
+        let scope_cols = columns.scope_columns();
+        let scope = scope_cols.first().expect("id should be scope column");
+        assert_eq!(scope.scope_variant().to_string(), "Tenant");
+        assert!(columns.validate_scope().is_ok());
+    }
+
+    #[test]
+    fn id_scope_variant_override_must_be_valid_identifier() {
+        let input: syn::Meta = parse_quote!(columns(
+            id(scope(variant = "not an ident")),
+            name = "String"
+        ));
+        let err = match Columns::from_meta(&input) {
+            Err(err) => err.to_string(),
+            Ok(_) => panic!("expected error"),
+        };
+        assert!(
+            err.contains("not a valid Rust identifier"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn id_scope_rejects_unknown_scope_option() {
+        let input: syn::Meta = parse_quote!(columns(id(scope(unknown = "x")), name = "String"));
+        let err = parse_columns_err(input);
+        assert!(
+            err.contains("unknown") || err.contains("Unknown"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn id_scope_rejects_name_value_form() {
+        let input: syn::Meta = parse_quote!(columns(id(scope = true), name = "String"));
+        let err = parse_columns_err(input);
+        assert!(err.contains("id(scope)"), "unexpected error: {err}");
     }
 
     #[test]

--- a/es-entity-macros/src/repo/options/columns.rs
+++ b/es-entity-macros/src/repo/options/columns.rs
@@ -43,53 +43,90 @@ impl Columns {
         self.all.iter().filter(|c| c.opts.list_for())
     }
 
-    /// The column marked `scope`, if any. Validated by
-    /// [`Self::validate_scope`] to be unique and non-nullable.
-    pub fn scope_column(&self) -> Option<&Column> {
-        self.all.iter().find(|c| c.opts.scope)
+    /// The columns marked `scope`, in declaration order (declaration order
+    /// becomes enum-variant order and dispatch-arm order). Validated by
+    /// [`Self::validate_scope`].
+    pub fn scope_columns(&self) -> Vec<&Column> {
+        self.all.iter().filter(|c| c.opts.scope).collect()
     }
 
-    /// Validates the `scope` column marker:
+    /// Validates the `scope` column markers:
     ///
-    /// - at most one column may be marked `scope`
-    /// - the scope column must be non-nullable (`Option<T>` and
+    /// - scope columns must have pairwise-distinct Rust types (the generated
+    ///   `From<T>` conversions dispatch on type, so two same-typed scope
+    ///   columns would produce conflicting impls) and pairwise-distinct
+    ///   variant names (UpperCamel of the column name), neither colliding
+    ///   with the reserved `All` variant
+    /// - every scope column must be non-nullable (`Option<T>` and
     ///   `nullable`-annotated types are rejected — nullable scope columns are
     ///   a future feature)
-    /// - the scope column must not be `Forgettable<T>`
-    /// - the scope column must not be the `parent` column (nested repos
-    ///   cannot be scoped — children are custody-guarded via their parent)
+    /// - every scope column must not be `Forgettable<T>`
+    /// - no scope column may be the `parent` column (nested repos cannot be
+    ///   scoped — children are custody-guarded via their parent)
     pub fn validate_scope(&self) -> darling::Result<()> {
         let scope_columns: Vec<_> = self.all.iter().filter(|c| c.opts.scope).collect();
-        if scope_columns.len() > 1 {
-            return Err(darling::Error::custom(
-                "only one scope column per repo is supported",
-            ));
-        }
-        let Some(col) = scope_columns.first() else {
+        if scope_columns.is_empty() {
             return Ok(());
-        };
-        if col.is_nullable_column() {
-            return Err(darling::Error::custom(format!(
-                "scope column '{}' must be non-nullable — nullable scope columns are not supported (yet)",
-                col.name(),
-            )));
-        }
-        if col.opts.forgettable {
-            return Err(darling::Error::custom(format!(
-                "scope column '{}' cannot be Forgettable",
-                col.name(),
-            )));
-        }
-        if col.opts.parent_opts.is_some() {
-            return Err(darling::Error::custom(format!(
-                "scope column '{}' cannot be the parent column — nested repos cannot be scoped",
-                col.name(),
-            )));
         }
         if self.parent().is_some() {
             return Err(darling::Error::custom(
                 "scope is not supported on nested repos — children are custody-guarded via their (scoped) parent",
             ));
+        }
+        for col in &scope_columns {
+            if col.is_nullable_column() {
+                return Err(darling::Error::custom(format!(
+                    "scope column '{}' must be non-nullable — nullable scope columns are not supported (yet)",
+                    col.name(),
+                )));
+            }
+            if col.opts.forgettable {
+                return Err(darling::Error::custom(format!(
+                    "scope column '{}' cannot be Forgettable",
+                    col.name(),
+                )));
+            }
+            if col.opts.parent_opts.is_some() {
+                return Err(darling::Error::custom(format!(
+                    "scope column '{}' cannot be the parent column — nested repos cannot be scoped",
+                    col.name(),
+                )));
+            }
+        }
+        // The generated From<T> conversions dispatch on the Rust type — every
+        // scope column must have a distinct type or the impls conflict.
+        for (i, a) in scope_columns.iter().enumerate() {
+            for b in &scope_columns[i + 1..] {
+                let ty_a = quote::ToTokens::to_token_stream(a.ty()).to_string();
+                let ty_b = quote::ToTokens::to_token_stream(b.ty()).to_string();
+                if ty_a == ty_b {
+                    return Err(darling::Error::custom(format!(
+                        "scope columns '{}' and '{}' have the same Rust type '{}' — the generated From<T> conversions would conflict; use distinct newtype ids",
+                        a.name(),
+                        b.name(),
+                        ty_a,
+                    )));
+                }
+            }
+        }
+        // Variant idents are UpperCamel(column name); they must not collide
+        // with each other or with the built-in `All` variant.
+        use convert_case::{Case, Casing};
+        let mut variant_names: Vec<String> = Vec::new();
+        for col in &scope_columns {
+            let variant = col.name().to_string().to_case(Case::UpperCamel);
+            if variant == "All" {
+                return Err(darling::Error::custom(format!(
+                    "scope column '{}' maps to the reserved variant name 'All'",
+                    col.name(),
+                )));
+            }
+            if variant_names.contains(&variant) {
+                return Err(darling::Error::custom(format!(
+                    "scope columns map to the same variant name '{variant}'",
+                )));
+            }
+            variant_names.push(variant);
         }
         Ok(())
     }
@@ -799,9 +836,11 @@ struct ColumnOpts {
     /// `NULL` by `forget()`/`delete()`. `ty` is rewritten to `Option<Inner>`.
     #[darling(default, skip)]
     forgettable: bool,
-    /// Marks the repo's scope column: every generated read fn gains a leading
+    /// Marks a repo scope column: every generated read fn gains a leading
     /// `scope: impl Into<{Entity}Scope>` argument and filters by this column
-    /// under `Only(_)`. Validated by [`Columns::validate_scope`].
+    /// under its dedicated enum variant. Multiple columns may be marked
+    /// `scope` (one variant each, plus `All`). Validated by
+    /// [`Columns::validate_scope`].
     #[darling(default)]
     scope: bool,
     #[darling(default)]
@@ -1169,7 +1208,8 @@ mod tests {
         assert_eq!(columns.all.len(), 1);
         columns.set_id_column(&parse_quote!(TestId));
 
-        let scope = columns.scope_column().expect("id should be scope column");
+        let scope_cols = columns.scope_columns();
+        let scope = scope_cols.first().expect("id should be scope column");
         assert_eq!(scope.name().to_string(), "id");
         // The id column keeps its point-read and cursor fns despite being
         // the scope column (`for_id` opts in explicitly).
@@ -1183,7 +1223,7 @@ mod tests {
         let input: syn::Meta = parse_quote!(columns(name = "String"));
         let mut columns = Columns::from_meta(&input).expect("Failed to parse Fields");
         columns.set_id_column(&parse_quote!(TestId));
-        assert!(columns.scope_column().is_none());
+        assert!(columns.scope_columns().is_empty());
     }
 
     fn parse_columns_err(input: syn::Meta) -> String {
@@ -1215,14 +1255,37 @@ mod tests {
     }
 
     #[test]
-    fn id_scope_conflicts_with_column_scope() {
+    fn id_scope_composes_with_distinct_column_scope() {
+        // Multiple scope columns are allowed as long as their Rust types are
+        // pairwise distinct — `id(scope)` (TestId) plus a `partner_id(scope)`
+        // (PartnerId) is a valid two-dimension scope.
         let input: syn::Meta =
             parse_quote!(columns(id(scope), partner_id(ty = "PartnerId", scope)));
         let mut columns = Columns::from_meta(&input).expect("Failed to parse Fields");
         columns.set_id_column(&parse_quote!(TestId));
+        assert!(columns.validate_scope().is_ok());
+        assert_eq!(columns.scope_columns().len(), 2);
+    }
+
+    #[test]
+    fn same_type_scope_columns_rejected() {
+        let input: syn::Meta = parse_quote!(columns(
+            partner_id(ty = "PartnerId", scope),
+            other_partner_id(ty = "PartnerId", scope)
+        ));
+        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        let err = columns.validate_scope().unwrap_err().to_string();
+        assert!(err.contains("same Rust type"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn colliding_variant_names_rejected() {
+        // `all` as a column name collides with the reserved `All` variant.
+        let input: syn::Meta = parse_quote!(columns(all(ty = "PartnerId", scope)));
+        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
         let err = columns.validate_scope().unwrap_err().to_string();
         assert!(
-            err.contains("only one scope column"),
+            err.contains("reserved variant name"),
             "unexpected error: {err}"
         );
     }

--- a/es-entity-macros/src/repo/options/columns.rs
+++ b/es-entity-macros/src/repo/options/columns.rs
@@ -25,7 +25,7 @@ impl Columns {
 
     pub fn set_id_column(&mut self, ty: &syn::Ident) {
         let mut id_column = Column::for_id(syn::parse_str(&ty.to_string()).unwrap());
-        id_column.opts.scope = self.id_scope;
+        id_column.opts.scope_opts = self.id_scope.then(ScopeOpts::default);
         let mut all = vec![Column::for_created_at(), id_column];
         all.append(&mut self.all);
         self.all = all;
@@ -47,7 +47,10 @@ impl Columns {
     /// becomes enum-variant order and dispatch-arm order). Validated by
     /// [`Self::validate_scope`].
     pub fn scope_columns(&self) -> Vec<&Column> {
-        self.all.iter().filter(|c| c.opts.scope).collect()
+        self.all
+            .iter()
+            .filter(|c| c.opts.scope_opts.is_some())
+            .collect()
     }
 
     /// Validates the `scope` column markers:
@@ -64,7 +67,11 @@ impl Columns {
     /// - no scope column may be the `parent` column (nested repos cannot be
     ///   scoped — children are custody-guarded via their parent)
     pub fn validate_scope(&self) -> darling::Result<()> {
-        let scope_columns: Vec<_> = self.all.iter().filter(|c| c.opts.scope).collect();
+        let scope_columns: Vec<_> = self
+            .all
+            .iter()
+            .filter(|c| c.opts.scope_opts.is_some())
+            .collect();
         if scope_columns.is_empty() {
             return Ok(());
         }
@@ -109,12 +116,12 @@ impl Columns {
                 }
             }
         }
-        // Variant idents are UpperCamel(column name); they must not collide
-        // with each other or with the built-in `All` variant.
-        use convert_case::{Case, Casing};
+        // Variant idents default to UpperCamel(column name) but may be
+        // overridden via `scope(variant = "...")`; either way they must not
+        // collide with each other or with the built-in `All` variant.
         let mut variant_names: Vec<String> = Vec::new();
         for col in &scope_columns {
-            let variant = col.name().to_string().to_case(Case::UpperCamel);
+            let variant = col.scope_variant().to_string();
             if variant == "All" {
                 return Err(darling::Error::custom(format!(
                     "scope column '{}' maps to the reserved variant name 'All'",
@@ -591,7 +598,7 @@ impl Column {
                 ty,
                 is_id: true,
                 forgettable: false,
-                scope: false,
+                scope_opts: None,
                 list_by: Some(true),
                 find_by: Some(true),
                 nullable: None,
@@ -618,7 +625,7 @@ impl Column {
                 ),
                 is_id: false,
                 forgettable: false,
-                scope: false,
+                scope_opts: None,
                 list_by: Some(true),
                 find_by: Some(false),
                 nullable: None,
@@ -646,6 +653,23 @@ impl Column {
 
     pub fn is_id(&self) -> bool {
         self.opts.is_id
+    }
+
+    /// The scope enum variant ident for this column: the explicit
+    /// `scope(variant = "...")` override if given, else UpperCamel of the
+    /// column name. Only meaningful for columns marked `scope`.
+    pub fn scope_variant(&self) -> syn::Ident {
+        self.opts
+            .scope_opts
+            .as_ref()
+            .and_then(|o| o.variant.clone())
+            .unwrap_or_else(|| {
+                use convert_case::{Case, Casing};
+                syn::Ident::new(
+                    &self.name.to_string().to_case(Case::UpperCamel),
+                    proc_macro2::Span::call_site(),
+                )
+            })
     }
 
     /// True iff the Rust type is syntactically `Option<T>`.
@@ -839,10 +863,11 @@ struct ColumnOpts {
     /// Marks a repo scope column: every generated read fn gains a leading
     /// `scope: impl Into<{Entity}Scope>` argument and filters by this column
     /// under its dedicated enum variant. Multiple columns may be marked
-    /// `scope` (one variant each, plus `All`). Validated by
-    /// [`Columns::validate_scope`].
-    #[darling(default)]
-    scope: bool,
+    /// `scope` (one variant each, plus `All`). Bare `scope` names the
+    /// variant UpperCamel(column name); `scope(variant = "...")` overrides
+    /// it. Validated by [`Columns::validate_scope`].
+    #[darling(default, rename = "scope")]
+    scope_opts: Option<ScopeOpts>,
     #[darling(default)]
     find_by: Option<bool>,
     #[darling(default)]
@@ -873,7 +898,7 @@ impl ColumnOpts {
             ty,
             is_id: false,
             forgettable: false,
-            scope: false,
+            scope_opts: None,
             find_by: None,
             list_by: None,
             nullable: None,
@@ -898,7 +923,7 @@ impl ColumnOpts {
     fn find_by(&self) -> bool {
         // `scope` flips the default to false — every read is already
         // filtered by the scope column; explicit `find_by = true` opts in.
-        self.find_by.unwrap_or(!self.scope)
+        self.find_by.unwrap_or(self.scope_opts.is_none())
     }
 
     fn list_by(&self) -> bool {
@@ -1041,6 +1066,41 @@ impl FromMeta for ListForOpts {
             }
         }
         Ok(ListForOpts { by_columns })
+    }
+}
+
+/// Options for a `scope` column marker. Bare `scope` leaves `variant: None`
+/// (the enum variant defaults to UpperCamel of the column name, computed in
+/// [`Column::scope_variant`]); `scope(variant = "...")` overrides it.
+#[derive(PartialEq, Debug, Default)]
+struct ScopeOpts {
+    variant: Option<syn::Ident>,
+}
+
+impl FromMeta for ScopeOpts {
+    fn from_word() -> darling::Result<Self> {
+        Ok(ScopeOpts::default())
+    }
+
+    fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
+        #[derive(FromMeta)]
+        struct Inner {
+            #[darling(default)]
+            variant: Option<String>,
+        }
+
+        let inner = Inner::from_list(items)?;
+        let variant = inner
+            .variant
+            .map(|v| {
+                syn::parse_str::<syn::Ident>(&v).map_err(|_| {
+                    darling::Error::custom(format!(
+                        "scope variant '{v}' is not a valid Rust identifier"
+                    ))
+                })
+            })
+            .transpose()?;
+        Ok(ScopeOpts { variant })
     }
 }
 
@@ -1282,6 +1342,85 @@ mod tests {
     fn colliding_variant_names_rejected() {
         // `all` as a column name collides with the reserved `All` variant.
         let input: syn::Meta = parse_quote!(columns(all(ty = "PartnerId", scope)));
+        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        let err = columns.validate_scope().unwrap_err().to_string();
+        assert!(
+            err.contains("reserved variant name"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn scope_bare_word_defaults_variant_to_upper_camel_column_name() {
+        let input: syn::Meta = parse_quote!(thing(ty = "PartnerId", scope));
+        let values = ColumnOpts::from_meta(&input).expect("Failed to parse Field");
+        assert!(values.scope_opts.is_some());
+        assert!(values.scope_opts.as_ref().unwrap().variant.is_none());
+
+        let column = Column {
+            name: parse_quote!(partner_id),
+            opts: values,
+        };
+        assert_eq!(column.scope_variant().to_string(), "PartnerId");
+    }
+
+    #[test]
+    fn scope_variant_override_is_parsed_and_used() {
+        let input: syn::Meta = parse_quote!(thing(ty = "PartnerId", scope(variant = "Partner")));
+        let values = ColumnOpts::from_meta(&input).expect("Failed to parse Field");
+        assert_eq!(
+            values
+                .scope_opts
+                .as_ref()
+                .and_then(|o| o.variant.as_ref())
+                .expect("variant override")
+                .to_string(),
+            "Partner"
+        );
+
+        let column = Column {
+            name: parse_quote!(partner_id),
+            opts: values,
+        };
+        assert_eq!(column.scope_variant().to_string(), "Partner");
+    }
+
+    #[test]
+    fn scope_variant_override_must_be_valid_identifier() {
+        let input: syn::Meta =
+            parse_quote!(thing(ty = "PartnerId", scope(variant = "not an ident")));
+        let err = match ColumnOpts::from_meta(&input) {
+            Err(err) => err.to_string(),
+            Ok(_) => panic!("expected error"),
+        };
+        assert!(
+            err.contains("not a valid Rust identifier"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn overridden_variant_names_still_checked_for_collisions() {
+        // Two scope columns whose override collapses to the same variant
+        // name must be rejected, same as the unoverridden case.
+        let input: syn::Meta = parse_quote!(columns(
+            partner_id(ty = "PartnerId", scope(variant = "Tenant")),
+            customer_id(ty = "CustomerId", scope(variant = "Tenant"))
+        ));
+        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        let err = columns.validate_scope().unwrap_err().to_string();
+        assert!(
+            err.contains("same variant name 'Tenant'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn overridden_variant_colliding_with_all_is_rejected() {
+        let input: syn::Meta = parse_quote!(columns(partner_id(
+            ty = "PartnerId",
+            scope(variant = "All")
+        )));
         let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
         let err = columns.validate_scope().unwrap_err().to_string();
         assert!(

--- a/es-entity-macros/src/repo/scope.rs
+++ b/es-entity-macros/src/repo/scope.rs
@@ -1,9 +1,13 @@
-use convert_case::{Case, Casing};
 use darling::ToTokens;
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::{TokenStreamExt, quote};
 
 use super::options::*;
+
+#[cfg(test)]
+use convert_case::{Case, Casing};
+#[cfg(test)]
+use proc_macro2::Span;
 
 /// One scope column: its enum variant ident (UpperCamel of the column name,
 /// e.g. `partner_id` -> `PartnerId`), the column name, and its Rust type.
@@ -28,6 +32,10 @@ impl ScopeCol<'_> {
     }
 }
 
+/// Test-only helper mirroring [`super::options::Column::scope_variant`]'s
+/// default (no override) computation, for building [`ScopeCol`] fixtures
+/// directly without going through a parsed `Column`.
+#[cfg(test)]
 fn variant_ident(column_name: &syn::Ident) -> syn::Ident {
     syn::Ident::new(
         &column_name.to_string().to_case(Case::UpperCamel),
@@ -60,7 +68,7 @@ impl<'a> ScopeInfo<'a> {
             .scope_columns()
             .into_iter()
             .map(|col| ScopeCol {
-                variant: variant_ident(col.name()),
+                variant: col.scope_variant(),
                 column_name: col.name(),
                 column_ty: col.ty(),
             })

--- a/es-entity-macros/src/repo/scope.rs
+++ b/es-entity-macros/src/repo/scope.rs
@@ -1,31 +1,76 @@
+use convert_case::{Case, Casing};
 use darling::ToTokens;
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{TokenStreamExt, quote};
 
 use super::options::*;
 
-/// Info about a repo's scope column, shared by the read-fn emitters.
-///
-/// A repo with a column marked `scope` generates every read fn
-/// (`find_by_*`, `find_all`, `list_by_*`, `list_for_*`, `list_for_filters*`)
-/// with a leading `scope: impl Into<{Entity}Scope>` argument. At runtime the
-/// fn dispatches on the scope: `All` executes the exact same SQL as an
-/// unscoped repo, `Only(value)` executes a variant with an additional
-/// `scope_column = $n` conjunct — both static, sargable `es_query!` literals.
+/// One scope column: its enum variant ident (UpperCamel of the column name,
+/// e.g. `partner_id` -> `PartnerId`), the column name, and its Rust type.
 #[derive(Clone)]
-pub struct ScopeInfo<'a> {
-    /// The generated scope enum ident: `{Entity}Scope`.
-    pub scope_ty: syn::Ident,
+pub struct ScopeCol<'a> {
+    pub variant: syn::Ident,
     pub column_name: &'a syn::Ident,
     pub column_ty: &'a syn::Type,
 }
 
+impl ScopeCol<'_> {
+    /// The SQL conjunct for this column's arm at the given parameter index.
+    pub fn predicate(&self, param_idx: u32) -> String {
+        format!("{} = ${}", self.column_name, param_idx)
+    }
+
+    /// The query binding for this column's arm (pairs with the dispatch
+    /// arm's `__scope_val` pattern binding).
+    pub fn arg_tokens(&self) -> TokenStream {
+        let column_ty = self.column_ty;
+        quote! { __scope_val as &#column_ty, }
+    }
+}
+
+fn variant_ident(column_name: &syn::Ident) -> syn::Ident {
+    syn::Ident::new(
+        &column_name.to_string().to_case(Case::UpperCamel),
+        Span::call_site(),
+    )
+}
+
+/// Info about a repo's scope columns, shared by the read-fn emitters.
+///
+/// A repo with one or more columns marked `scope` generates every read fn
+/// (`find_by_*`, `find_all`, `list_by_*`, `list_for_*`, `list_for_filters*`)
+/// with a leading `scope: impl Into<{Entity}Scope>` argument. At runtime the
+/// fn dispatches on the scope: `All` executes the exact same SQL as an
+/// unscoped repo, each scope column's variant executes a variant with that
+/// column's additional `scope_column = $n` conjunct — all static, sargable
+/// `es_query!` literals.
+#[derive(Clone)]
+pub struct ScopeInfo<'a> {
+    /// The generated scope enum ident: `{Entity}Scope`.
+    pub scope_ty: syn::Ident,
+    /// The scope columns in declaration order (= variant order = dispatch
+    /// arm order).
+    pub cols: Vec<ScopeCol<'a>>,
+}
+
 impl<'a> ScopeInfo<'a> {
     pub fn from_opts(opts: &'a RepositoryOptions) -> Option<Self> {
-        opts.columns.scope_column().map(|col| ScopeInfo {
+        let cols: Vec<_> = opts
+            .columns
+            .scope_columns()
+            .into_iter()
+            .map(|col| ScopeCol {
+                variant: variant_ident(col.name()),
+                column_name: col.name(),
+                column_ty: col.ty(),
+            })
+            .collect();
+        if cols.is_empty() {
+            return None;
+        }
+        Some(ScopeInfo {
             scope_ty: opts.scope_type_ident(),
-            column_name: col.name(),
-            column_ty: col.ty(),
+            cols,
         })
     }
 
@@ -45,26 +90,24 @@ impl<'a> ScopeInfo<'a> {
         quote! { let __scope = scope.into(); }
     }
 
-    /// The SQL conjunct for the `Only` arm at the given parameter index.
-    pub fn predicate(&self, param_idx: u32) -> String {
-        format!("{} = ${}", self.column_name, param_idx)
-    }
-
-    /// The query binding for the `Only` arm (pairs with [`Self::dispatch`]'s
-    /// `__scope_val` pattern binding).
-    pub fn arg_tokens(&self) -> TokenStream {
-        let column_ty = self.column_ty;
-        quote! { __scope_val as &#column_ty, }
-    }
-
-    /// Runtime dispatch between the unscoped (`All`) and scoped (`Only`)
-    /// query variants. The `Only` arm binds `__scope_val: &T`.
-    pub fn dispatch(&self, all_arm: TokenStream, only_arm: TokenStream) -> TokenStream {
+    /// Runtime dispatch between the unscoped (`All`) query variant and one
+    /// variant per scope column. `scoped_arm` is invoked once per column to
+    /// build that column's arm body; the arm pattern binds `__scope_val: &T`.
+    pub fn dispatch(
+        &self,
+        all_arm: TokenStream,
+        scoped_arm: impl Fn(&ScopeCol<'a>) -> TokenStream,
+    ) -> TokenStream {
         let scope_ty = &self.scope_ty;
+        let arms = self.cols.iter().map(|col| {
+            let variant = &col.variant;
+            let body = scoped_arm(col);
+            quote! { #scope_ty::#variant(__scope_val) => #body, }
+        });
         quote! {
             match &__scope {
                 #scope_ty::All => #all_arm,
-                #scope_ty::Only(__scope_val) => #only_arm,
+                #(#arms)*
             }
         }
     }
@@ -75,13 +118,15 @@ impl<'a> ScopeInfo<'a> {
 /// ```ignore
 /// pub enum UserScope {
 ///     All,
-///     Only(PartnerId),
+///     PartnerId(PartnerId),
+///     CustomerId(CustomerId),
 /// }
 /// ```
 ///
-/// plus `From<T>` / `From<&T>` conversions into `Only` so call sites can pass
-/// a scope value directly. Deliberately **no** `From<Option<T>>`: mapping
-/// `None` to `All` would turn a stray `None` into silent all-scope access.
+/// plus `From<T>` / `From<&T>` conversions into each column's variant so call
+/// sites can pass a scope value directly. Deliberately **no**
+/// `From<Option<T>>`: mapping `None` to `All` would turn a stray `None` into
+/// silent all-scope access.
 pub struct ScopeType<'a> {
     entity: &'a syn::Ident,
     info: ScopeInfo<'a>,
@@ -99,12 +144,42 @@ impl<'a> ScopeType<'a> {
 impl ToTokens for ScopeType<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let scope_ty = &self.info.scope_ty;
-        let column_ty = self.info.column_ty;
         let doc = format!(
-            "Scope argument for [`{}`] repository reads: `Only(value)` filters every query by \
-             the scope column, `All` reads across all scopes (audited escape hatch).",
+            "Scope argument for [`{}`] repository reads: each column variant filters every \
+             query by that scope column, `All` reads across all scopes (audited escape hatch).",
             self.entity,
         );
+
+        let variants = self.info.cols.iter().map(|col| {
+            let variant = &col.variant;
+            let column_ty = col.column_ty;
+            let vdoc = format!(
+                "Restricts every read to rows whose `{}` column equals the value.",
+                col.column_name,
+            );
+            quote! {
+                #[doc = #vdoc]
+                #variant(#column_ty),
+            }
+        });
+
+        let from_impls = self.info.cols.iter().map(|col| {
+            let variant = &col.variant;
+            let column_ty = col.column_ty;
+            quote! {
+                impl From<#column_ty> for #scope_ty {
+                    fn from(value: #column_ty) -> Self {
+                        #scope_ty::#variant(value)
+                    }
+                }
+
+                impl From<&#column_ty> for #scope_ty {
+                    fn from(value: &#column_ty) -> Self {
+                        #scope_ty::#variant(*value)
+                    }
+                }
+            }
+        });
 
         tokens.append_all(quote! {
             #[doc = #doc]
@@ -112,21 +187,10 @@ impl ToTokens for ScopeType<'_> {
             pub enum #scope_ty {
                 /// No scope filter — reads across all scopes.
                 All,
-                /// Restricts every read to rows whose scope column equals the value.
-                Only(#column_ty),
+                #(#variants)*
             }
 
-            impl From<#column_ty> for #scope_ty {
-                fn from(value: #column_ty) -> Self {
-                    #scope_ty::Only(value)
-                }
-            }
-
-            impl From<&#column_ty> for #scope_ty {
-                fn from(value: &#column_ty) -> Self {
-                    #scope_ty::Only(*value)
-                }
-            }
+            #(#from_impls)*
 
             impl From<&#scope_ty> for #scope_ty {
                 fn from(value: &#scope_ty) -> Self {
@@ -140,28 +204,30 @@ impl ToTokens for ScopeType<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proc_macro2::Span;
 
-    fn test_info<'a>(
-        column_name: &'a syn::Ident,
-        column_ty: &'a syn::Type,
-    ) -> (ScopeInfo<'a>, syn::Ident) {
+    fn test_info<'a>(cols: &[(&'a syn::Ident, &'a syn::Type)]) -> (ScopeInfo<'a>, syn::Ident) {
         let entity = syn::Ident::new("Entity", Span::call_site());
         (
             ScopeInfo {
                 scope_ty: syn::Ident::new("EntityScope", Span::call_site()),
-                column_name,
-                column_ty,
+                cols: cols
+                    .iter()
+                    .map(|(name, ty)| ScopeCol {
+                        variant: variant_ident(name),
+                        column_name: name,
+                        column_ty: ty,
+                    })
+                    .collect(),
             },
             entity,
         )
     }
 
     #[test]
-    fn scope_type_tokens() {
+    fn scope_type_tokens_single() {
         let column_name = syn::Ident::new("partner_id", Span::call_site());
         let column_ty: syn::Type = syn::parse_str("PartnerId").unwrap();
-        let (info, entity) = test_info(&column_name, &column_ty);
+        let (info, entity) = test_info(&[(&column_name, &column_ty)]);
         let scope_type = ScopeType {
             entity: &entity,
             info,
@@ -172,19 +238,70 @@ mod tests {
         let token_str = tokens.to_string();
 
         assert!(token_str.contains("pub enum EntityScope"));
-        assert!(token_str.contains("Only (PartnerId)"));
+        assert!(token_str.contains("PartnerId (PartnerId)"));
+        assert!(!token_str.contains("Only"));
         assert!(token_str.contains("impl From < PartnerId > for EntityScope"));
         assert!(token_str.contains("impl From < & PartnerId > for EntityScope"));
         assert!(!token_str.contains("Option"));
     }
 
     #[test]
-    fn scope_info_predicate() {
+    fn scope_type_tokens_multi() {
+        let partner = syn::Ident::new("partner_id", Span::call_site());
+        let partner_ty: syn::Type = syn::parse_str("PartnerId").unwrap();
+        let customer = syn::Ident::new("customer_id", Span::call_site());
+        let customer_ty: syn::Type = syn::parse_str("CustomerId").unwrap();
+        let (info, entity) = test_info(&[(&partner, &partner_ty), (&customer, &customer_ty)]);
+        let scope_type = ScopeType {
+            entity: &entity,
+            info,
+        };
+
+        let mut tokens = TokenStream::new();
+        scope_type.to_tokens(&mut tokens);
+        let token_str = tokens.to_string();
+
+        assert!(token_str.contains("pub enum EntityScope"));
+        assert!(token_str.contains("PartnerId (PartnerId)"));
+        assert!(token_str.contains("CustomerId (CustomerId)"));
+        assert!(token_str.contains("impl From < PartnerId > for EntityScope"));
+        assert!(token_str.contains("impl From < CustomerId > for EntityScope"));
+        assert!(token_str.contains("impl From < & CustomerId > for EntityScope"));
+    }
+
+    #[test]
+    fn scope_col_predicate() {
         let column_name = syn::Ident::new("partner_id", Span::call_site());
         let column_ty: syn::Type = syn::parse_str("PartnerId").unwrap();
-        let (info, _entity) = test_info(&column_name, &column_ty);
+        let (info, _entity) = test_info(&[(&column_name, &column_ty)]);
 
-        assert_eq!(info.predicate(1), "partner_id = $1");
-        assert_eq!(info.predicate(3), "partner_id = $3");
+        assert_eq!(info.cols[0].predicate(1), "partner_id = $1");
+        assert_eq!(info.cols[0].predicate(3), "partner_id = $3");
+    }
+
+    #[test]
+    fn dispatch_emits_one_arm_per_column() {
+        let partner = syn::Ident::new("partner_id", Span::call_site());
+        let partner_ty: syn::Type = syn::parse_str("PartnerId").unwrap();
+        let customer = syn::Ident::new("customer_id", Span::call_site());
+        let customer_ty: syn::Type = syn::parse_str("CustomerId").unwrap();
+        let (info, _entity) = test_info(&[(&partner, &partner_ty), (&customer, &customer_ty)]);
+
+        let tokens = info
+            .dispatch(quote! { all() }, |col| {
+                let p = col.predicate(2);
+                quote! { scoped(#p) }
+            })
+            .to_string();
+        assert!(tokens.contains("EntityScope :: All => all ()"));
+        assert!(
+            tokens
+                .contains("EntityScope :: PartnerId (__scope_val) => scoped (\"partner_id = $2\")")
+        );
+        assert!(
+            tokens.contains(
+                "EntityScope :: CustomerId (__scope_val) => scoped (\"customer_id = $2\")"
+            )
+        );
     }
 }

--- a/migrations/20260823000000_multi_scope_test.sql
+++ b/migrations/20260823000000_multi_scope_test.sql
@@ -1,0 +1,19 @@
+CREATE TABLE facilities (
+  id UUID PRIMARY KEY,
+  partner_id UUID NOT NULL,
+  customer_id UUID NOT NULL,
+  status VARCHAR NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_facilities_partner_created_id ON facilities (partner_id, created_at DESC, id DESC);
+CREATE INDEX idx_facilities_customer_created_id ON facilities (customer_id, created_at DESC, id DESC);
+
+CREATE TABLE facility_events (
+  id UUID NOT NULL REFERENCES facilities(id),
+  sequence INT NOT NULL,
+  event_type VARCHAR NOT NULL,
+  event JSONB NOT NULL,
+  context JSONB DEFAULT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(id, sequence)
+);

--- a/tests/entities/facility.rs
+++ b/tests/entities/facility.rs
@@ -1,0 +1,92 @@
+#![allow(dead_code)]
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use es_entity::*;
+
+es_entity::entity_id! { FacilityId }
+es_entity::entity_id! { PartnerId }
+es_entity::entity_id! { CustomerId }
+
+/// Mirrors lana's multi-API shape: a `CreditFacility`-like entity read by an
+/// admin API (`All`), a partner API (`partner_id` scope) and a customer API
+/// (`customer_id` scope) — two independent, disjunctive scope dimensions on
+/// the same repo.
+#[derive(EsEvent, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "FacilityId")]
+pub enum FacilityEvent {
+    Initialized {
+        id: FacilityId,
+        partner_id: PartnerId,
+        customer_id: CustomerId,
+        status: String,
+    },
+}
+
+#[derive(EsEntity, Builder)]
+#[builder(pattern = "owned", build_fn(error = "EntityHydrationError"))]
+pub struct Facility {
+    pub id: FacilityId,
+    pub partner_id: PartnerId,
+    pub customer_id: CustomerId,
+    pub status: String,
+
+    events: EntityEvents<FacilityEvent>,
+}
+
+impl TryFromEvents<FacilityEvent> for Facility {
+    fn try_from_events(events: EntityEvents<FacilityEvent>) -> Result<Self, EntityHydrationError> {
+        let mut builder = FacilityBuilder::default();
+        for event in events.iter_all() {
+            match event {
+                FacilityEvent::Initialized {
+                    id,
+                    partner_id,
+                    customer_id,
+                    status,
+                } => {
+                    builder = builder
+                        .id(*id)
+                        .partner_id(*partner_id)
+                        .customer_id(*customer_id)
+                        .status(status.clone());
+                }
+            }
+        }
+        builder.events(events).build()
+    }
+}
+
+#[derive(Debug, Builder)]
+pub struct NewFacility {
+    #[builder(setter(into))]
+    pub id: FacilityId,
+    #[builder(setter(into))]
+    pub partner_id: PartnerId,
+    #[builder(setter(into))]
+    pub customer_id: CustomerId,
+    #[builder(setter(into))]
+    pub status: String,
+}
+
+impl NewFacility {
+    pub fn builder() -> NewFacilityBuilder {
+        NewFacilityBuilder::default()
+    }
+}
+
+impl IntoEvents<FacilityEvent> for NewFacility {
+    fn into_events(self) -> EntityEvents<FacilityEvent> {
+        EntityEvents::init(
+            self.id,
+            [FacilityEvent::Initialized {
+                id: self.id,
+                partner_id: self.partner_id,
+                customer_id: self.customer_id,
+                status: self.status,
+            }],
+        )
+    }
+}

--- a/tests/entities/mod.rs
+++ b/tests/entities/mod.rs
@@ -1,5 +1,6 @@
 pub mod contact;
 pub mod customer;
+pub mod facility;
 pub mod order;
 pub mod partner;
 pub mod profile;

--- a/tests/index_catalog_verification.rs
+++ b/tests/index_catalog_verification.rs
@@ -96,12 +96,27 @@ async fn specialization_relied_on_indexes_physically_exist() -> anyhow::Result<(
     );
 
     // `tests/scoped_repo_sargable.rs` `Contacts` (scope partner_id, sort
-    // created_at): the scoped Only-arm auto-prefixes the scope column.
+    // created_at): the scoped PartnerId-arm auto-prefixes the scope column.
     let contacts = index_key_columns(&mut conn, "contacts").await?;
     assert!(
         covered(&contacts, &["partner_id"], "created_at"),
         "contacts must have an index covering (partner_id, created_at, ...); \
          got {contacts:?}"
+    );
+
+    // `tests/multi_scoped_repo.rs` `Facilities` (scope partner_id AND
+    // customer_id, sort created_at): each dimension's arm is checked
+    // independently against the catalog, so both must be covered.
+    let facilities = index_key_columns(&mut conn, "facilities").await?;
+    assert!(
+        covered(&facilities, &["partner_id"], "created_at"),
+        "facilities must have an index covering (partner_id, created_at, ...); \
+         got {facilities:?}"
+    );
+    assert!(
+        covered(&facilities, &["customer_id"], "created_at"),
+        "facilities must have an index covering (customer_id, created_at, ...); \
+         got {facilities:?}"
     );
 
     // Newly-permitted shape (#185): a bare `(status)` index covers the status

--- a/tests/multi_scoped_repo.rs
+++ b/tests/multi_scoped_repo.rs
@@ -29,6 +29,42 @@ impl Facilities {
     }
 }
 
+/// Same table as [`Facilities`], but the partner dimension's enum variant is
+/// renamed via `scope(variant = "Partner")` — proves the override produces a
+/// real, working dispatch arm end-to-end (SQL + `From` conversion), not just
+/// codegen tokens. `customer_id` is left at its default (`CustomerId`) to
+/// prove overridden and defaulted columns compose on the same repo.
+///
+/// Wrapped in its own module: the derive generates entity-named companion
+/// types (`FacilityScope`, `FacilityFindError`, ...) keyed off `entity`, not
+/// the repo struct name, so a second `entity = "Facility"` repo in the same
+/// scope as [`Facilities`] would collide.
+pub mod overridden_scope {
+    use sqlx::PgPool;
+
+    use super::entities::facility::*;
+    use es_entity::*;
+
+    #[derive(EsRepo, Debug)]
+    #[es_repo(
+        entity = "Facility",
+        columns(
+            partner_id(ty = "PartnerId", scope(variant = "Partner")),
+            customer_id(ty = "CustomerId", scope),
+            status(ty = "String"),
+        )
+    )]
+    pub struct FacilitiesByOverriddenScope {
+        pool: PgPool,
+    }
+
+    impl FacilitiesByOverriddenScope {
+        pub fn new(pool: PgPool) -> Self {
+            Self { pool }
+        }
+    }
+}
+
 async fn seed_facilities(
     repo: &Facilities,
     partner_id: PartnerId,
@@ -311,6 +347,49 @@ async fn cursor_replay_across_dimensions_never_widens() -> anyhow::Result<()> {
         )
         .await?;
     assert!(ret.entities.iter().all(|f| f.customer_id == customer_x));
+
+    Ok(())
+}
+
+/// `scope(variant = "Partner")` end-to-end: the overridden variant name
+/// dispatches real, correctly-scoped SQL — not just distinctive codegen.
+#[tokio::test]
+async fn scope_variant_override_dispatches_correctly() -> anyhow::Result<()> {
+    use overridden_scope::*;
+
+    let pool = helpers::init_pool().await?;
+    let facilities = FacilitiesByOverriddenScope::new(pool);
+
+    let partner_a = PartnerId::new();
+    let partner_b = PartnerId::new();
+    let customer_x = CustomerId::new();
+
+    let id_a = FacilityId::new();
+    let new = NewFacility::builder()
+        .id(id_a)
+        .partner_id(partner_a)
+        .customer_id(customer_x)
+        .status("active")
+        .build()
+        .unwrap();
+    facilities.create(new).await?;
+
+    // raw id routes through `From<PartnerId> for FacilityScope` into the
+    // overridden `Partner` variant
+    let found = facilities.find_by_id(partner_a, id_a).await?;
+    assert_eq!(found.partner_id, partner_a);
+
+    // explicit overridden-variant spelling
+    facilities
+        .find_by_id(FacilityScope::Partner(partner_a), id_a)
+        .await?;
+
+    // foreign partner under the overridden variant still misses correctly
+    let err = facilities.find_by_id(partner_b, id_a).await;
+    assert!(matches!(err, Err(FacilityFindError::NotFound { .. })));
+
+    // the un-overridden customer dimension on the same repo still works
+    facilities.find_by_id(customer_x, id_a).await?;
 
     Ok(())
 }

--- a/tests/multi_scoped_repo.rs
+++ b/tests/multi_scoped_repo.rs
@@ -1,0 +1,316 @@
+mod entities;
+mod helpers;
+
+use sqlx::PgPool;
+
+use entities::facility::*;
+use es_entity::*;
+
+/// Two-dimension scoped repo mirroring lana's admin/partner/customer split:
+/// `partner_id` and `customer_id` are both `scope` columns. Reads are scoped
+/// by exactly one dimension (`PartnerId(_)`, `CustomerId(_)`) or by `All` —
+/// never by both at once (disjunctive scoping).
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "Facility",
+    columns(
+        partner_id(ty = "PartnerId", scope),
+        customer_id(ty = "CustomerId", scope),
+        status(ty = "String", list_for(by(created_at))),
+    )
+)]
+pub struct Facilities {
+    pool: PgPool,
+}
+
+impl Facilities {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+async fn seed_facilities(
+    repo: &Facilities,
+    partner_id: PartnerId,
+    customer_id: CustomerId,
+    specs: &[&str],
+) -> anyhow::Result<Vec<FacilityId>> {
+    let mut ids = Vec::new();
+    for status in specs {
+        let id = FacilityId::new();
+        let new = NewFacility::builder()
+            .id(id)
+            .partner_id(partner_id)
+            .customer_id(customer_id)
+            .status(*status)
+            .build()
+            .unwrap();
+        // create is deliberately unscoped: both scope columns are ordinary
+        // NewEntity data.
+        repo.create(new).await?;
+        ids.push(id);
+    }
+    Ok(ids)
+}
+
+#[tokio::test]
+async fn multi_scoped_point_reads() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let facilities = Facilities::new(pool);
+
+    let partner_a = PartnerId::new();
+    let partner_b = PartnerId::new();
+    let customer_x = CustomerId::new();
+    let customer_y = CustomerId::new();
+
+    let ids_ax = seed_facilities(&facilities, partner_a, customer_x, &["active"]).await?;
+    let ids_by = seed_facilities(&facilities, partner_b, customer_y, &["active"]).await?;
+    let (id_ax, id_by) = (ids_ax[0], ids_by[0]);
+
+    // own dimension: raw ids route to the right variant via `From`
+    let found = facilities.find_by_id(partner_a, id_ax).await?;
+    assert_eq!(found.partner_id, partner_a);
+    let found = facilities.find_by_id(customer_x, id_ax).await?;
+    assert_eq!(found.customer_id, customer_x);
+
+    // explicit enum forms
+    facilities
+        .find_by_id(FacilityScope::PartnerId(partner_a), id_ax)
+        .await?;
+    facilities
+        .find_by_id(FacilityScope::CustomerId(customer_x), id_ax)
+        .await?;
+
+    // cross-dimension / foreign misses look identical to a missing row
+    let err = facilities.find_by_id(partner_b, id_ax).await;
+    assert!(matches!(err, Err(FacilityFindError::NotFound { .. })));
+    assert!(
+        facilities
+            .maybe_find_by_id(customer_y, id_ax)
+            .await?
+            .is_none()
+    );
+
+    // All sees both rows
+    facilities.find_by_id(FacilityScope::All, id_ax).await?;
+    facilities.find_by_id(FacilityScope::All, id_by).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn multi_scoped_find_all_intersects_per_dimension() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let facilities = Facilities::new(pool);
+
+    let partner_a = PartnerId::new();
+    let partner_b = PartnerId::new();
+    let customer_x = CustomerId::new();
+    let customer_y = CustomerId::new();
+
+    let ids_ax = seed_facilities(&facilities, partner_a, customer_x, &["active", "active"]).await?;
+    let ids_by = seed_facilities(&facilities, partner_b, customer_y, &["active"]).await?;
+
+    let all_ids: Vec<FacilityId> = ids_ax.iter().chain(ids_by.iter()).copied().collect();
+
+    // PartnerId(a): only that partner's rows — the other dimension's rows
+    // are silently absent
+    let found = facilities.find_all::<Facility>(partner_a, &all_ids).await?;
+    assert_eq!(found.len(), 2);
+    assert!(ids_ax.iter().all(|id| found.contains_key(id)));
+    assert!(ids_by.iter().all(|id| !found.contains_key(id)));
+
+    // CustomerId(y): only that customer's rows
+    let found = facilities
+        .find_all::<Facility>(customer_y, &all_ids)
+        .await?;
+    assert_eq!(found.len(), 1);
+    assert!(found.contains_key(&ids_by[0]));
+
+    // All: everything
+    let found = facilities
+        .find_all::<Facility>(FacilityScope::All, &all_ids)
+        .await?;
+    assert_eq!(found.len(), 3);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn multi_scoped_lists_paginate_per_dimension() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let facilities = Facilities::new(pool);
+
+    let partner_a = PartnerId::new();
+    let customer_x = CustomerId::new();
+    let customer_y = CustomerId::new();
+
+    // same partner, split across two customers
+    let ids_x = seed_facilities(&facilities, partner_a, customer_x, &["active", "active"]).await?;
+    let ids_y = seed_facilities(&facilities, partner_a, customer_y, &["active"]).await?;
+
+    // PartnerId(a) sees all 3 rows, paginated
+    let mut collected = Vec::new();
+    let mut after: Option<facility_cursor::FacilityByCreatedAtCursor> = None;
+    loop {
+        let ret = facilities
+            .list_by_created_at(
+                partner_a,
+                PaginatedQueryArgs { first: 2, after },
+                ListDirection::Descending,
+            )
+            .await?;
+        collected.extend(ret.entities.iter().map(|f| f.id));
+        if !ret.has_next_page {
+            break;
+        }
+        after = ret.end_cursor;
+    }
+    let expected: std::collections::HashSet<_> =
+        ids_x.iter().chain(ids_y.iter()).copied().collect();
+    let collected: std::collections::HashSet<_> = collected.into_iter().collect();
+    assert_eq!(collected, expected);
+
+    // CustomerId(x) sees only its own 2 rows
+    let ret = facilities
+        .list_by_created_at(
+            customer_x,
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert_eq!(ret.entities.len(), 2);
+    assert!(ret.entities.iter().all(|f| f.customer_id == customer_x));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn multi_scoped_reads_in_op() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let facilities = Facilities::new(pool);
+
+    let partner_a = PartnerId::new();
+    let partner_b = PartnerId::new();
+    let customer_x = CustomerId::new();
+    let ids = seed_facilities(&facilities, partner_a, customer_x, &["active"]).await?;
+
+    let mut op = facilities.begin_op().await?;
+    facilities
+        .find_by_id_in_op(&mut op, partner_a, ids[0])
+        .await?;
+    facilities
+        .find_by_id_in_op(&mut op, customer_x, ids[0])
+        .await?;
+    assert!(
+        facilities
+            .maybe_find_by_id_in_op(&mut op, partner_b, ids[0])
+            .await?
+            .is_none()
+    );
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn multi_scoped_bound_view() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let facilities = Facilities::new(pool);
+
+    let partner_a = PartnerId::new();
+    let customer_x = CustomerId::new();
+    let customer_y = CustomerId::new();
+    seed_facilities(&facilities, partner_a, customer_x, &["active"]).await?;
+    seed_facilities(&facilities, partner_a, customer_y, &["active"]).await?;
+
+    let view = facilities.scoped(customer_x);
+    assert!(matches!(view.scope(), FacilityScope::CustomerId(c) if c == customer_x));
+
+    let ret = view
+        .list_by_created_at(
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert!(ret.entities.iter().all(|f| f.customer_id == customer_x));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn multi_scoped_filters_compose_per_dimension() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let facilities = Facilities::new(pool);
+
+    let partner_a = PartnerId::new();
+    let customer_x = CustomerId::new();
+    seed_facilities(&facilities, partner_a, customer_x, &["active", "inactive"]).await?;
+
+    let ret = facilities
+        .list_for_status_by_created_at(
+            customer_x,
+            "active",
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert_eq!(ret.entities.len(), 1);
+    assert_eq!(ret.entities[0].status, "active");
+    assert_eq!(ret.entities[0].customer_id, customer_x);
+
+    Ok(())
+}
+
+/// A cursor minted under one dimension replayed under another repositions
+/// pagination but never widens the result set — every page's SQL carries the
+/// scope conjunct for the dimension actually passed at call time.
+#[tokio::test]
+async fn cursor_replay_across_dimensions_never_widens() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let facilities = Facilities::new(pool);
+
+    let partner_a = PartnerId::new();
+    let customer_x = CustomerId::new();
+    let customer_y = CustomerId::new();
+    seed_facilities(&facilities, partner_a, customer_x, &["active", "active"]).await?;
+    seed_facilities(&facilities, partner_a, customer_y, &["active"]).await?;
+
+    // mint a cursor under PartnerId(a)
+    let ret = facilities
+        .list_by_created_at(
+            partner_a,
+            PaginatedQueryArgs {
+                first: 1,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    let cursor = ret.end_cursor.expect("expected a next page");
+
+    // replay it under CustomerId(x): every row returned must still belong to
+    // customer_x — the foreign cursor repositions but cannot leak rows
+    let ret = facilities
+        .list_by_created_at(
+            customer_x,
+            PaginatedQueryArgs {
+                first: 100,
+                after: Some(cursor),
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert!(ret.entities.iter().all(|f| f.customer_id == customer_x));
+
+    Ok(())
+}

--- a/tests/scoped_repo.rs
+++ b/tests/scoped_repo.rs
@@ -7,15 +7,16 @@ use entities::contact::*;
 use es_entity::*;
 
 /// Partner-scoped repo: every generated read fn requires a leading
-/// `scope: impl Into<ContactScope>` argument. `Only(partner_id)` filters all
-/// reads by the scope column; `All` reads across scopes. Writes (`create`,
-/// `update`, `delete`) keep their unscoped signatures — mutations operate on
-/// entities that could only have been obtained through a scoped read.
+/// `scope: impl Into<ContactScope>` argument. `PartnerId(partner_id)` filters
+/// all reads by the scope column; `All` reads across scopes. Writes
+/// (`create`, `update`, `delete`) keep their unscoped signatures — mutations
+/// operate on entities that could only have been obtained through a scoped
+/// read.
 ///
 /// The scope column additionally opts into `find_by`/`list_for`: callers
 /// filter by `partner_id` through the normal query surface, composing with
-/// the scope — under `Only(a)` the column is double-specified (filter AND
-/// scope conjunct), so a mismatching caller value is a contradictory
+/// the scope — under `PartnerId(a)` the column is double-specified (filter
+/// AND scope conjunct), so a mismatching caller value is a contradictory
 /// predicate returning an empty result.
 #[derive(EsRepo, Debug)]
 #[es_repo(
@@ -71,12 +72,13 @@ async fn scoped_point_reads() -> anyhow::Result<()> {
     let (id_a, id_b) = (ids_a[0], ids_b[0]);
 
     // own scope: found — `impl Into<ContactScope>` accepts the partner id
-    // directly (From<PartnerId> => Only), a reference, or the explicit enum.
+    // directly (From<PartnerId> => PartnerId), a reference, or the explicit
+    // enum.
     let found = contacts.find_by_id(partner_a, id_a).await?;
     assert_eq!(found.partner_id, partner_a);
     contacts.find_by_id(&partner_a, id_a).await?;
     contacts
-        .find_by_id(ContactScope::Only(partner_a), id_a)
+        .find_by_id(ContactScope::PartnerId(partner_a), id_a)
         .await?;
 
     // foreign scope: missing and not-yours look identical
@@ -142,8 +144,8 @@ async fn scoped_find_all_drops_foreign_ids() -> anyhow::Result<()> {
 
     let all_ids: Vec<ContactId> = ids_a.iter().chain(ids_b.iter()).copied().collect();
 
-    // Only(a): foreign ids are silently absent — missing and not-yours look
-    // identical.
+    // PartnerId(a): foreign ids are silently absent — missing and not-yours
+    // look identical.
     let found = contacts.find_all::<Contact>(partner_a, &all_ids).await?;
     assert_eq!(found.len(), 2);
     assert!(ids_a.iter().all(|id| found.contains_key(id)));
@@ -169,8 +171,8 @@ async fn scoped_list_by_paginates_within_scope() -> anyhow::Result<()> {
     let ids_a = seed_contacts(&contacts, partner_a, &specs).await?;
     seed_contacts(&contacts, partner_b, &specs).await?;
 
-    // paginate under Only(a) with a page size that forces both the page-1
-    // and the cursor-page specialized variants to execute
+    // paginate under PartnerId(a) with a page size that forces both the
+    // page-1 and the cursor-page specialized variants to execute
     let mut collected = Vec::new();
     let mut after: Option<contact_cursor::ContactByCreatedAtCursor> = None;
     let mut pages = 0;
@@ -335,7 +337,7 @@ async fn foreign_cursor_cannot_leak_rows() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The `Only` arm's page-1 list SQL must be sargable against a
+/// The `PartnerId` arm's page-1 list SQL must be sargable against a
 /// `(partner_id, created_at, id)` composite index — the scope conjunct is a
 /// plain equality, not a COALESCE catch-all.
 #[tokio::test]
@@ -346,7 +348,7 @@ async fn scoped_list_query_plan_uses_composite_index() -> anyhow::Result<()> {
     sqlx::query("SET LOCAL enable_seqscan = off")
         .execute(&mut *tx)
         .await?;
-    // The exact page-1 `Only` arm SQL shape generated for
+    // The exact page-1 `PartnerId` arm SQL shape generated for
     // `list_by_created_at`.
     let rows: Vec<(String,)> = sqlx::query_as(
         "EXPLAIN SELECT created_at, id FROM contacts WHERE partner_id = $1 \
@@ -397,7 +399,7 @@ async fn scoped_view_delegates() -> anyhow::Result<()> {
     let ids_b = seed_contacts(&contacts, partner_b, &[("v3", "active")]).await?;
 
     let view = contacts.scoped(partner_a);
-    assert!(matches!(view.scope(), ContactScope::Only(p) if p == partner_a));
+    assert!(matches!(view.scope(), ContactScope::PartnerId(p) if p == partner_a));
 
     // point reads — no scope argument at the call sites
     let contact = view.find_by_id(ids_a[0]).await?;
@@ -477,7 +479,7 @@ async fn scoped_view_delegates() -> anyhow::Result<()> {
 
 /// The scope column opted into `find_by = true`: the lookup composes with
 /// the scope via the double-specified conjunct (`partner_id = $1 AND
-/// partner_id = $2`). Under `Only(a)` a lookup of `b != a` is a
+/// partner_id = $2`). Under `PartnerId(a)` a lookup of `b != a` is a
 /// contradictory predicate — not-found, indistinguishable from missing.
 #[tokio::test]
 async fn scope_column_find_by_composes() -> anyhow::Result<()> {
@@ -495,11 +497,11 @@ async fn scope_column_find_by_composes() -> anyhow::Result<()> {
         .await?;
     assert_eq!(found.partner_id, partner_a);
 
-    // Only(a) + a: match — behaves like the scoped read
+    // PartnerId(a) + a: match — behaves like the scoped read
     let found = contacts.find_by_partner_id(partner_a, partner_a).await?;
     assert_eq!(found.partner_id, partner_a);
 
-    // Only(a) + b: mismatch — not-found, indistinguishable from missing
+    // PartnerId(a) + b: mismatch — not-found, indistinguishable from missing
     let err = contacts.find_by_partner_id(partner_a, partner_b).await;
     assert!(matches!(err, Err(ContactFindError::NotFound { .. })));
     assert!(
@@ -518,8 +520,8 @@ async fn scope_column_find_by_composes() -> anyhow::Result<()> {
 ///
 /// - `All` + `None`      → unfiltered
 /// - `All` + `Some(p)`   → rows of `p`
-/// - `Only(a)` + `None`  → rows of `a`
-/// - `Only(a)` + `Some(b)` → `partner_id = b AND partner_id = a` — empty
+/// - `PartnerId(a)` + `None`  → rows of `a`
+/// - `PartnerId(a)` + `Some(b)` → `partner_id = b AND partner_id = a` — empty
 ///   unless `a == b` (a caller filter can narrow but never widen the scope)
 #[tokio::test]
 async fn scope_column_filter_combinations() -> anyhow::Result<()> {
@@ -577,19 +579,19 @@ async fn scope_column_filter_combinations() -> anyhow::Result<()> {
     assert_eq!(ret.entities.len(), 2);
     assert!(ret.entities.iter().all(|c| c.partner_id == partner_a));
 
-    // Only(a) + None: the scope alone filters
+    // PartnerId(a) + None: the scope alone filters
     let ret = contacts
         .list_for_filters(partner_a, ContactFilters::default(), sort(), query())
         .await?;
     assert_eq!(ret.entities.len(), 2);
 
-    // Only(a) + Some(a): match — same result as the scope alone
+    // PartnerId(a) + Some(a): match — same result as the scope alone
     let ret = contacts
         .list_for_filters(partner_a, partner_filter(partner_a), sort(), query())
         .await?;
     assert_eq!(ret.entities.len(), 2);
 
-    // Only(a) + Some(b): a caller filter can never widen the scope — the
+    // PartnerId(a) + Some(b): a caller filter can never widen the scope — the
     // mismatch honestly returns nothing instead of being silently ignored
     let ret = contacts
         .list_for_filters(partner_a, partner_filter(partner_b), sort(), query())

--- a/tests/scoped_repo_by_id.rs
+++ b/tests/scoped_repo_by_id.rs
@@ -236,3 +236,68 @@ async fn id_scoped_view_delegates() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Same table as [`Partners`], but the tenancy-root variant is renamed via
+/// `id(scope(variant = "Tenant"))` — proves the override reaches the
+/// macro-owned `id` column, not just ordinary scope columns. Wrapped in its
+/// own module: both repos share `entity = "Partner"`, so their
+/// derive-generated companion types (`PartnerScope`, `PartnerFindError`, ...)
+/// would otherwise collide.
+pub mod overridden_id_scope {
+    use sqlx::PgPool;
+
+    use super::entities::partner::*;
+    use es_entity::*;
+
+    #[derive(EsRepo, Debug)]
+    #[es_repo(
+        entity = "Partner",
+        columns(id(scope(variant = "Tenant")), name(ty = "String"))
+    )]
+    pub struct PartnersByOverriddenScope {
+        pool: PgPool,
+    }
+
+    impl PartnersByOverriddenScope {
+        pub fn new(pool: PgPool) -> Self {
+            Self { pool }
+        }
+    }
+}
+
+#[tokio::test]
+async fn id_scope_variant_override_dispatches_correctly() -> anyhow::Result<()> {
+    use overridden_id_scope::*;
+
+    let pool = helpers::init_pool().await?;
+    let partners = PartnersByOverriddenScope::new(pool);
+
+    let id = PartnerId::new();
+    let new = NewPartner::builder()
+        .id(id)
+        .name(format!("tenant-{id}"))
+        .build()
+        .unwrap();
+    partners.create(new).await?;
+
+    // raw id routes through `From<PartnerId> for PartnerScope` into the
+    // overridden `Tenant` variant
+    let found = partners.find_by_id(id, id).await?;
+    assert_eq!(found.id, id);
+
+    // explicit overridden-variant spelling
+    partners.find_by_id(PartnerScope::Tenant(id), id).await?;
+
+    // a foreign id under the overridden variant still collapses to
+    // self-or-nothing, same as the un-overridden `Id` variant does
+    let foreign = PartnerId::new();
+    assert!(matches!(
+        partners.find_by_id(foreign, id).await,
+        Err(PartnerFindError::NotFound { .. })
+    ));
+
+    // All still reads across scopes
+    partners.find_by_id(PartnerScope::All, id).await?;
+
+    Ok(())
+}

--- a/tests/scoped_repo_by_id.rs
+++ b/tests/scoped_repo_by_id.rs
@@ -9,7 +9,7 @@ use es_entity::*;
 /// Id-scoped repo — the tenancy-root variant of a scoped repository. The
 /// entity has no separate tenant column: its rows' scope value is its own
 /// `id`, marked via `id(scope)`. Every generated read fn requires a leading
-/// `scope: impl Into<PartnerScope>` argument; under `Only(id)` every query
+/// `scope: impl Into<PartnerScope>` argument; under `Id(id)` every query
 /// carries an `id = $n` conjunct, so reads collapse to self-or-nothing —
 /// missing and not-yours look identical. `All` reads across scopes. Writes
 /// (`create`, `update`, `delete`) keep their unscoped signatures.
@@ -46,12 +46,12 @@ async fn id_scoped_point_reads() -> anyhow::Result<()> {
     let partner_b = seed_partner(&partners, "b").await?;
 
     // own scope: found — `impl Into<PartnerScope>` accepts the id directly
-    // (From<PartnerId> => Only), a reference, or the explicit enum.
+    // (From<PartnerId> => Id), a reference, or the explicit enum.
     let found = partners.find_by_id(partner_a, partner_a).await?;
     assert_eq!(found.id, partner_a);
     partners.find_by_id(&partner_a, partner_a).await?;
     partners
-        .find_by_id(PartnerScope::Only(partner_a), partner_a)
+        .find_by_id(PartnerScope::Id(partner_a), partner_a)
         .await?;
 
     // foreign scope: missing and not-yours look identical
@@ -114,7 +114,7 @@ async fn id_scoped_find_all_intersects_to_own_row() -> anyhow::Result<()> {
     let partner_b = seed_partner(&partners, "fb").await?;
     let all_ids = [partner_a, partner_b];
 
-    // Only(a): at most the own row — foreign ids are silently absent.
+    // Id(a): at most the own row — foreign ids are silently absent.
     let found = partners.find_all::<Partner>(partner_a, &all_ids).await?;
     assert_eq!(found.len(), 1);
     assert!(found.contains_key(&partner_a));
@@ -136,7 +136,7 @@ async fn id_scoped_lists_return_own_row() -> anyhow::Result<()> {
     let partner_a = seed_partner(&partners, "la").await?;
     let partner_b = seed_partner(&partners, "lb").await?;
 
-    // Only(a): exactly the own row, whatever the page size.
+    // Id(a): exactly the own row, whatever the page size.
     let ret = partners
         .list_by_created_at(
             partner_a,

--- a/tests/scoped_repo_sargable.rs
+++ b/tests/scoped_repo_sargable.rs
@@ -7,11 +7,11 @@ use entities::contact::*;
 use es_entity::*;
 
 /// The scoped `Contacts` repo whose migrations declare a
-/// `(partner_id, created_at, id)` index, so the scoped `Only`-arm
+/// `(partner_id, created_at, id)` index, so the scoped `PartnerId`-arm
 /// no-filter combo is specialized (the scope column is auto-prefixed): the
 /// scope × filter composition must hold through the specialized unified query,
 /// not just the catch-all fallback (exercised by `scoped_repo.rs`). The scope
-/// column doubles as a `list_for` filter column; under `Only` it is
+/// column doubles as a `list_for` filter column; under `PartnerId(_)` it is
 /// double-specified (filter AND scope conjunct) — a mismatch is a
 /// contradictory predicate returning no
 /// rows.
@@ -109,7 +109,7 @@ async fn sargable_scope_column_filter_combinations() -> anyhow::Result<()> {
     assert_eq!(ret.entities.len(), 2);
     assert!(ret.entities.iter().all(|c| c.partner_id == partner_a));
 
-    // Only(a) + Some(a): match — the conjunct is satisfiable, same rows
+    // PartnerId(a) + Some(a): match — the conjunct is satisfiable, same rows
     let ret = contacts
         .list_for_filters(
             partner_a,
@@ -123,7 +123,7 @@ async fn sargable_scope_column_filter_combinations() -> anyhow::Result<()> {
         .await?;
     assert_eq!(ret.entities.len(), 2);
 
-    // Only(a) + Some(b): mismatch — contradictory conjunct, empty
+    // PartnerId(a) + Some(b): mismatch — contradictory conjunct, empty
     let ret = contacts
         .list_for_filters(
             partner_a,


### PR DESCRIPTION
## Summary

Extends es-entity's repo `scope` feature from one scope column to N. The
generated `{Entity}Scope` enum now has one named variant per scope column
(UpperCamel of the column name) plus `All`, instead of the single-column
`Only(T)`. Every read fn dispatches at runtime over N+1 static,
compile-time-checked, sargable query variants — one per scope dimension.

This lets one repo serve several independent principal kinds over the same
rows — e.g. an admin API (`All`), a partner API (`PartnerId(id)`), and a
customer API (`CustomerId(id)`) — with the compiler still enforcing that
every read carries a scope decision. The dimensions are **disjunctive**: a
read is scoped by exactly one column or by `All`, never by more than one
column at once.

## ⚠️ BREAKING CHANGE — shipped as a patch release

`{Entity}Scope::Only(v)` no longer exists, **including for existing
single-scope-column repos**. It is renamed to `{Entity}Scope::{Column}(v)`:

```rust
// before
ContactScope::Only(partner_id)
PartnerScope::Only(partner_id)   // id(scope) tenancy root

// after
ContactScope::PartnerId(partner_id)
PartnerScope::Id(partner_id)     // id(scope) tenancy root
```

**Unaffected**: `impl Into<{Entity}Scope>` call sites passing a raw id
directly (`repo.find_by_id(partner_id, id)`), and `{Entity}Scope::All`.
Only explicit `::Only(...)` spellings need a mechanical rename.

This is a breaking rename intentionally released as a **patch** (per
maintainer decision) rather than a minor version bump — hence no `!` in
this PR title/commit. Consumers adopting the new version need only the
mechanical `Only` → named-variant rename at call sites that spell out the
enum explicitly.

## What's new

- **Validation**: any number of columns may be marked `scope`. They must
  have pairwise-distinct Rust types (the generated `From<T>` conversions
  dispatch on type — same-typed columns would produce conflicting impls)
  and pairwise-distinct UpperCamel variant names, none colliding with the
  reserved `All` variant. Per-column checks are unchanged (non-nullable,
  non-`Forgettable`, not the parent column, no nested repos).
- **All five read emitters** (`find_by`, `find_all`, `list_by`, `list_for`,
  `list_for_filters`) generalize from a single `Option<&ScopeInfo>` scoped
  arm to one arm per scope column, reusing the same query-construction
  logic per column.
- **`list_for_filters` specialization** is decided **independently per
  scope dimension** against the physical index catalog — a repo may have
  partner-led composite indexes but no customer-led ones yet, in which case
  the partner arm specializes while the customer arm honestly falls back
  to the non-sargable `COALESCE` query until its indexes exist.
- New two-dimension test fixture (`Facilities`: `partner_id` +
  `customer_id`) and `tests/multi_scoped_repo.rs` covering per-dimension
  point reads, `find_all` intersection, pagination, the bound view,
  filter composition, and cursor-replay-never-widens.
- `book/src/scoped-repositories.md`: new "Multiple scope dimensions"
  section; renamed `Only` references throughout.

## Explicitly out of scope

- Conjunctive scoping (a single read scoped by more than one column at
  once — e.g. "partner acting on behalf of one specific customer").
- Nullable scope columns (still rejected).
- Same-Rust-type scope columns (rejected with a clear error).

## Verification

- `cargo test -p es-entity-macros` — 152 unit tests green, including new
  multi-scope codegen tests and a revert-to-red check (temporarily
  hard-coded the scope predicate to always target `partner_id`; 5/7 new
  integration tests failed with the correct leak/not-found symptom,
  confirming they discriminate the per-column dispatch; reverted).
- `nix run .#nextest` — full live-Postgres workspace suite green
  (includes mdbook tests, doctests, `cargo doc`).
- `cargo fmt` — clean.

`nix flake check` / clippy have not yet been run in this session; CI is
authoritative per this repo's push policy (this PR is a draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking change to generated tenancy-scope enums and SQL dispatch that gates every scoped read. Incorrect per-column conjuncts would leak or hide rows across tenants.
> 
> **Overview**
> Allows **N independent `scope` columns** on one repo so the same rows can be read as admin (`All`), partner, customer, etc. Dimensions are **disjunctive**: a read is scoped by exactly one column or `All`, never both.
> 
> **Breaking:** `{Entity}Scope::Only(v)` is gone even for single-column repos. Variants are now named after the column (`PartnerId(v)`, `Id(v)` for `id(scope)`). Raw `impl Into` call sites are unchanged; only explicit `::Only(...)` needs a rename. Optional `scope(variant = "...")` (including `id(scope(variant = "..."))`) overrides the variant name.
> 
> Read emitters (`find_by` / `find_all` / `list_*`) dispatch one static sargable SQL arm per column. `list_for_filters` specialization is **per dimension** against the index catalog. Compile-time checks: distinct Rust types, distinct variant names, no collision with `All`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe5ba54b21fc8a65f5002368b4d362fe5b5ed233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->