### PR TITLE
feat(operation): delegate AtomicOperation with a macro, drop WrapsOperation

### DIFF
--- a/book/src/connection-traits.md
+++ b/book/src/connection-traits.md
@@ -49,7 +49,7 @@ Implementations of `AtomicOperation`:
 - `OpWithTime<'_, Op>` (where `Op: AtomicOperation`)
 - `HookOperation<'_>` (used internally by hooks)
 - `SavepointOp<'_>` (see [Savepoints](./savepoints.md))
-- anything implementing [`WrapsOperation`](#wrapping-another-operation)
+- anything using the [`delegate_atomic_operation!`](#wrapping-another-operation) macro
 
 Every `AtomicOperation` also gets `with_savepoint` / `begin_savepoint` from the blanket `SavepointOperation` trait — see [Savepoints](./savepoints.md).
 
@@ -59,50 +59,45 @@ Most code never implements `AtomicOperation`; it takes `&mut impl AtomicOperatio
 
 ### Wrapping another operation
 
-A type that wraps an operation — a newtype over `&mut DbOp` that seals off `commit()`, a restricted view handed to a callback — should implement `WrapsOperation` rather than `AtomicOperation`:
+A type that wraps an operation — a newtype over `&mut DbOp` that seals off `commit()`, a restricted view handed to a callback — should use the `delegate_atomic_operation!` macro rather than writing the impl out:
 
 ```rust,ignore
 struct FlushOp<'a>(&'a mut es_entity::DbOp<'static>);
 
-impl<'a> WrapsOperation for FlushOp<'a> {
-    type Inner = es_entity::DbOp<'static>;
-    fn op(&self) -> &Self::Inner { self.0 }
-    fn op_mut(&mut self) -> &mut Self::Inner { self.0 }
-}
+es_entity::delegate_atomic_operation!(FlushOp<'_>, { s => s.0 });
 ```
 
-That is the entire implementation. A blanket impl derives all of `AtomicOperation` from those two accessors — time, clock, executor, commit hooks, `supports_hooks`, savepoints — each reporting the wrapped operation's real capability rather than a trait default. Methods added to `AtomicOperation` later cost you nothing.
+That is the entire implementation. The macro generates all of `AtomicOperation` — time, clock, executor, commit hooks, `supports_hooks`, savepoints — each reporting the wrapped operation's real capability rather than a trait default. Methods added to `AtomicOperation` later cost you nothing.
 
-Delegating by hand instead is not just verbose, it is a trap: a method you forget silently inherits its default, so `maybe_now` starts returning `None` or `supports_hooks` returns `false`. The behaviour changes and nothing fails to compile.
+Crucially it adds **no accessor of its own**. The wrapped operation stays exactly as private as you made it, so a type that withholds `&mut` access on purpose — to stop callers committing it or swapping it out — keeps that guarantee.
 
-`WrapsOperation` is all-or-nothing. A type cannot implement it *and* override one method, since that needs its own conflicting `impl AtomicOperation`. Two cases therefore hand-write the impl:
+Delegating by hand instead is not just verbose, it is a trap: a method you forget silently inherits its default, so `maybe_now` starts returning `None`, `supports_hooks` returns `false`, or `savepoint_parts` reports no hook buffer while the wrapped op has one. The behaviour changes and nothing fails to compile.
 
-- **Wrappers that genuinely differ.** `OpWithTime` and `DbOpWithTime` override `maybe_now` to report their cached time.
-- **Enums that dispatch over several operations.** A single associated `Inner` cannot cover several variants, so each method is a `match`:
+### Enums
 
-  ```rust,ignore
-  impl AtomicOperation for UseCaseOp<'_, '_> {
-      fn connection(&mut self) -> &mut db::Connection {
-          match self {
-              Self::Owned(op) => op.connection(),
-              Self::Db(op) => op.connection(),
-              Self::Savepoint(op) => op.connection(),
-          }
-      }
+An enum choosing between several operations works the same way. Arms may hold different types, because the macro generates the `match` inside each method rather than unifying the arms into one value:
 
-      fn savepoint_parts(&mut self) -> (&mut db::Connection, HookSlot<'_>) {
-          match self {
-              Self::Owned(op) => op.savepoint_parts(),
-              Self::Db(op) => op.savepoint_parts(),
-              Self::Savepoint(op) => op.savepoint_parts(),
-          }
-      }
+```rust,ignore
+es_entity::delegate_atomic_operation!(UseCaseOp<'_, '_>, {
+    Self::Owned(op) => op,
+    Self::Db(op) => op,
+    Self::Savepoint(op) => op,
+});
+```
 
-      // ...and so on for the remaining methods
-  }
-  ```
+Delegating `savepoint_parts` this way is what lets such an enum open a savepoint whatever it currently holds — including nesting when it is already savepoint-backed.
 
-  Dispatching `savepoint_parts` this way is what lets such an enum open a savepoint whatever it currently holds — including nesting when it is already savepoint-backed.
+### Generic types
+
+Pass the impl generics in brackets first:
+
+```rust,ignore
+es_entity::delegate_atomic_operation!([<'a, T: AtomicOperation>] MyOp<'a, T>, { s => s.inner });
+```
+
+### When not to use it
+
+Only for pure delegation — the macro forwards every method. A wrapper that changes behaviour must hand-write the impl; `OpWithTime` and `DbOpWithTime` do, since both override `maybe_now` to report their cached time.
 
 ### Owning a connection directly
 
@@ -123,7 +118,7 @@ fn savepoint_parts(&mut self) -> (&mut db::Connection, HookSlot<'_>) {
 
 Because the default reports "no hook buffer", a type that forwards `supports_hooks` to an operation it wraps but forgets to override `savepoint_parts` would refuse hooks inside every savepoint taken through it, while the wrapped operation supports them fine — a behaviour change with no compile error.
 
-`begin_savepoint` therefore fails with a protocol error when an operation reports `supports_hooks()` but hands back an unsupported slot. The two can only disagree that one way, so the check has no false positives: an op that honestly has no hooks reports `false` on both sides. Implementing `WrapsOperation` avoids the situation entirely.
+`begin_savepoint` therefore fails with a protocol error when an operation reports `supports_hooks()` but hands back an unsupported slot. The two can only disagree that one way, so the check has no false positives: an op that honestly has no hooks reports `false` on both sides. Using the `delegate_atomic_operation!` macro avoids the situation entirely.
 
 ## IntoOneTimeExecutor
 

--- a/book/src/savepoints.md
+++ b/book/src/savepoints.md
@@ -80,7 +80,7 @@ sp.release().await?;
 | `HookOperation` | the running commit pass, or nothing on the `force_execute_pre_commit` path |
 | `OpWithTime<'_, Op>` | whatever the wrapped operation folds into |
 | `sqlx::Transaction` | nothing — hooks are refused |
-| your own `WrapsOperation` type | whatever the wrapped operation folds into |
+| your own delegating type | whatever the wrapped operation folds into |
 
 Because the API lives on a trait, one generic helper serves them all:
 
@@ -102,7 +102,7 @@ async fn process_all(
 
 `DbOp` and `DbOpWithTime` also keep inherent `with_savepoint` / `begin_savepoint` methods, so existing call sites work without importing the trait. Reaching for them on any *other* operation needs `use es_entity::SavepointOperation;`.
 
-Your own operation types get savepoints too — see [implementing `AtomicOperation`](./connection-traits.md#implementing-the-trait). Wrapper types need only `WrapsOperation`; nothing there is savepoint-specific.
+Your own operation types get savepoints too — see [implementing `AtomicOperation`](./connection-traits.md#implementing-the-trait). Wrapper types need only the `delegate_atomic_operation!` macro; nothing there is savepoint-specific.
 
 ## Nesting
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -571,3 +571,114 @@ macro_rules! entity_id {
         $crate::__entity_id_conversions!($($from => $to),*);
     };
 }
+
+/// Implements [`AtomicOperation`](crate::AtomicOperation) for a type by
+/// delegating every method to an operation it holds.
+///
+/// A type that wraps or dispatches to another operation — a newtype over
+/// `&mut DbOp` that seals off `commit()`, a restricted view handed to a
+/// callback, an enum choosing between several ops — needs all of
+/// `AtomicOperation` forwarded. Written by hand that is eight near-identical
+/// bodies per type, and a method left out silently inherits a trait default:
+/// `maybe_now` starts reporting `None`, `supports_hooks` `false`, or
+/// [`savepoint_parts`](crate::AtomicOperation::savepoint_parts) reports no hook
+/// buffer while the wrapped op has one. The behaviour changes and nothing fails
+/// to compile.
+///
+/// This macro generates the whole impl, so those cannot drift apart, and it adds
+/// **no** public accessor — the wrapped operation stays as private as it was.
+/// That matters for types that withhold `&mut` access on purpose: exposing it
+/// would let a caller swap the operation out or commit it directly.
+///
+/// # Newtype
+///
+/// ```rust,ignore
+/// struct FlushOp<'a>(&'a mut es_entity::DbOp<'static>);
+///
+/// es_entity::delegate_atomic_operation!(FlushOp<'_>, { s => s.0 });
+/// ```
+///
+/// # Enum
+///
+/// Each arm names a pattern and the operation to delegate to. Arms may hold
+/// different types — `DbOp`, `&mut DbOp`, `&mut SavepointOp` — because the
+/// generated code calls the method inside each arm rather than unifying the
+/// arms into one value.
+///
+/// ```rust,ignore
+/// es_entity::delegate_atomic_operation!(UseCaseOp<'_, '_>, {
+///     Self::Owned(op) => op,
+///     Self::Db(op) => op,
+///     Self::Savepoint(op) => op,
+/// });
+/// ```
+///
+/// # Generic types
+///
+/// Pass the impl generics in brackets first:
+///
+/// ```rust,ignore
+/// es_entity::delegate_atomic_operation!([<'a, T: es_entity::AtomicOperation>] MyOp<'a, T>, {
+///     s => s.inner
+/// });
+/// ```
+///
+/// # When not to use it
+///
+/// Only for pure delegation. A wrapper that changes behaviour — reporting its
+/// own cached time, refusing hooks — must hand-write the impl, since this macro
+/// forwards every method.
+#[macro_export]
+macro_rules! delegate_atomic_operation {
+    // Bracketed generics first: otherwise the bare arm below tries to parse a
+    // leading `[` as the start of a slice type.
+    ([$($generics:tt)*] $ty:ty, { $($pat:pat => $target:expr),+ $(,)? }) => {
+        impl $($generics)* $crate::AtomicOperation for $ty {
+            fn maybe_now(
+                &self,
+            ) -> Option<$crate::prelude::chrono::DateTime<$crate::prelude::chrono::Utc>> {
+                match self { $($pat => $target.maybe_now()),+ }
+            }
+
+            fn clock(&self) -> &$crate::clock::ClockHandle {
+                match self { $($pat => $target.clock()),+ }
+            }
+
+            fn connection(&mut self) -> &mut $crate::db::Connection {
+                match self { $($pat => $target.connection()),+ }
+            }
+
+            fn as_executor(
+                &mut self,
+            ) -> $crate::OneTimeExecutor<'_, &mut $crate::db::Connection> {
+                match self { $($pat => $target.as_executor()),+ }
+            }
+
+            fn add_commit_hook<__H: $crate::hooks::CommitHook>(
+                &mut self,
+                hook: __H,
+            ) -> Result<(), __H> {
+                match self { $($pat => $target.add_commit_hook(hook)),+ }
+            }
+
+            fn commit_hook<__H: $crate::hooks::CommitHook>(&self) -> Option<&__H> {
+                match self { $($pat => $target.commit_hook::<__H>()),+ }
+            }
+
+            fn supports_hooks(&self) -> bool {
+                match self { $($pat => $target.supports_hooks()),+ }
+            }
+
+            fn savepoint_parts(
+                &mut self,
+            ) -> (&mut $crate::db::Connection, $crate::HookSlot<'_>) {
+                match self { $($pat => $target.savepoint_parts()),+ }
+            }
+        }
+    };
+
+    // Bare form: no impl generics.
+    ($ty:ty, { $($pat:pat => $target:expr),+ $(,)? }) => {
+        $crate::delegate_atomic_operation!([] $ty, { $($pat => $target),+ });
+    };
+}

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -477,8 +477,9 @@ pub trait AtomicOperation: Send {
     /// that has none — a bare [`sqlx::Transaction`] needs nothing else.
     ///
     /// It is **not** correct for an operation that wraps one which does. Such a
-    /// type must override this (or implement [`WrapsOperation`], which does it
-    /// for you), because the default would otherwise refuse hooks inside every
+    /// type must override this — the
+    /// [`delegate_atomic_operation!`](crate::delegate_atomic_operation) macro
+    /// does it for you — because the default would otherwise refuse hooks inside every
     /// savepoint taken through it while the wrapped operation supports them
     /// fine. That mismatch is caught rather than left silent:
     /// [`begin_savepoint`](SavepointOperation::begin_savepoint) fails with a
@@ -488,92 +489,6 @@ pub trait AtomicOperation: Send {
     /// `savepoint_parts`" produces.
     fn savepoint_parts(&mut self) -> (&mut db::Connection, savepoint::HookSlot<'_>) {
         (self.connection(), savepoint::HookSlot::unsupported())
-    }
-}
-
-/// Derives the whole of [`AtomicOperation`] for a type that wraps another
-/// operation, by delegation.
-///
-/// A wrapper that restricts or re-presents an operation — obix's `FlushOp`, a
-/// newtype that seals off `commit()`, anything holding a `&mut DbOp` — needs
-/// every [`AtomicOperation`] method to forward to the operation inside. Written
-/// by hand that is eight near-identical bodies, it must be redone for each new
-/// wrapper, and a method left out silently inherits a trait default: `maybe_now`
-/// starts reporting `None`, or `supports_hooks` `false`, changing behaviour
-/// rather than failing to compile.
-///
-/// Implement this instead and the delegation is generated:
-///
-/// ```rust,ignore
-/// struct FlushOp<'a>(&'a mut es_entity::DbOp<'static>);
-///
-/// impl<'a> WrapsOperation for FlushOp<'a> {
-///     type Inner = es_entity::DbOp<'static>;
-///     fn op(&self) -> &Self::Inner { self.0 }
-///     fn op_mut(&mut self) -> &mut Self::Inner { self.0 }
-/// }
-/// ```
-///
-/// That is the entire implementation. `FlushOp` now has time, the clock, the
-/// executor, commit hooks, `supports_hooks`, and — through
-/// [`savepoint_parts`](AtomicOperation::savepoint_parts) — the full
-/// [`SavepointOperation`] pair including nesting, all with the inner operation's
-/// real capabilities rather than a default. Methods added to `AtomicOperation`
-/// in future cost implementors nothing.
-///
-/// # All or nothing
-///
-/// This is a blanket `impl AtomicOperation for W`, so a type cannot implement
-/// `WrapsOperation` *and* override a single method — that would need its own
-/// `impl AtomicOperation`, which would conflict. Wrappers that genuinely differ
-/// from the operation they hold write the impl by hand instead; [`OpWithTime`]
-/// and [`DbOpWithTime`] do exactly that, since both override
-/// [`maybe_now`](AtomicOperation::maybe_now) to report their cached time.
-///
-/// Use `WrapsOperation` for pure delegation; hand-write the impl when the
-/// wrapper changes behaviour.
-pub trait WrapsOperation: Send {
-    /// The operation being wrapped.
-    type Inner: AtomicOperation + ?Sized;
-
-    /// Shared access, for the `&self` methods.
-    fn op(&self) -> &Self::Inner;
-
-    /// Exclusive access, for the `&mut self` methods.
-    fn op_mut(&mut self) -> &mut Self::Inner;
-}
-
-impl<W: WrapsOperation> AtomicOperation for W {
-    fn maybe_now(&self) -> Option<chrono::DateTime<chrono::Utc>> {
-        self.op().maybe_now()
-    }
-
-    fn clock(&self) -> &ClockHandle {
-        self.op().clock()
-    }
-
-    fn connection(&mut self) -> &mut db::Connection {
-        self.op_mut().connection()
-    }
-
-    fn as_executor(&mut self) -> OneTimeExecutor<'_, &mut db::Connection> {
-        self.op_mut().as_executor()
-    }
-
-    fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
-        self.op_mut().add_commit_hook(hook)
-    }
-
-    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
-        self.op().commit_hook::<H>()
-    }
-
-    fn supports_hooks(&self) -> bool {
-        self.op().supports_hooks()
-    }
-
-    fn savepoint_parts(&mut self) -> (&mut db::Connection, savepoint::HookSlot<'_>) {
-        self.op_mut().savepoint_parts()
     }
 }
 

--- a/src/operation/savepoint.rs
+++ b/src/operation/savepoint.rs
@@ -278,7 +278,8 @@ impl AtomicOperation for SavepointOp<'_> {
 /// This trait has a blanket implementation and no methods to implement: an
 /// operation earns savepoints by implementing
 /// [`AtomicOperation::savepoint_parts`], and a wrapper type that implements
-/// [`WrapsOperation`](super::WrapsOperation) gets even that by delegation. So
+/// the [`delegate_atomic_operation!`](crate::delegate_atomic_operation) macro
+/// generates even that. So
 /// `DbOp`, `DbOpWithTime`, `SavepointOp` (nesting), [`HookOperation`], a bare
 /// [`sqlx::Transaction`], any [`OpWithTime`] wrapper, and operation types
 /// defined outside this crate all share one implementation of the pair.
@@ -380,7 +381,8 @@ pub trait SavepointOperation: AtomicOperation {
                     "operation reports supports_hooks() but its savepoint_parts() \
                      yields no hook buffer — commit hooks registered inside this \
                      savepoint would be silently refused. Implement \
-                     AtomicOperation::savepoint_parts (or WrapsOperation) on this \
+                     AtomicOperation::savepoint_parts (or use the 
+                     delegate_atomic_operation! macro) on this \
                      type instead of inheriting the default."
                         .to_string(),
                 ));

--- a/tests/savepoint.rs
+++ b/tests/savepoint.rs
@@ -1,7 +1,7 @@
 mod helpers;
 
 use es_entity::operation::{
-    AtomicOperation, DbOp, SavepointOperation, WrapsOperation,
+    AtomicOperation, DbOp, SavepointOperation,
     hooks::{CommitHook, HookOperation, PreCommitRet},
 };
 use std::sync::{Arc, Mutex};
@@ -638,23 +638,14 @@ async fn explicit_savepoint_release_and_rollback() -> anyhow::Result<()> {
 /// An operation defined *outside* `es_entity::operation` — standing in for the
 /// wrapper types consumers define (obix's `BatchOp` / `IsolatedOp` / `FlushOp`).
 ///
-/// This is the whole implementation. Two accessors earn the entire
+/// This is the whole implementation: one macro line earns the entire
 /// `AtomicOperation` surface — time, clock, executor, commit hooks — and with it
 /// `SavepointOperation`, nesting included, all carrying the inner operation's
-/// real capabilities rather than trait defaults.
+/// real capabilities rather than trait defaults. Note that no accessor for the
+/// wrapped `DbOp` is exposed, so a wrapper can still seal it off.
 struct WrapperOp<'a>(&'a mut DbOp<'static>);
 
-impl<'a> WrapsOperation for WrapperOp<'a> {
-    type Inner = DbOp<'static>;
-
-    fn op(&self) -> &Self::Inner {
-        self.0
-    }
-
-    fn op_mut(&mut self) -> &mut Self::Inner {
-        self.0
-    }
-}
+es_entity::delegate_atomic_operation!(WrapperOp<'_>, { s => s.0 });
 
 /// Delegation must carry the inner op's real answers, not the trait defaults —
 /// the failure mode being a wrapper that silently reports `supports_hooks()
@@ -667,15 +658,7 @@ async fn wrapping_op_delegates_full_capability() -> anyhow::Result<()> {
 
     // Wrap a DbOpWithTime to prove the associated type is not pinned to DbOp.
     struct TimedWrapper<'a>(&'a mut es_entity::operation::DbOpWithTime<'static>);
-    impl<'a> WrapsOperation for TimedWrapper<'a> {
-        type Inner = es_entity::operation::DbOpWithTime<'static>;
-        fn op(&self) -> &Self::Inner {
-            self.0
-        }
-        fn op_mut(&mut self) -> &mut Self::Inner {
-            self.0
-        }
-    }
+    es_entity::delegate_atomic_operation!(TimedWrapper<'_>, { s => s.0 });
 
     let mut wrapper = TimedWrapper(&mut op);
     assert!(
@@ -1057,12 +1040,11 @@ async fn nested_savepoint_under_force_executed_hook_refuses_hooks() -> anyhow::R
 }
 
 // ---------------------------------------------------------------------------
-// An enum-dispatching operation — lana's `UseCaseOp` shape. `WrapsOperation`
-// cannot serve this (one associated `Inner` cannot cover four variants), so the
-// impl is hand-written; `savepoint_parts` is simply one more match in the same
-// style as the methods already there. The payoff is that `isolated` below needs
-// no per-variant special-casing and no "savepoints unsupported" error: the
-// savepoint-backed variant nests, rather than being refused.
+// An enum-dispatching operation — lana's `UseCaseOp` shape. Each arm holds a
+// different type, so the macro generates the match inside every method rather
+// than unifying the arms into one value. The payoff is that `isolated` below
+// needs no per-variant special-casing and no "savepoints unsupported" error:
+// the savepoint-backed variant nests, rather than being refused.
 // ---------------------------------------------------------------------------
 
 enum UseCaseOp<'op, 'parent> {
@@ -1071,71 +1053,11 @@ enum UseCaseOp<'op, 'parent> {
     Savepoint(&'op mut es_entity::operation::SavepointOp<'parent>),
 }
 
-impl AtomicOperation for UseCaseOp<'_, '_> {
-    fn maybe_now(&self) -> Option<chrono::DateTime<chrono::Utc>> {
-        match self {
-            Self::Owned(op) => op.maybe_now(),
-            Self::Db(op) => op.maybe_now(),
-            Self::Savepoint(op) => op.maybe_now(),
-        }
-    }
-
-    fn clock(&self) -> &es_entity::clock::ClockHandle {
-        match self {
-            Self::Owned(op) => AtomicOperation::clock(op),
-            Self::Db(op) => AtomicOperation::clock(*op),
-            Self::Savepoint(op) => AtomicOperation::clock(*op),
-        }
-    }
-
-    fn connection(&mut self) -> &mut es_entity::db::Connection {
-        match self {
-            Self::Owned(op) => op.connection(),
-            Self::Db(op) => op.connection(),
-            Self::Savepoint(op) => op.connection(),
-        }
-    }
-
-    fn add_commit_hook<H: CommitHook>(&mut self, hook: H) -> Result<(), H> {
-        match self {
-            Self::Owned(op) => op.add_commit_hook(hook),
-            Self::Db(op) => op.add_commit_hook(hook),
-            Self::Savepoint(op) => op.add_commit_hook(hook),
-        }
-    }
-
-    fn commit_hook<H: CommitHook>(&self) -> Option<&H> {
-        match self {
-            Self::Owned(op) => op.commit_hook::<H>(),
-            Self::Db(op) => op.commit_hook::<H>(),
-            Self::Savepoint(op) => op.commit_hook::<H>(),
-        }
-    }
-
-    fn supports_hooks(&self) -> bool {
-        match self {
-            Self::Owned(op) => op.supports_hooks(),
-            Self::Db(op) => op.supports_hooks(),
-            Self::Savepoint(op) => op.supports_hooks(),
-        }
-    }
-
-    /// The one addition. Every variant already knows how to yield its parts, so
-    /// this is pure dispatch — and it is what lets `isolated` treat all variants
-    /// alike, the savepoint-backed one included.
-    fn savepoint_parts(
-        &mut self,
-    ) -> (
-        &mut es_entity::db::Connection,
-        es_entity::operation::HookSlot<'_>,
-    ) {
-        match self {
-            Self::Owned(op) => op.savepoint_parts(),
-            Self::Db(op) => op.savepoint_parts(),
-            Self::Savepoint(op) => op.savepoint_parts(),
-        }
-    }
-}
+es_entity::delegate_atomic_operation!(UseCaseOp<'_, '_>, {
+    Self::Owned(op) => op,
+    Self::Db(op) => op,
+    Self::Savepoint(op) => op,
+});
 
 impl UseCaseOp<'_, '_> {
     /// No variant match, no `SavepointsUnsupported`: uniform across all of them.
@@ -1329,5 +1251,47 @@ async fn honest_hookless_op_still_savepoints() -> anyhow::Result<()> {
         labels(&pool, &prefix).await?,
         vec![format!("{prefix}-kept")]
     );
+    Ok(())
+}
+
+/// The macro's bracketed-generics form: a wrapper generic over the operation it
+/// holds, which is the shape `OpWithTime` would have if it delegated purely.
+struct GenericWrapper<'a, Op: AtomicOperation + ?Sized> {
+    inner: &'a mut Op,
+}
+
+es_entity::delegate_atomic_operation!(
+    [<'a, Op: AtomicOperation + ?Sized>] GenericWrapper<'a, Op>,
+    { s => s.inner }
+);
+
+#[tokio::test]
+async fn generic_wrapper_delegates_and_savepoints() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let prefix = format!("sp-{}", new_id());
+    let probe = Probe::default();
+    let mut op = DbOp::init(&pool).await?;
+
+    {
+        let mut wrapper = GenericWrapper { inner: &mut op };
+        assert!(wrapper.supports_hooks());
+
+        let res = wrapper
+            .with_savepoint(async |sp| {
+                assert!(sp.supports_hooks());
+                insert_item_in_op(sp, new_id(), &format!("{prefix}-kept")).await?;
+                sp.add_commit_hook(probe.hook("generic")).unwrap();
+                Ok::<_, sqlx::Error>(())
+            })
+            .await?;
+        assert!(res.is_ok());
+    }
+
+    op.commit().await?;
+    assert_eq!(
+        labels(&pool, &prefix).await?,
+        vec![format!("{prefix}-kept")]
+    );
+    assert_eq!(probe.post(), vec!["generic".to_string()]);
     Ok(())
 }


### PR DESCRIPTION
## Summary

`WrapsOperation` shipped in 0.12.13 as the way for a wrapper type to derive `AtomicOperation`. **obix cannot adopt it**, and the reason is not incidental — so this replaces it with a macro before anyone builds on it.

Patch-level: `savepoint_parts` keeps its default, nothing else changes shape.

## Why `WrapsOperation` doesn't work

All three obix wrapper ops (`BatchOp`, `IsolatedOp`, `FlushOp` in `src/out/ctx.rs`) hand-write `AtomicOperation` precisely to **withhold** mutable access to the `DbOp` they hold. Their own `op_mut` is private, and the type doc states the property directly:

> There is no mutable access to the raw `es_entity::DbOp` (only a shared `Deref` view): committing, rolling back, or **swapping out the underlying op is unrepresentable**, so work and checkpoint can only land together, through the runner.

`WrapsOperation::op_mut` is necessarily **public** — trait methods are as visible as the trait. Implementing it hands any third-party handler holding a `&mut FlushOp` a `&mut DbOp<'static>`, and with it the ability to commit the real op or `mem::swap` in a decoy. The mechanism built for wrapper consumers is unusable by the wrapper consumer that needed it most.

It also cannot express an **enum** dispatching over several operations — a single associated `Inner` cannot cover variants of different types, which is exactly lana's `UseCaseOp` shape.

## What replaces it

```rust
// newtype — sealing intact, no accessor added
es_entity::delegate_atomic_operation!(FlushOp<'_>, { s => s.0 });

// enum — arms may hold different types
es_entity::delegate_atomic_operation!(UseCaseOp<'_, '_>, {
    Self::Owned(op) => op,
    Self::Db(op) => op,
    Self::Savepoint(op) => op,
});

// generic wrapper — impl generics in brackets first
es_entity::delegate_atomic_operation!([<'a, Op: AtomicOperation + ?Sized>] MyOp<'a, Op>, { s => s.inner });
```

The macro generates the impl in place and **exposes no accessor at all**, so a type's sealing survives untouched. Enum arms of differing types work because the generated code calls each method *inside* the arm rather than unifying the arms into one value, so method-call auto-deref absorbs the difference.

## Removal, not deprecation

`WrapsOperation` shipped one patch release ago and has **no adopters** — no consumer repo references it (`grep -rn "WrapsOperation"` across cala, job, obix, lana returns nothing). Deprecating it would leave a trap that cannot be adopted safely; removing it now costs nothing.

## What is unchanged

`savepoint_parts` keeps its default, and the `begin_savepoint` coherence check stays. A wrapper that forwards `supports_hooks` while inheriting the default still gets a loud protocol error rather than silently refusing hooks — the macro is what makes that mistake hard to reach in the first place, not a replacement for the guard.

## Tests

289 passing. `tests/savepoint.rs` now exercises the macro in all three forms — a newtype wrapper, a wrapper over `DbOpWithTime` (asserting cached time and hook support survive delegation rather than falling back to defaults), the `UseCaseOp` enum with nested `isolated()`, and a generic wrapper. The enum's previous 65-line hand-written impl is now one macro call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a public trait in favor of a macro (breaking for any **`WrapsOperation`** adopter, though none exist); changes are central to **`AtomicOperation`** delegation and savepoint hook propagation.
> 
> **Overview**
> Replaces the **`WrapsOperation`** trait (and its blanket **`AtomicOperation`** impl) with an exported **`delegate_atomic_operation!`** macro so wrapper types can derive full operation behavior **without** a public **`op` / `op_mut`** accessor that would break sealing of the inner **`DbOp`**.
> 
> The macro supports **newtypes**, **enum dispatch** across different inner operation types, and **generic wrappers** (impl generics in brackets). It forwards every **`AtomicOperation`** method—including **`savepoint_parts`**—so capability cannot silently fall back to trait defaults. Docs and **`begin_savepoint`** protocol errors now point at the macro instead of **`WrapsOperation`**. **`tests/savepoint.rs`** switches existing wrapper/enum cases to the macro and adds coverage for the generic form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820609c22c0046431ddaaf1c04accd650adf68d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->