### PR TITLE
feat(macros): update_all_mut_in_op accepts a chained iterator

### DIFF
--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -49,12 +49,29 @@ impl<'a> From<&'a RepositoryOptions> for UpdateAllFn<'a> {
 /// Which shape of parent collection a generated bulk-update function
 /// operates on.
 ///
-/// `update_all_in_op` is the top-level, caller-facing batch API: it owns a
-/// contiguous `&mut [Entity]`. `update_all_mut_in_op` is the shape needed to
-/// batch *nested children across many parents*: each parent owns its own
-/// children (in its own `HashMap`), so gathering "every persisted child that
-/// needs updating, across the whole parent batch" can only ever produce a
-/// `Vec` of scattered `&mut Entity` borrows, never a contiguous slice.
+/// `update_all_in_op` is the top-level API for a caller that already owns a
+/// contiguous, owned collection: it takes `&mut [Entity]` and never copies
+/// or reallocates it. `update_all_mut_in_op` is the shape needed to batch
+/// *nested children across many parents*: each parent owns its own children
+/// (in its own `HashMap`), so gathering "every persisted child that needs
+/// updating, across the whole parent batch" can only ever produce scattered
+/// `&mut Entity` borrows, never a contiguous slice — there is no owned
+/// collection for a caller to hand over `&mut` to in the first place.
+///
+/// Because of that, `update_all_mut_in_op` accepts `impl IntoIterator<Item =
+/// &mut Entity>` rather than a concrete `Vec`: a caller assembling those
+/// scattered borrows (e.g. `parents.iter_mut().flat_map(|p|
+/// p.children.values_mut())`) can pass the chain straight through instead of
+/// collecting it themselves first. The *internal* representation is still a
+/// `Vec<&mut Entity>` — the body below needs multiple independent passes
+/// over `entities` (SQL building, marking events persisted, computing the
+/// returned count, and, when this entity itself has nested children, the
+/// nested phase), which a bare `IntoIterator` only supports once — so the
+/// very first thing the generated `RefVec` body does is `.into_iter().collect()`
+/// into a `Vec` shadowing the parameter. Every use of `entities` after that
+/// point operates on that `Vec`, so it reads exactly like `update_all_in_op`
+/// (and like this fn did before the parameter type changed) — only the
+/// entry point moved from "caller collects" to "callee collects".
 ///
 /// Both variants share the exact same SQL-building logic below; only the
 /// outer signature and how `entities` is iterated differ, via `iter_ref` /
@@ -64,7 +81,9 @@ impl<'a> From<&'a RepositoryOptions> for UpdateAllFn<'a> {
 /// unify against a concrete `&mut Entity`, not `&mut &mut Entity`), so the
 /// `RefVec` adapters reborrow down to a single level with `.map(|e| &mut
 /// **e)` / `.map(|e| &**e)`, making the entity-loop bodies below identical
-/// text for both modes.
+/// text for both modes. That reborrow is unaffected by where the `Vec` comes
+/// from — collected internally now, formerly passed in — since it only ever
+/// operates on the `Vec`, never on the caller's original iterator.
 enum BatchMode {
     OwnedSlice,
     RefVec,
@@ -82,16 +101,29 @@ impl UpdateAllFn<'_> {
         let entity = self.entity;
         let modify_error = &self.modify_error;
 
-        let (fn_name, entities_param, iter_ref, iter_mut_ref) = match mode {
+        let (fn_name, entities_param, entities_prelude, iter_ref, iter_mut_ref) = match mode {
             BatchMode::OwnedSlice => (
                 quote::format_ident!("update_all_in_op"),
                 quote! { entities: &mut [#entity] },
+                None,
                 quote! { entities.iter() },
                 quote! { entities.iter_mut() },
             ),
             BatchMode::RefVec => (
                 quote::format_ident!("update_all_mut_in_op"),
-                quote! { mut entities: Vec<&mut #entity> },
+                quote! { entities: impl IntoIterator<Item = &mut #entity> },
+                // The caller hands us anything iterable once (a `Vec`, an
+                // array, or — the motivating case — a `flat_map` chain
+                // scattering across many parents' `HashMap`s); we collect it
+                // into an owned `Vec` exactly once, right here, and every use
+                // of `entities` below this point operates on that `Vec`.
+                // Shadowing the parameter name means the reborrow adapters
+                // and every later `entities.iter()`/`entities.iter_mut()`
+                // call are unchanged text from before this Vec was built
+                // internally rather than passed in.
+                Some(quote! {
+                    let mut entities: Vec<&mut #entity> = entities.into_iter().collect();
+                }),
                 quote! { entities.iter().map(|e| &**e) },
                 quote! { entities.iter_mut().map(|e| &mut **e) },
             ),
@@ -258,7 +290,7 @@ impl UpdateAllFn<'_> {
         };
 
         #[cfg(feature = "instrument")]
-        let (instrument_attr, error_recording) = {
+        let (instrument_attr, error_recording, count_recording) = {
             let entity_name = entity.to_string();
             let repo_name = &self.repo_name_snake;
             let span_suffix = match mode {
@@ -266,9 +298,23 @@ impl UpdateAllFn<'_> {
                 BatchMode::RefVec => "update_all_mut",
             };
             let span_name = format!("{}.{}", repo_name, span_suffix);
+            // `OwnedSlice`'s `entities: &mut [Entity]` has a `.len()` at
+            // function entry, so its `count` field is populated immediately.
+            // `RefVec`'s `entities: impl IntoIterator<...>` does not — the
+            // count is only known once it's collected into a `Vec` inside
+            // the async body, so that variant records it there instead.
+            let count_field = match mode {
+                BatchMode::OwnedSlice => quote! { count = entities.len(), },
+                BatchMode::RefVec => quote! { count = tracing::field::Empty, },
+            };
+            let count_recording = matches!(mode, BatchMode::RefVec).then(|| {
+                quote! {
+                    tracing::Span::current().record("count", entities.len());
+                }
+            });
             (
                 quote! {
-                    #[tracing::instrument(name = #span_name, skip_all, fields(entity = #entity_name, count = entities.len(), error = tracing::field::Empty, exception.message = tracing::field::Empty, exception.type = tracing::field::Empty))]
+                    #[tracing::instrument(name = #span_name, skip_all, fields(entity = #entity_name, #count_field error = tracing::field::Empty, exception.message = tracing::field::Empty, exception.type = tracing::field::Empty))]
                 },
                 quote! {
                     if let Err(ref e) = __result {
@@ -277,10 +323,12 @@ impl UpdateAllFn<'_> {
                         tracing::Span::current().record("exception.type", std::any::type_name_of_val(e));
                     }
                 },
+                count_recording,
             )
         };
         #[cfg(not(feature = "instrument"))]
-        let (instrument_attr, error_recording) = (quote! {}, quote! {});
+        let (instrument_attr, error_recording, count_recording) =
+            (quote! {}, quote! {}, None::<TokenStream>);
 
         let post_persist_check = if self.post_persist_error.is_some() {
             quote! {
@@ -318,6 +366,9 @@ impl UpdateAllFn<'_> {
             {
                 let __result: Result<usize, #modify_error> = async {
                     use es_entity::prelude::sqlx::Row;
+
+                    #entities_prelude
+                    #count_recording
 
                     if entities.is_empty() {
                         return Ok(0);
@@ -512,13 +563,15 @@ mod tests {
             pub async fn update_all_mut_in_op<OP>(
                 &self,
                 op: &mut OP,
-                mut entities: Vec<&mut Entity>
+                entities: impl IntoIterator<Item = &mut Entity>
             ) -> Result<usize, EntityModifyError>
             where
                 OP: es_entity::AtomicOperation
             {
                 let __result: Result<usize, EntityModifyError> = async {
                     use es_entity::prelude::sqlx::Row;
+
+                    let mut entities: Vec<&mut Entity> = entities.into_iter().collect();
 
                     if entities.is_empty() {
                         return Ok(0);
@@ -703,13 +756,15 @@ mod tests {
             pub async fn update_all_mut_in_op<OP>(
                 &self,
                 op: &mut OP,
-                mut entities: Vec<&mut Entity>
+                entities: impl IntoIterator<Item = &mut Entity>
             ) -> Result<usize, EntityModifyError>
             where
                 OP: es_entity::AtomicOperation
             {
                 let __result: Result<usize, EntityModifyError> = async {
                     use es_entity::prelude::sqlx::Row;
+
+                    let mut entities: Vec<&mut Entity> = entities.into_iter().collect();
 
                     if entities.is_empty() {
                         return Ok(0);

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -49,29 +49,18 @@ impl<'a> From<&'a RepositoryOptions> for UpdateAllFn<'a> {
 /// Which shape of parent collection a generated bulk-update function
 /// operates on.
 ///
-/// `update_all_in_op` is the top-level API for a caller that already owns a
-/// contiguous, owned collection: it takes `&mut [Entity]` and never copies
-/// or reallocates it. `update_all_mut_in_op` is the shape needed to batch
-/// *nested children across many parents*: each parent owns its own children
-/// (in its own `HashMap`), so gathering "every persisted child that needs
-/// updating, across the whole parent batch" can only ever produce scattered
-/// `&mut Entity` borrows, never a contiguous slice — there is no owned
-/// collection for a caller to hand over `&mut` to in the first place.
-///
-/// Because of that, `update_all_mut_in_op` accepts `impl IntoIterator<Item =
-/// &mut Entity>` rather than a concrete `Vec`: a caller assembling those
-/// scattered borrows (e.g. `parents.iter_mut().flat_map(|p|
-/// p.children.values_mut())`) can pass the chain straight through instead of
-/// collecting it themselves first. The *internal* representation is still a
-/// `Vec<&mut Entity>` — the body below needs multiple independent passes
-/// over `entities` (SQL building, marking events persisted, computing the
-/// returned count, and, when this entity itself has nested children, the
-/// nested phase), which a bare `IntoIterator` only supports once — so the
-/// very first thing the generated `RefVec` body does is `.into_iter().collect()`
-/// into a `Vec` shadowing the parameter. Every use of `entities` after that
-/// point operates on that `Vec`, so it reads exactly like `update_all_in_op`
-/// (and like this fn did before the parameter type changed) — only the
-/// entry point moved from "caller collects" to "callee collects".
+/// `update_all_in_op` is the top-level, caller-facing batch API: it owns a
+/// contiguous `&mut [Entity]`. `update_all_mut_in_op` is the shape needed to
+/// batch *nested children across many parents*: each parent owns its own
+/// children (in its own `HashMap`), so gathering "every persisted child that
+/// needs updating, across the whole parent batch" can only ever produce
+/// scattered `&mut Entity` borrows, never a contiguous slice. It accepts
+/// `impl IntoIterator<Item = &mut Entity>` rather than a concrete `Vec` so a
+/// caller assembling those scattered borrows can pass the chain straight
+/// through; the *internal* representation is still `Vec<&mut Entity>` (the
+/// body needs multiple passes over `entities`, which a bare `IntoIterator`
+/// only supports once), collected right at the top of the generated `RefVec`
+/// body, shadowing the parameter.
 ///
 /// Both variants share the exact same SQL-building logic below; only the
 /// outer signature and how `entities` is iterated differ, via `iter_ref` /
@@ -81,9 +70,7 @@ impl<'a> From<&'a RepositoryOptions> for UpdateAllFn<'a> {
 /// unify against a concrete `&mut Entity`, not `&mut &mut Entity`), so the
 /// `RefVec` adapters reborrow down to a single level with `.map(|e| &mut
 /// **e)` / `.map(|e| &**e)`, making the entity-loop bodies below identical
-/// text for both modes. That reborrow is unaffected by where the `Vec` comes
-/// from — collected internally now, formerly passed in — since it only ever
-/// operates on the `Vec`, never on the caller's original iterator.
+/// text for both modes.
 enum BatchMode {
     OwnedSlice,
     RefVec,
@@ -112,15 +99,6 @@ impl UpdateAllFn<'_> {
             BatchMode::RefVec => (
                 quote::format_ident!("update_all_mut_in_op"),
                 quote! { entities: impl IntoIterator<Item = &mut #entity> },
-                // The caller hands us anything iterable once (a `Vec`, an
-                // array, or — the motivating case — a `flat_map` chain
-                // scattering across many parents' `HashMap`s); we collect it
-                // into an owned `Vec` exactly once, right here, and every use
-                // of `entities` below this point operates on that `Vec`.
-                // Shadowing the parameter name means the reborrow adapters
-                // and every later `entities.iter()`/`entities.iter_mut()`
-                // call are unchanged text from before this Vec was built
-                // internally rather than passed in.
                 Some(quote! {
                     let mut entities: Vec<&mut #entity> = entities.into_iter().collect();
                 }),
@@ -298,11 +276,6 @@ impl UpdateAllFn<'_> {
                 BatchMode::RefVec => "update_all_mut",
             };
             let span_name = format!("{}.{}", repo_name, span_suffix);
-            // `OwnedSlice`'s `entities: &mut [Entity]` has a `.len()` at
-            // function entry, so its `count` field is populated immediately.
-            // `RefVec`'s `entities: impl IntoIterator<...>` does not — the
-            // count is only known once it's collected into a `Vec` inside
-            // the async body, so that variant records it there instead.
             let count_field = match mode {
                 BatchMode::OwnedSlice => quote! { count = entities.len(), },
                 BatchMode::RefVec => quote! { count = tracing::field::Empty, },

--- a/tests/nested_batch_statement_count.rs
+++ b/tests/nested_batch_statement_count.rs
@@ -211,13 +211,6 @@ async fn update_all_batches_nested_children_across_parents() -> anyhow::Result<(
     Ok(())
 }
 
-/// `update_all_mut_in_op` accepts `impl IntoIterator<Item = &mut Entity>`
-/// specifically so a caller can hand it a genuinely chained iterator —
-/// `flat_map` scattering `&mut` borrows across many parents' own
-/// `HashMap`s — without collecting into a `Vec` first. This is the
-/// motivating case from the nested-batching design: it's exactly what the
-/// macro-generated `update_nested_*_in_op` glue does internally, exercised
-/// here directly against the child repo.
 #[tokio::test]
 async fn update_all_mut_accepts_a_chained_iterator() -> anyhow::Result<()> {
     let pool = init_pool().await?;
@@ -244,10 +237,6 @@ async fn update_all_mut_accepts_a_chained_iterator() -> anyhow::Result<()> {
             .expect("item-0 exists");
     }
 
-    // The chain itself: each `order.iter_persisted_children_mut()` borrows
-    // from that order's own `Nested<OrderItem>` HashMap, `flat_map` scatters
-    // those borrows across the whole `batch`, and the chain is passed
-    // straight through — no `.collect::<Vec<_>>()` at the call site.
     let mut op = orders.begin_op().await?;
     let n_events = orders
         .items

--- a/tests/nested_batch_statement_count.rs
+++ b/tests/nested_batch_statement_count.rs
@@ -210,3 +210,69 @@ async fn update_all_batches_nested_children_across_parents() -> anyhow::Result<(
 
     Ok(())
 }
+
+/// `update_all_mut_in_op` accepts `impl IntoIterator<Item = &mut Entity>`
+/// specifically so a caller can hand it a genuinely chained iterator —
+/// `flat_map` scattering `&mut` borrows across many parents' own
+/// `HashMap`s — without collecting into a `Vec` first. This is the
+/// motivating case from the nested-batching design: it's exactly what the
+/// macro-generated `update_nested_*_in_op` glue does internally, exercised
+/// here directly against the child repo.
+#[tokio::test]
+async fn update_all_mut_accepts_a_chained_iterator() -> anyhow::Result<()> {
+    let pool = init_pool().await?;
+    let orders = Orders::new(pool);
+
+    const N_PARENTS: usize = 3;
+    const M_ITEMS: usize = 2;
+
+    let mut order_ids = Vec::new();
+    for _ in 0..N_PARENTS {
+        let (order_id, _items) = create_order_with_items(&orders, M_ITEMS).await?;
+        order_ids.push(order_id);
+    }
+
+    let mut loaded = orders.find_all::<Order>(&order_ids).await?;
+    let mut batch: Vec<Order> = order_ids
+        .iter()
+        .map(|id| loaded.remove(id).expect("order was loaded"))
+        .collect();
+
+    for order in batch.iter_mut() {
+        order
+            .update_item_quantity("item-0", 99)
+            .expect("item-0 exists");
+    }
+
+    // The chain itself: each `order.iter_persisted_children_mut()` borrows
+    // from that order's own `Nested<OrderItem>` HashMap, `flat_map` scatters
+    // those borrows across the whole `batch`, and the chain is passed
+    // straight through — no `.collect::<Vec<_>>()` at the call site.
+    let mut op = orders.begin_op().await?;
+    let n_events = orders
+        .items
+        .update_all_mut_in_op(
+            &mut op,
+            batch
+                .iter_mut()
+                .flat_map(|order| order.iter_persisted_children_mut()),
+        )
+        .await?;
+    op.commit().await?;
+
+    assert_eq!(
+        n_events, N_PARENTS,
+        "one QuantityUpdated event per parent's item-0"
+    );
+
+    let mut reloaded = orders.find_all::<Order>(&order_ids).await?;
+    for order_id in &order_ids {
+        let order = reloaded.remove(order_id).expect("order reloaded");
+        let item0 = order
+            .find_item_with_name("item-0")
+            .expect("item-0 still present");
+        assert_eq!(item0.quantity, 99, "order {order_id}'s item-0 was updated");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Follow-up to #203

Justin asked whether `update_all_mut_in_op(op, entities: Vec<&mut Entity>)` can be generalized beyond a `Vec`.

**Outcome: yes, via `impl IntoIterator<Item = &mut Entity>`, with the collect moved inside the macro.**

### What changed

`update_all_mut_in_op` now accepts `impl IntoIterator<Item = &mut Entity>` instead of `Vec<&mut Entity>`. A caller assembling scattered child borrows across many parents' own `HashMap`s (the motivating case from #203's nested batching) can pass the chain straight through:

```rust
repo.update_all_mut_in_op(
    op,
    parents.iter_mut().flat_map(|p| p.children.values_mut()),
)
```

instead of collecting it into a `Vec` themselves first.

### Why this is safe despite the multi-pass body

The generated body needs several independent passes over the batch (SQL building, marking events persisted, computing the returned count, and the nested phase) — a bare `IntoIterator` only supports one. So the very first thing the generated body does is `.into_iter().collect()` into a `Vec<&mut Entity>`, **shadowing the parameter**. Every line below that point — including the `RefVec` reborrow adapters that solve the `&mut &mut Entity` problem — is unchanged text, since it now operates on that internal `Vec` exactly as it did before the parameter type changed.

`update_all_in_op` (the `OwnedSlice` variant, for callers that already hold a contiguous, owned collection) is untouched. Both variants still share one generated body via `BatchMode`, as #203 deliberately arranged.

### Compatibility

Source-compatible, no semver break: `Vec<T>` already implements `IntoIterator<Item = T>`, so every existing call site (the macro-generated `update_nested_*_in_op` glue, which currently does `.collect::<Vec<_>>()` before calling) keeps compiling unchanged. Verified with `cargo check --workspace --all-features`.

### Instrumentation note

Under the `instrument` feature, the `count` tracing field can no longer be populated at function entry (a generic `IntoIterator` has no `.len()`), so `RefVec` now records it right after the internal collect via `tracing::Span::current().record(...)`. `OwnedSlice` is unaffected — its `count = entities.len()` at entry is unchanged.

### Testing

Added `update_all_mut_accepts_a_chained_iterator` to `tests/nested_batch_statement_count.rs`, which calls `update_all_mut_in_op` directly with a real `flat_map` chain over multiple parents' `Nested<T>` `HashMap`s (via the public `Parent::iter_persisted_children_mut()`), not just a `Vec` passed through the new signature. Ran locally against the dev Postgres via `cargo nextest run --test nested_batch_statement_count --features instrument`: 2 passed.

Only `cargo fmt` was run as a local gate per policy — pushing early for GitHub Actions to be authoritative on clippy/tests/audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Source-compatible API widening of generated bulk-update helpers; SQL and persistence logic are unchanged.
> 
> **Overview**
> Lets callers pass a chained iterator of scattered `&mut Entity` borrows into generated `update_all_mut_in_op` instead of collecting a `Vec` first.
> 
> The generated body still `.collect()`s into `Vec<&mut Entity>` immediately so multi-pass SQL/event logic is unchanged. `update_all_in_op` is untouched. Existing `Vec` call sites remain valid.
> 
> Under `instrument`, `count` is recorded after collect because a generic iterator has no `.len()` at span entry. Adds a nested-batch test that `flat_map`s `iter_persisted_children_mut()` across parents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e2dbd8a00ab0b89baae23762a78e1b64226fc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->