### PR TITLE
feat(operation): nested savepoints

### DIFF
--- a/book/src/commit-hooks.md
+++ b/book/src/commit-hooks.md
@@ -86,7 +86,7 @@ impl CommitHook for MyHook {
 }
 ```
 
-`HookOperation` implements `AtomicOperation` so it can be passed to any function expecting that trait.
+`HookOperation` implements `AtomicOperation` so it can be passed to any function expecting that trait. It also exposes `with_savepoint` / `begin_savepoint`, letting `pre_commit` isolate its own multi-statement write in a nested `SAVEPOINT` — see [Nesting](./savepoints.md#nesting).
 
 ## Rollback Notification
 

--- a/book/src/savepoints.md
+++ b/book/src/savepoints.md
@@ -69,6 +69,30 @@ self.process_in_op(&mut sp, item).await?;
 sp.release().await?;
 ```
 
+## Nesting
+
+`SavepointOp` exposes the same `with_savepoint` / `begin_savepoint` pair as `DbOp`, so a savepoint can nest inside another — isolating a sub-item's failure within an already-isolated item, without giving up any of the outer batch's atomicity:
+
+```rust,ignore
+op.with_savepoint(async |outer| {
+    self.process_in_op(outer, item).await?;
+
+    for sub_item in &item.sub_items {
+        // A sub-item's failure unwinds only its own writes — `item`'s own
+        // work, and the batch, stay intact either way.
+        let _ = outer.with_savepoint(async |inner| {
+            self.process_sub_item_in_op(inner, sub_item).await
+        }).await?;
+    }
+
+    Ok::<_, MyError>(())
+}).await?;
+```
+
+Releasing an inner savepoint folds its staged hooks into its *immediate* parent's staged buffer, not straight into the root `DbOp` — an N-deep chain rolls up one level at a time, so nothing is visible further out until every enclosing savepoint has itself released.
+
+A [`CommitHook`](./commit-hooks.md)'s own `pre_commit` can nest a savepoint too: `HookOperation` — the type `pre_commit` is handed — exposes the same pair, letting a hook isolate its own multi-statement write the same way application code isolates a batch item. This works even on the [`force_execute_pre_commit`](./commit-hooks.md) escape hatch, where there is no commit pass for a registered hook to join: the raw `SAVEPOINT`/`RELEASE`/`ROLLBACK` still works (it only needs the connection), but `add_commit_hook` inside that savepoint keeps refusing, exactly as it already does on the `HookOperation` directly.
+
 ## When not to use savepoints
 
 If every item performs the same statement, `create_all` / `update_all` / `find_all` remain cheaper — one statement for the whole batch beats one savepoint pair per item. Reach for savepoints when items need genuinely per-item logic *and* per-item error isolation.

--- a/src/operation/hooks.rs
+++ b/src/operation/hooks.rs
@@ -93,8 +93,12 @@
 //! operation's set — through the same registration/merge path — when the savepoint
 //! is released; a rolled-back savepoint discards them. No callback runs at a
 //! savepoint boundary, so the lifecycle above is unchanged: one `pre_commit` pass at
-//! the parent's commit, `post_commit` only after a durable `COMMIT`. See
-//! [`SavepointOp`] for details.
+//! the root's commit, `post_commit` only after a durable `COMMIT`. Savepoints nest:
+//! [`SavepointOp`] itself exposes `with_savepoint`/`begin_savepoint`, and so does
+//! [`HookOperation`] — letting a hook's own `pre_commit` isolate its own
+//! multi-statement write the same way. Releasing an inner savepoint folds into its
+//! *immediate* parent's staged buffer, not straight to the root, so an N-deep chain
+//! rolls up one level at a time. See [`SavepointOp`] for details.
 //!
 //! [`SavepointOp`]: super::SavepointOp
 //!
@@ -380,6 +384,53 @@ impl<'c> HookOperation<'c> {
     fn drain_staged(&mut self) -> Option<CommitHooks> {
         Some(std::mem::take(self.staged.as_mut()?))
     }
+
+    /// Runs `f` inside a `SAVEPOINT` scoped to this hook's connection — see
+    /// [`DbOp::with_savepoint`](super::DbOp::with_savepoint) for the full
+    /// contract. Lets a hook's `pre_commit` isolate its own multi-statement
+    /// work (e.g. writing one outbox row per staged event) the same way
+    /// application code isolates a batch item, without risking the enclosing
+    /// commit pass.
+    pub async fn with_savepoint<T, E, F>(&mut self, f: F) -> Result<Result<T, E>, sqlx::Error>
+    where
+        F: AsyncFnOnce(&mut super::SavepointOp<'_>) -> Result<T, E>,
+    {
+        let mut op = self.begin_savepoint().await?;
+        match f(&mut op).await {
+            Ok(value) => {
+                op.release().await?;
+                Ok(Ok(value))
+            }
+            Err(error) => {
+                op.rollback().await?;
+                Ok(Err(error))
+            }
+        }
+    }
+
+    /// Begins a `SAVEPOINT` scope explicitly — see
+    /// [`DbOp::begin_savepoint`](super::DbOp::begin_savepoint).
+    ///
+    /// Hooks registered inside stage normally and, on
+    /// [`release`](super::SavepointOp::release), fold into this
+    /// `HookOperation`'s own buffer exactly like a top-level savepoint folds
+    /// into a `DbOp` — *if* this `HookOperation` is on a real commit pass
+    /// ([`supports_hooks`](AtomicOperation::supports_hooks) is `true`). On the
+    /// [`force_execute_pre_commit`](CommitHook::force_execute_pre_commit) path
+    /// there is no pass to fold into, so registering a hook inside the
+    /// savepoint fails the same way it would have on this `HookOperation`
+    /// directly — the `SAVEPOINT`/`RELEASE`/`ROLLBACK` machinery itself still
+    /// works regardless, since it needs only the connection.
+    pub async fn begin_savepoint(&mut self) -> Result<super::SavepointOp<'_>, sqlx::Error> {
+        let clock = AtomicOperation::clock(self).clone();
+        super::SavepointOp::begin(
+            &mut *self.conn,
+            clock,
+            self.now,
+            super::savepoint::HookParent::Root(&mut self.staged),
+        )
+        .await
+    }
 }
 
 impl<'c> AtomicOperation for HookOperation<'c> {
@@ -529,6 +580,10 @@ impl CommitHooks {
         }
 
         self.hooks.push((type_id, new_hook));
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.hooks.is_empty()
     }
 
     pub(super) fn get_last<H: CommitHook>(&self) -> Option<&H> {

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -183,7 +183,7 @@ impl<'c> DbOp<'c> {
             &mut self.tx,
             self.clock.clone(),
             self.now,
-            &mut self.commit_hooks,
+            savepoint::HookParent::Root(&mut self.commit_hooks),
         )
         .await
     }

--- a/src/operation/savepoint.rs
+++ b/src/operation/savepoint.rs
@@ -6,14 +6,78 @@ use crate::{clock::ClockHandle, db};
 
 use super::{AtomicOperation, hooks};
 
-/// An [`AtomicOperation`] scoped to a database `SAVEPOINT` inside a parent [`DbOp`].
+/// The buffer a released [`SavepointOp`]'s staged hooks fold into.
 ///
-/// Created by [`DbOp::with_savepoint`] / [`DbOp::begin_savepoint`]. Statements
-/// executed through it run inside the savepoint, so they can be undone with
-/// [`rollback`](Self::rollback) without poisoning — or ending — the parent
+/// A top-level savepoint (opened via [`DbOp::begin_savepoint`] or
+/// [`HookOperation::begin_savepoint`]) folds into that operation's own
+/// `Option<CommitHooks>`. Both operations share this exact representation:
+/// `DbOp`'s is `Some` for its whole lifetime (`None` only while a `commit()` is
+/// actively draining it, which can't overlap with an open savepoint borrowing
+/// the same `DbOp`); `HookOperation`'s is `Some` while a real commit pass is
+/// staging through it and `None` on the [`force_execute_pre_commit`] path,
+/// where there is no pass to fold into — see [`supports_hooks`](Self::supports_hooks).
+///
+/// A nested savepoint (opened via [`SavepointOp::begin_savepoint`]) folds into
+/// its parent `SavepointOp`'s `staged` buffer instead, so releasing an N-deep
+/// chain folds hooks inward one level at a time until they reach the root.
+///
+/// [`HookOperation::begin_savepoint`]: super::hooks::HookOperation::begin_savepoint
+/// [`force_execute_pre_commit`]: hooks::CommitHook::force_execute_pre_commit
+pub(super) enum HookParent<'t> {
+    Root(&'t mut Option<hooks::CommitHooks>),
+    Nested(&'t mut hooks::CommitHooks),
+}
+
+impl HookParent<'_> {
+    /// Whether this buffer can actually receive folded hooks.
+    ///
+    /// `false` only for a [`Root`](Self::Root) currently holding `None` — i.e.
+    /// a `HookOperation` on the `force_execute_pre_commit` path, which has no
+    /// commit pass to fold into. Everything else (a live `DbOp`/`HookOperation`
+    /// buffer, or any `Nested` parent) always accepts hooks.
+    fn supports_hooks(&self) -> bool {
+        match self {
+            Self::Root(hooks) => hooks.is_some(),
+            Self::Nested(_) => true,
+        }
+    }
+
+    /// Folds staged hooks in. `staged` is guaranteed empty when
+    /// [`supports_hooks`](Self::supports_hooks) was `false` — nothing could
+    /// have been added to it, since [`SavepointOp::add_commit_hook`] itself
+    /// refuses in that case — so the `None` arm is a documented no-op, not a
+    /// silent drop of real hook state.
+    fn absorb_staged(&mut self, staged: hooks::CommitHooks) {
+        match self {
+            Self::Root(Some(hooks)) => hooks.absorb_staged(staged),
+            Self::Root(None) => debug_assert!(
+                staged.is_empty(),
+                "hooks staged on a savepoint whose root doesn't support hooks"
+            ),
+            Self::Nested(hooks) => hooks.absorb_staged(staged),
+        }
+    }
+
+    fn get_last<H: hooks::CommitHook>(&self) -> Option<&H> {
+        match self {
+            Self::Root(hooks) => hooks.as_ref()?.get_last::<H>(),
+            Self::Nested(hooks) => hooks.get_last::<H>(),
+        }
+    }
+}
+
+/// An [`AtomicOperation`] scoped to a database `SAVEPOINT` inside a parent [`DbOp`]
+/// or another `SavepointOp`.
+///
+/// Created by [`DbOp::with_savepoint`] / [`DbOp::begin_savepoint`], or — to nest
+/// one savepoint inside another — [`Self::with_savepoint`] / [`Self::begin_savepoint`].
+/// Statements executed through it run inside the savepoint, so they can be undone
+/// with [`rollback`](Self::rollback) without poisoning — or ending — the parent
 /// transaction. This is what makes a "loop over N items in one transaction, but
 /// isolate each item's failure" pattern possible: one `COMMIT` (one WAL flush)
 /// for the whole batch, while a failing item unwinds only its own writes.
+/// Nesting extends this to per-sub-item isolation within an already-isolated
+/// item, without giving up any of the outer batch's atomicity.
 ///
 /// # Hooks are staged, not executed
 ///
@@ -24,16 +88,19 @@ use super::{AtomicOperation, hooks};
 /// - [`release`](Self::release) issues `RELEASE SAVEPOINT` and then folds the
 ///   staged hooks into the parent's buffer through the ordinary
 ///   registration/merge path, exactly as if they had been registered on the
-///   parent directly.
+///   parent directly. For a nested savepoint the "parent" is the enclosing
+///   `SavepointOp`'s own staged buffer — folding there is not yet visible to
+///   *its* parent until it, too, is released.
 /// - [`rollback`](Self::rollback) issues `ROLLBACK TO SAVEPOINT` and drops the
 ///   staged hooks. A rolled-back item therefore contributes zero hook state to
 ///   match its zero database state — no phantom event publishes, no inserts
 ///   referencing rows that no longer exist.
 ///
-/// No hook's [`pre_commit`] / [`post_commit`] ever runs at savepoint boundaries.
-/// They run once, at the parent's [`commit`](DbOp::commit), over the final merged
-/// hook set — so `post_commit` still only fires after a durable `COMMIT`, and
-/// [`on_rollback`] still only fires when the whole transaction is gone.
+/// No hook's [`pre_commit`] / [`post_commit`] ever runs at savepoint boundaries,
+/// nested or not. They run once, at the root [`commit`](DbOp::commit), over the
+/// final merged hook set — so `post_commit` still only fires after a durable
+/// `COMMIT`, and [`on_rollback`] still only fires when the whole transaction is
+/// gone.
 ///
 /// [`DbOp`]: super::DbOp
 /// [`DbOp::with_savepoint`]: super::DbOp::with_savepoint
@@ -48,22 +115,33 @@ pub struct SavepointOp<'t> {
     /// Hooks registered while the savepoint is open. Folded into
     /// `parent_hooks` on release, dropped on rollback.
     staged: hooks::CommitHooks,
-    /// The parent operation's hook buffer. Held as a `&mut` to a *disjoint*
-    /// field of the parent (the nested transaction borrows its `tx` field), so
-    /// the savepoint can fold into it without the parent's hooks ever leaving
-    /// the parent.
-    parent_hooks: &'t mut Option<hooks::CommitHooks>,
+    /// The enclosing operation's hook buffer — a `DbOp`'s own buffer for a
+    /// top-level savepoint, or a parent `SavepointOp`'s `staged` buffer for a
+    /// nested one. Held as a `&mut` to a *disjoint* field of that operation
+    /// (the nested transaction borrows its `tx` field), so this savepoint can
+    /// fold into it without the enclosing hooks ever leaving their owner.
+    parent_hooks: HookParent<'t>,
 }
 
 impl<'t> SavepointOp<'t> {
-    pub(super) async fn begin(
-        tx: &'t mut Transaction<'_, db::Db>,
+    /// `acquire` is generic so this serves every concrete operation that can
+    /// nest a `SAVEPOINT`: a `&mut Transaction` (from `DbOp` or another
+    /// `SavepointOp`) or a bare `&mut db::Connection` (from a
+    /// [`HookOperation`](super::hooks::HookOperation), which holds the raw
+    /// connection rather than a `Transaction` wrapper). sqlx tracks nesting
+    /// depth on the connection itself, so either one correctly issues
+    /// `SAVEPOINT` rather than `BEGIN` given we're already inside a transaction.
+    pub(super) async fn begin<A>(
+        acquire: A,
         clock: ClockHandle,
         now: Option<chrono::DateTime<chrono::Utc>>,
-        parent_hooks: &'t mut Option<hooks::CommitHooks>,
-    ) -> Result<Self, sqlx::Error> {
+        parent_hooks: HookParent<'t>,
+    ) -> Result<Self, sqlx::Error>
+    where
+        A: Acquire<'t, Database = db::Db>,
+    {
         Ok(Self {
-            tx: tx.begin().await?,
+            tx: acquire.begin().await?,
             clock,
             now,
             staged: hooks::CommitHooks::new(),
@@ -74,33 +152,32 @@ impl<'t> SavepointOp<'t> {
     /// Releases the savepoint, keeping this scope's work.
     ///
     /// Issues `RELEASE SAVEPOINT`, then folds the staged commit hooks into the
-    /// parent operation's buffer via the normal registration/merge path — so a
-    /// mergeable hook type accumulates across savepoints exactly as it would
+    /// enclosing operation's buffer via the normal registration/merge path — so
+    /// a mergeable hook type accumulates across savepoints exactly as it would
     /// have on the parent, and a non-mergeable one lands at its own position in
-    /// release order.
+    /// release order. For a nested savepoint this is its parent `SavepointOp`'s
+    /// staged buffer, not necessarily the root `DbOp` — a further `release` (or
+    /// `rollback`) up the chain is what makes the fold visible further out.
     ///
     /// If the `RELEASE` itself fails the staged hooks are dropped and the error
-    /// is returned: the parent transaction is in an indeterminate state and the
-    /// caller must abandon it rather than commit.
+    /// is returned: the enclosing transaction is in an indeterminate state and
+    /// the caller must abandon it rather than commit or release further.
     pub async fn release(self) -> Result<(), sqlx::Error> {
         let Self {
             tx,
             staged,
-            parent_hooks,
+            mut parent_hooks,
             ..
         } = self;
         tx.commit().await?;
-        parent_hooks
-            .as_mut()
-            .expect("no hooks")
-            .absorb_staged(staged);
+        parent_hooks.absorb_staged(staged);
         Ok(())
     }
 
     /// Rolls back to the savepoint, discarding this scope's work.
     ///
     /// Issues `ROLLBACK TO SAVEPOINT` and drops the staged commit hooks. The
-    /// parent transaction stays alive and usable — including after an error
+    /// enclosing operation stays alive and usable — including after an error
     /// that would otherwise have poisoned it.
     ///
     /// Dropping a `SavepointOp` without calling either `release` or `rollback`
@@ -108,6 +185,42 @@ impl<'t> SavepointOp<'t> {
     /// connection) and likewise discards the staged hooks.
     pub async fn rollback(self) -> Result<(), sqlx::Error> {
         self.tx.rollback().await
+    }
+
+    /// Runs `f` inside a `SAVEPOINT` nested within this one — see
+    /// [`DbOp::with_savepoint`] for the full contract. Identical in behavior,
+    /// just one level deeper: releasing the inner savepoint folds its staged
+    /// hooks into *this* savepoint's staged buffer rather than straight into
+    /// the root `DbOp`.
+    pub async fn with_savepoint<T, E, F>(&mut self, f: F) -> Result<Result<T, E>, sqlx::Error>
+    where
+        F: AsyncFnOnce(&mut SavepointOp<'_>) -> Result<T, E>,
+    {
+        let mut op = self.begin_savepoint().await?;
+        match f(&mut op).await {
+            Ok(value) => {
+                op.release().await?;
+                Ok(Ok(value))
+            }
+            Err(error) => {
+                op.rollback().await?;
+                Ok(Err(error))
+            }
+        }
+    }
+
+    /// Begins a `SAVEPOINT` scope nested within this one, explicitly — see
+    /// [`DbOp::begin_savepoint`]. Must be finished with
+    /// [`release`](Self::release) or [`rollback`](Self::rollback); dropping it
+    /// rolls back.
+    pub async fn begin_savepoint(&mut self) -> Result<SavepointOp<'_>, sqlx::Error> {
+        SavepointOp::begin(
+            &mut self.tx,
+            self.clock.clone(),
+            self.now,
+            HookParent::Nested(&mut self.staged),
+        )
+        .await
     }
 }
 
@@ -124,7 +237,12 @@ impl AtomicOperation for SavepointOp<'_> {
         self.tx.connection()
     }
 
+    /// Refuses, like any other operation, when the enclosing chain ultimately
+    /// has nowhere to fold hooks — see [`HookParent::supports_hooks`].
     fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
+        if !self.parent_hooks.supports_hooks() {
+            return Err(hook);
+        }
         self.staged.add(hook);
         Ok(())
     }
@@ -137,10 +255,10 @@ impl AtomicOperation for SavepointOp<'_> {
     fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
         self.staged
             .get_last::<H>()
-            .or_else(|| self.parent_hooks.as_ref()?.get_last::<H>())
+            .or_else(|| self.parent_hooks.get_last::<H>())
     }
 
     fn supports_hooks(&self) -> bool {
-        true
+        self.parent_hooks.supports_hooks()
     }
 }

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1176,6 +1176,144 @@ async fn force_execute_path_still_refuses_reentrant_registration() -> anyhow::Re
     Ok(())
 }
 
+/// A hook whose `pre_commit` isolates its own multi-row write in a nested
+/// `SAVEPOINT`, discarding one row without losing the others or poisoning the
+/// enclosing commit pass.
+#[derive(Debug)]
+struct SavepointingHook {
+    prefix: String,
+    clashing_id: uuid::Uuid,
+}
+
+impl CommitHook for SavepointingHook {
+    async fn pre_commit(
+        self,
+        mut op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        sqlx::query!(
+            "INSERT INTO savepoint_items (id, label) VALUES ($1, $2)",
+            self.clashing_id,
+            format!("{}-kept", self.prefix)
+        )
+        .execute(op.as_executor())
+        .await?;
+
+        let doomed_res = op
+            .with_savepoint(async |sp| {
+                sqlx::query!(
+                    "INSERT INTO savepoint_items (id, label) VALUES ($1, $2)",
+                    self.clashing_id,
+                    format!("{}-doomed", self.prefix)
+                )
+                .execute(sp.as_executor())
+                .await
+            })
+            .await?;
+        assert!(doomed_res.is_err(), "duplicate id must fail the insert");
+
+        PreCommitRet::ok(self, op)
+    }
+}
+
+#[tokio::test]
+async fn hook_pre_commit_savepoint_isolates_its_own_write() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let prefix = format!("sp-hook-{}", uuid::Uuid::now_v7());
+
+    op.add_commit_hook(SavepointingHook {
+        prefix: prefix.clone(),
+        clashing_id: uuid::Uuid::now_v7(),
+    })
+    .unwrap();
+
+    // Proves the hook's rolled-back savepoint didn't poison the commit pass's
+    // own transaction.
+    op.commit().await?;
+
+    let labels: Vec<String> = sqlx::query!(
+        "SELECT label FROM savepoint_items WHERE label LIKE $1 ORDER BY label",
+        format!("{prefix}%")
+    )
+    .fetch_all(&pool)
+    .await?
+    .into_iter()
+    .map(|r| r.label)
+    .collect();
+    assert_eq!(labels, vec![format!("{prefix}-kept")]);
+
+    Ok(())
+}
+
+/// On the `force_execute_pre_commit` path there is no commit pass for a
+/// registered hook to join, so `add_commit_hook` inside a nested savepoint
+/// must keep refusing exactly like it does directly on the `HookOperation` —
+/// but the raw `SAVEPOINT`/`RELEASE`/`ROLLBACK` machinery, needing only the
+/// connection, works regardless.
+#[derive(Debug)]
+struct ForcePathSavepointProbe {
+    prefix: String,
+    add_hook_result: Arc<Mutex<Option<bool>>>,
+}
+
+impl CommitHook for ForcePathSavepointProbe {
+    async fn pre_commit(
+        self,
+        mut op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        let mut sp = op.begin_savepoint().await?;
+
+        let registered = sp
+            .add_commit_hook(NonMergingGetterHook { label: "child" })
+            .is_ok();
+        *self.add_hook_result.lock().unwrap() = Some(registered);
+
+        sqlx::query!(
+            "INSERT INTO savepoint_items (id, label) VALUES ($1, $2)",
+            uuid::Uuid::now_v7(),
+            format!("{}-forced", self.prefix)
+        )
+        .execute(sp.as_executor())
+        .await?;
+        sp.release().await?;
+
+        PreCommitRet::ok(self, op)
+    }
+}
+
+#[tokio::test]
+async fn force_execute_path_savepoint_works_without_hook_support() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut tx = pool.begin().await?; // bare sqlx::Transaction: no hook support at all
+    let prefix = format!("sp-force-{}", uuid::Uuid::now_v7());
+
+    let add_hook_result = Arc::new(Mutex::new(None));
+
+    ForcePathSavepointProbe {
+        prefix: prefix.clone(),
+        add_hook_result: add_hook_result.clone(),
+    }
+    .force_execute_pre_commit(&mut tx)
+    .await?;
+
+    assert_eq!(*add_hook_result.lock().unwrap(), Some(false));
+
+    tx.commit().await?;
+
+    let labels: Vec<String> = sqlx::query!(
+        "SELECT label FROM savepoint_items WHERE label LIKE $1 ORDER BY label",
+        format!("{prefix}%")
+    )
+    .fetch_all(&pool)
+    .await?
+    .into_iter()
+    .map(|r| r.label)
+    .collect();
+    assert_eq!(labels, vec![format!("{prefix}-forced")]);
+
+    Ok(())
+}
+
 #[derive(Debug)]
 struct StagesFailingChild {
     label: &'static str,

--- a/tests/savepoint.rs
+++ b/tests/savepoint.rs
@@ -457,6 +457,150 @@ async fn savepoint_inherits_cached_time() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn nested_savepoint_rolls_back_without_poisoning_parent() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let prefix = format!("sp-{}", new_id());
+    let clashing_id = new_id();
+
+    let mut op = DbOp::init(&pool).await?;
+
+    op.with_savepoint(async |op| {
+        insert_item_in_op(op, clashing_id, &format!("{prefix}-outer")).await?;
+
+        // A nested savepoint isolates a sub-item's failure from the item's own
+        // (already-isolated) scope.
+        let inner_res = op
+            .with_savepoint(async |op| {
+                insert_item_in_op(op, clashing_id, &format!("{prefix}-inner-doomed")).await
+            })
+            .await?;
+        assert!(inner_res.is_err());
+
+        // The outer item's own writes, and the parent transaction, survive the
+        // inner savepoint's rollback.
+        insert_item_in_op(op, new_id(), &format!("{prefix}-outer-continues")).await
+    })
+    .await?
+    .unwrap();
+
+    op.commit().await?;
+
+    assert_eq!(
+        labels(&pool, &prefix).await?,
+        vec![
+            format!("{prefix}-outer"),
+            format!("{prefix}-outer-continues"),
+        ]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn nested_savepoint_hooks_roll_up_one_parent_at_a_time() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let probe = Probe::default();
+
+    op.with_savepoint(async |outer| {
+        outer.add_commit_hook(probe.hook("outer")).unwrap();
+
+        outer
+            .with_savepoint(async |inner| {
+                // Not yet visible on the grandparent `DbOp` — only the immediate
+                // parent (`outer`) has folded it in, and only once `outer`
+                // itself releases.
+                inner.add_commit_hook(probe.hook("inner")).unwrap();
+                Ok::<_, anyhow::Error>(())
+            })
+            .await?
+            .unwrap();
+
+        // Released into `outer`'s own staged buffer: visible here, on the
+        // savepoint it rolled up into, but the root `DbOp` still knows nothing
+        // about it until `outer` itself releases.
+        let seen = outer
+            .commit_hook::<MergingProbeHook>()
+            .expect("inner's hook rolled up into outer");
+        assert_eq!(seen.labels, vec!["outer", "inner"]);
+
+        Ok::<_, anyhow::Error>(())
+    })
+    .await?
+    .unwrap();
+
+    op.commit().await?;
+
+    // One level up again at the root commit: both merged into a single hook,
+    // in release order.
+    assert_eq!(probe.pre(), vec!["outer", "inner"]);
+    assert_eq!(probe.post(), vec!["outer", "inner"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn rolled_back_outer_savepoint_discards_already_rolled_up_inner_hooks() -> anyhow::Result<()>
+{
+    let pool = helpers::init_pool().await?;
+    let mut op = DbOp::init(&pool).await?;
+    let probe = Probe::default();
+
+    let res = op
+        .with_savepoint(async |outer| {
+            outer
+                .with_savepoint(async |inner| {
+                    inner.add_commit_hook(probe.hook("inner")).unwrap();
+                    Ok::<_, anyhow::Error>(())
+                })
+                .await
+                .unwrap()
+                .unwrap();
+
+            // The inner hook is now staged on `outer`; rolling `outer` back
+            // must discard it right along with `outer`'s own writes/hooks.
+            Err::<(), _>("outer failed")
+        })
+        .await?;
+    assert_eq!(res, Err("outer failed"));
+
+    op.commit().await?;
+
+    assert!(probe.pre().is_empty());
+    assert!(probe.post().is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn explicit_nested_savepoint_release_and_rollback() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let prefix = format!("sp-{}", new_id());
+    let mut op = DbOp::init(&pool).await?;
+
+    let mut outer = op.begin_savepoint().await?;
+    insert_item_in_op(&mut outer, new_id(), &format!("{prefix}-outer")).await?;
+
+    let mut inner = outer.begin_savepoint().await?;
+    insert_item_in_op(&mut inner, new_id(), &format!("{prefix}-inner-kept")).await?;
+    inner.release().await?;
+
+    let mut inner = outer.begin_savepoint().await?;
+    insert_item_in_op(&mut inner, new_id(), &format!("{prefix}-inner-undone")).await?;
+    inner.rollback().await?;
+
+    outer.release().await?;
+    op.commit().await?;
+
+    assert_eq!(
+        labels(&pool, &prefix).await?,
+        vec![format!("{prefix}-inner-kept"), format!("{prefix}-outer")]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn explicit_savepoint_release_and_rollback() -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;
     let prefix = format!("sp-{}", new_id());


### PR DESCRIPTION
## Summary

Adds nested-savepoint support: `SavepointOp` and `HookOperation` now expose the same `with_savepoint` / `begin_savepoint` pair that `DbOp` already had, so a `SAVEPOINT` can nest inside another `SAVEPOINT`, or inside a `CommitHook`'s `pre_commit`.

- **`SavepointOp::with_savepoint` / `begin_savepoint`** — isolates a sub-item's failure within an already-isolated item, without giving up any of the outer batch's atomicity.
- **`HookOperation::with_savepoint` / `begin_savepoint`** — lets a hook's `pre_commit` isolate its own multi-statement write the same way, including on the `force_execute_pre_commit` fallback path (no hook support there, but the raw `SAVEPOINT`/`RELEASE`/`ROLLBACK` still works since it only needs the connection).

## Hook rollup semantics

Releasing an inner savepoint folds its staged hooks into its **immediate** parent's staged buffer, not straight into the root — an N-deep chain rolls up one level at a time, exactly mirroring the existing single-level release/rollback contract at each level.

## Implementation

- `SavepointOp::begin` is generalized from `&mut Transaction` to any `sqlx::Acquire<Database = db::Db>`, since `HookOperation` holds a bare `&mut db::Connection` rather than a `Transaction` wrapper. sqlx tracks transaction depth on the connection itself, so both correctly issue `SAVEPOINT` (not `BEGIN`) once already inside a transaction.
- Introduced a small `HookParent` enum (`Root` for a `DbOp`/`HookOperation`'s own `Option<CommitHooks>`, `Nested` for a parent `SavepointOp`'s staged buffer) so `release()` folds into the right place regardless of nesting depth.
- `SavepointOp::add_commit_hook` / `supports_hooks()` now delegate to whether the enclosing chain can actually receive folded hooks, instead of unconditionally succeeding — so registering a hook inside a savepoint nested under a non-hook-supporting `HookOperation` (force-execute path) refuses, exactly as it would directly on that `HookOperation`.

## Tests

- `tests/savepoint.rs`: nested release/rollback (explicit + closure form), hook rollup one level at a time, rollback of an outer savepoint discarding already-rolled-up inner hooks.
- `tests/hooks.rs`: a hook's `pre_commit` isolating a doomed write via a nested savepoint during a real commit pass; the `force_execute_pre_commit` path still getting working DB-level savepoints while `add_commit_hook` inside keeps refusing.

## Docs

Updated `book/src/savepoints.md` (new "Nesting" section) and `book/src/commit-hooks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction/savepoint and commit-hook staging paths used at commit time; behavior is well-tested but incorrect rollup or hook refusal could affect batch processing and outbox-style hooks.
> 
> **Overview**
> Adds **nested savepoint** support so `SAVEPOINT` scopes can stack: `SavepointOp` and `HookOperation` now expose the same `with_savepoint` / `begin_savepoint` API as `DbOp`, enabling per-sub-item isolation inside an already-isolated batch item and letting commit hooks isolate multi-statement writes inside `pre_commit`.
> 
> **Hook rollup** changes: releasing an inner savepoint folds staged commit hooks into the **immediate** parent’s buffer (another `SavepointOp`’s `staged` or root `DbOp` / `HookOperation`), not straight into the root. `HookParent` (`Root` vs `Nested`) drives that folding; `SavepointOp::add_commit_hook` and `supports_hooks` now follow whether the enclosing chain can accept hooks (e.g. still refuses on `force_execute_pre_commit`).
> 
> **Implementation**: `SavepointOp::begin` accepts any `sqlx::Acquire` (not only `&mut Transaction`) so hooks can open savepoints on a bare connection. Docs add a savepoints “Nesting” section and note `HookOperation` savepoints in commit-hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba21fd10da7b171bf750939145e9b09f9fa52b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->