### PR TITLE
feat(macros): allow nullable (Option<T>) scope columns

### DIFF
--- a/book/src/scoped-repositories.md
+++ b/book/src/scoped-repositories.md
@@ -104,19 +104,15 @@ pub enum PartyScope {
 ```
 
 The SQL conjunct is unchanged: `customer_id = $n`. Since SQL `=` never matches
-`NULL`, a row whose `customer_id` is `NULL` is simply invisible to every
-scoped variant — it behaves like a row that belongs to some other scope,
-falling out of the existing predicate with no special-casing. Only `All`
-sees it. Use this when NULL genuinely means "this row is unowned / belongs to
-no scope", not as a stand-in for "not yet migrated" — a backfill that leaves
-rows NULL will make them silently disappear from every scoped read.
-
-There is, as ever, deliberately **no** `From<Option<CustomerId>>`: a scope
-value passed at a call site is always concrete, so `PartyScope::Customer(None)`
-is unspellable. A column marked `nullable` (the opt-in for a non-`Option`
-Rust type whose custom `sqlx::Encode` maps some value to SQL `NULL`) is still
-rejected as a scope column — there is no inner type to unwrap, and scoping by
-the NULL-encoding value would silently match no rows at all.
+`NULL`, a row whose `customer_id` is `NULL` is invisible to every scoped
+variant — only `All` sees it — with no special-casing anywhere. Use this when
+NULL genuinely means "this row is unowned", not as a stand-in for "not yet
+migrated": a backfill that leaves rows NULL makes them silently disappear from
+every scoped read. There is deliberately **no** `From<Option<CustomerId>>` — a
+scope value is always concrete, so `PartyScope::Customer(None)` is unspellable
+— and a column marked `nullable` (the opt-in flag for a non-`Option` Rust type
+backed by a nullable SQL column) is still rejected as a scope column, since
+there is no inner type to unwrap.
 
 ## Tenancy roots: `id(scope)`
 

--- a/book/src/scoped-repositories.md
+++ b/book/src/scoped-repositories.md
@@ -78,6 +78,46 @@ Variant names, whether defaulted or overridden, must still be pairwise
 distinct and may not collide with the reserved `All` variant (see
 "Validation rules" below).
 
+## Nullable scope columns
+
+A scope column's Rust type may be `Option<T>` — the generated variant still
+carries the bare inner type, never `Option<T>`:
+
+```rust,ignore
+#[derive(EsRepo)]
+#[es_repo(
+    entity = "Party",
+    columns(
+        customer_id(ty = "Option<CustomerId>", scope(variant = "Customer")),
+        name(ty = "String"),
+    )
+)]
+pub struct Parties {
+    pool: PgPool,
+}
+
+// generates:
+pub enum PartyScope {
+    All,
+    Customer(CustomerId),   // not Customer(Option<CustomerId>)
+}
+```
+
+The SQL conjunct is unchanged: `customer_id = $n`. Since SQL `=` never matches
+`NULL`, a row whose `customer_id` is `NULL` is simply invisible to every
+scoped variant — it behaves like a row that belongs to some other scope,
+falling out of the existing predicate with no special-casing. Only `All`
+sees it. Use this when NULL genuinely means "this row is unowned / belongs to
+no scope", not as a stand-in for "not yet migrated" — a backfill that leaves
+rows NULL will make them silently disappear from every scoped read.
+
+There is, as ever, deliberately **no** `From<Option<CustomerId>>`: a scope
+value passed at a call site is always concrete, so `PartyScope::Customer(None)`
+is unspellable. A column marked `nullable` (the opt-in for a non-`Option`
+Rust type whose custom `sqlx::Encode` maps some value to SQL `NULL`) is still
+rejected as a scope column — there is no inner type to unwrap, and scoping by
+the NULL-encoding value would silently match no rows at all.
+
 ## Tenancy roots: `id(scope)`
 
 The tenancy-root entity itself — the `Partner` in a partner-scoped system —
@@ -317,16 +357,19 @@ self.repo
 
 The macro rejects at compile time:
 
-- scope columns whose Rust types are not pairwise distinct (the generated
-  `From<T>` conversions dispatch on type, so two same-typed scope columns
-  would produce conflicting impls)
+- scope columns whose types are not pairwise distinct, compared on the type
+  that lands in the generated enum — the inner type, for an `Option<T>`
+  scope column (the generated `From<T>` conversions dispatch on that type, so
+  two scope columns that resolve to the same type would produce conflicting
+  impls)
 - scope columns whose variant names collide with each other or with the
   reserved `All` variant — whether the name is the UpperCamel default or an
   explicit `scope(variant = "...")` override
 - a `scope(variant = "...")` value that isn't a valid Rust identifier
-- an `Option<T>` or `nullable`-annotated scope column (nullable scope columns
-  are not supported — every row must belong to exactly one scope, in every
-  dimension)
+- a `nullable`-annotated scope column whose Rust type is not syntactically
+  `Option<T>` (see [Nullable scope columns](#nullable-scope-columns) above —
+  there is no inner type to unwrap, and scoping by the NULL-encoding value
+  would silently match no rows)
 - a `Forgettable<T>` scope column
 - `scope` on nested repos — children are custody-guarded via their (scoped)
   parent

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -729,7 +729,11 @@ mod tests {
     }
 
     #[test]
-    fn optional_scope_column_is_error() {
+    fn optional_scope_column_is_ok() {
+        // A syntactic Option<T> scope column is accepted: the generated
+        // variant and its `From` impl carry the bare inner type, never
+        // `Option<T>` — a scope value is always concrete, and NULL rows are
+        // simply invisible to this variant (only `All` sees them).
         let input: syn::DeriveInput = parse_quote! {
             #[es_repo(
                 entity = "User",
@@ -739,15 +743,30 @@ mod tests {
                 pool: sqlx::PgPool,
             }
         };
-        let err = derive(input).unwrap_err();
-        assert!(
-            err.to_string().contains("non-nullable"),
-            "unexpected error: {err}"
-        );
+        let tokens = derive(input)
+            .expect("Option<T> scope column should derive")
+            .to_string();
+        assert!(tokens.contains("pub enum UserScope"));
+        // the variant carries the bare inner type, not Option<PartnerId>.
+        // The full derive output legitimately still contains "Option <
+        // PartnerId >" elsewhere (the column itself stays declared
+        // `Option<PartnerId>` for create/persist — only the scope enum and
+        // its `From` impls unwrap it), so assert on the specific
+        // scope-related spots rather than the whole token stream.
+        assert!(tokens.contains("PartnerId (PartnerId)"));
+        assert!(!tokens.contains("PartnerId (Option < PartnerId >)"));
+        assert!(tokens.contains("impl From < PartnerId > for UserScope"));
+        assert!(tokens.contains("impl From < & PartnerId > for UserScope"));
+        assert!(!tokens.contains("impl From < Option < PartnerId > > for UserScope"));
+        // the SQL conjunct is the ordinary equality — NULL rows fall out of
+        // `=` semantics with zero special-casing.
+        assert!(tokens.contains("WHERE id = $1 AND partner_id = $2"));
     }
 
     #[test]
     fn nullable_annotated_scope_column_is_error() {
+        // Unlike Option<T>, a `nullable`-annotated non-Option scope column
+        // has no inner type to unwrap — still rejected.
         let input: syn::DeriveInput = parse_quote! {
             #[es_repo(
                 entity = "User",
@@ -759,7 +778,7 @@ mod tests {
         };
         let err = derive(input).unwrap_err();
         assert!(
-            err.to_string().contains("non-nullable"),
+            err.to_string().contains("only syntactic Option<T>"),
             "unexpected error: {err}"
         );
     }

--- a/es-entity-macros/src/repo/options/columns.rs
+++ b/es-entity-macros/src/repo/options/columns.rs
@@ -57,14 +57,20 @@ impl Columns {
 
     /// Validates the `scope` column markers:
     ///
-    /// - scope columns must have pairwise-distinct Rust types (the generated
-    ///   `From<T>` conversions dispatch on type, so two same-typed scope
-    ///   columns would produce conflicting impls) and pairwise-distinct
-    ///   variant names (UpperCamel of the column name), neither colliding
-    ///   with the reserved `All` variant
-    /// - every scope column must be non-nullable (`Option<T>` and
-    ///   `nullable`-annotated types are rejected — nullable scope columns are
-    ///   a future feature)
+    /// - scope columns must have pairwise-distinct Rust types, compared on
+    ///   the type that lands in the generated enum ([`Column::ty_for_scope`]
+    ///   — the inner type for an `Option<T>` column) since the generated
+    ///   `From<T>` conversions dispatch on that type: two scope columns that
+    ///   resolve to the same type would produce conflicting impls. Variant
+    ///   names (UpperCamel of the column name, or `scope(variant = "...")`)
+    ///   must also be pairwise-distinct and not collide with the reserved
+    ///   `All` variant
+    /// - a `nullable`-annotated scope column whose Rust type is not
+    ///   syntactically `Option<T>` is rejected: there is no inner type to
+    ///   unwrap, and scoping by the NULL-encoding value would silently match
+    ///   no rows. Syntactic `Option<T>` scope columns are allowed — the
+    ///   generated variant carries the inner `T`, and NULL rows are simply
+    ///   invisible to every scoped variant (`All` still sees them)
     /// - every scope column must not be `Forgettable<T>`
     /// - no scope column may be the `parent` column (nested repos cannot be
     ///   scoped — children are custody-guarded via their parent)
@@ -83,9 +89,9 @@ impl Columns {
             ));
         }
         for col in &scope_columns {
-            if col.is_nullable_column() {
+            if col.opts.nullable() && !col.is_optional() {
                 return Err(darling::Error::custom(format!(
-                    "scope column '{}' must be non-nullable — nullable scope columns are not supported (yet)",
+                    "scope column '{}' is `nullable`-annotated — only syntactic Option<T> scope columns are supported (the NULL-encoding value would silently match no rows)",
                     col.name(),
                 )));
             }
@@ -102,12 +108,13 @@ impl Columns {
                 )));
             }
         }
-        // The generated From<T> conversions dispatch on the Rust type — every
-        // scope column must have a distinct type or the impls conflict.
+        // The generated From<T> conversions dispatch on the type that lands
+        // in the enum (the inner type for an Option<T> scope column) — every
+        // scope column must resolve to a distinct type or the impls conflict.
         for (i, a) in scope_columns.iter().enumerate() {
             for b in &scope_columns[i + 1..] {
-                let ty_a = quote::ToTokens::to_token_stream(a.ty()).to_string();
-                let ty_b = quote::ToTokens::to_token_stream(b.ty()).to_string();
+                let ty_a = quote::ToTokens::to_token_stream(&a.ty_for_scope()).to_string();
+                let ty_b = quote::ToTokens::to_token_stream(&b.ty_for_scope()).to_string();
                 if ty_a == ty_b {
                     return Err(darling::Error::custom(format!(
                         "scope columns '{}' and '{}' have the same Rust type '{}' — the generated From<T> conversions would conflict; use distinct newtype ids",
@@ -721,6 +728,18 @@ impl Column {
 
     pub fn name(&self) -> &syn::Ident {
         &self.name
+    }
+
+    /// The Rust type used in the generated `{Entity}Scope` enum variant, its
+    /// `From` impl, and the query bind. For a scope column whose declared
+    /// type is syntactically `Option<Inner>`, this is `Inner` — the
+    /// generated variant is `{Variant}(Inner)`, never `{Variant}(Option
+    /// <Inner>)`, since a scope value is always concrete: NULL rows match no
+    /// scoped variant (only `All` sees them). Non-`Option` scope columns are
+    /// unaffected. Only meaningful for columns marked `scope`; mirrors the
+    /// `Forgettable<Inner>` unwrapping in [`Self::ty_for_find_by`].
+    pub fn ty_for_scope(&self) -> syn::Type {
+        option_inner(self.ty()).unwrap_or_else(|| self.ty().clone())
     }
 
     pub fn ty(&self) -> &syn::Type {
@@ -1490,5 +1509,81 @@ mod tests {
             err.contains("reserved variant name"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn nullable_option_scope_column_is_accepted() {
+        // A syntactic Option<T> scope column is the new feature: previously
+        // rejected outright, now validates fine — the enum variant carries
+        // the inner type (checked in scope.rs's token tests).
+        let input: syn::Meta = parse_quote!(columns(customer_id(
+            ty = "Option<CustomerId>",
+            scope(variant = "Customer")
+        )));
+        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        assert!(columns.validate_scope().is_ok());
+        let scope_cols = columns.scope_columns();
+        let col = scope_cols
+            .first()
+            .expect("customer_id should be scope column");
+        assert!(col.is_optional());
+        assert_eq!(col.scope_variant().to_string(), "Customer");
+    }
+
+    #[test]
+    fn ty_for_scope_unwraps_option_to_inner_type() {
+        let input: syn::Meta = parse_quote!(columns(customer_id(ty = "Option<CustomerId>", scope)));
+        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        let scope_cols = columns.scope_columns();
+        let col = scope_cols
+            .first()
+            .expect("customer_id should be scope column");
+        assert_eq!(
+            quote::ToTokens::to_token_stream(&col.ty_for_scope()).to_string(),
+            quote!(CustomerId).to_string(),
+        );
+    }
+
+    #[test]
+    fn ty_for_scope_is_identity_for_non_option_column() {
+        let input: syn::Meta = parse_quote!(columns(partner_id(ty = "PartnerId", scope)));
+        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        let scope_cols = columns.scope_columns();
+        let col = scope_cols
+            .first()
+            .expect("partner_id should be scope column");
+        assert_eq!(
+            quote::ToTokens::to_token_stream(&col.ty_for_scope()).to_string(),
+            quote!(PartnerId).to_string(),
+        );
+    }
+
+    #[test]
+    fn nullable_annotated_non_option_scope_column_still_rejected() {
+        // `nullable` (the opt-in flag for a non-Option Rust type whose custom
+        // Encode maps a value to SQL NULL) has no inner type to unwrap into a
+        // variant payload — still rejected, with a narrowed message.
+        let input: syn::Meta = parse_quote!(columns(status(ty = "StatusEnum", nullable, scope)));
+        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        let err = columns.validate_scope().unwrap_err().to_string();
+        assert!(err.contains("nullable"), "unexpected error: {err}");
+        assert!(
+            err.contains("only syntactic Option<T>"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn option_and_bare_same_inner_type_scope_columns_rejected() {
+        // customer_id: Option<CustomerId> and other_customer_id: CustomerId
+        // both resolve to the same From<CustomerId> impl target — must be
+        // caught even though their declared Rust types differ syntactically.
+        let input: syn::Meta = parse_quote!(columns(
+            customer_id(ty = "Option<CustomerId>", scope),
+            other_customer_id(ty = "CustomerId", scope)
+        ));
+        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        let err = columns.validate_scope().unwrap_err().to_string();
+        assert!(err.contains("same Rust type"), "unexpected error: {err}");
     }
 }

--- a/es-entity-macros/src/repo/scope.rs
+++ b/es-entity-macros/src/repo/scope.rs
@@ -10,16 +10,21 @@ use convert_case::{Case, Casing};
 use proc_macro2::Span;
 
 /// One scope column: its enum variant ident (UpperCamel of the column name,
-/// e.g. `partner_id` -> `PartnerId`), the column name, and its Rust type.
+/// e.g. `partner_id` -> `PartnerId`), the column name, and its scope type
+/// ([`Column::ty_for_scope`] — the inner type, for a nullable `Option<T>`
+/// scope column).
 #[derive(Clone)]
 pub struct ScopeCol<'a> {
     pub variant: syn::Ident,
     pub column_name: &'a syn::Ident,
-    pub column_ty: &'a syn::Type,
+    pub column_ty: syn::Type,
 }
 
 impl ScopeCol<'_> {
     /// The SQL conjunct for this column's arm at the given parameter index.
+    /// Unchanged for a nullable scope column: `col = $n` never matches SQL
+    /// NULL, so rows where the column is NULL are invisible to this arm
+    /// with zero special-casing.
     pub fn predicate(&self, param_idx: u32) -> String {
         format!("{} = ${}", self.column_name, param_idx)
     }
@@ -27,7 +32,7 @@ impl ScopeCol<'_> {
     /// The query binding for this column's arm (pairs with the dispatch
     /// arm's `__scope_val` pattern binding).
     pub fn arg_tokens(&self) -> TokenStream {
-        let column_ty = self.column_ty;
+        let column_ty = &self.column_ty;
         quote! { __scope_val as &#column_ty, }
     }
 }
@@ -70,7 +75,7 @@ impl<'a> ScopeInfo<'a> {
             .map(|col| ScopeCol {
                 variant: col.scope_variant(),
                 column_name: col.name(),
-                column_ty: col.ty(),
+                column_ty: col.ty_for_scope(),
             })
             .collect();
         if cols.is_empty() {
@@ -134,7 +139,10 @@ impl<'a> ScopeInfo<'a> {
 /// plus `From<T>` / `From<&T>` conversions into each column's variant so call
 /// sites can pass a scope value directly. Deliberately **no**
 /// `From<Option<T>>`: mapping `None` to `All` would turn a stray `None` into
-/// silent all-scope access.
+/// silent all-scope access. For a scope column whose declared Rust type is
+/// `Option<T>` ([`Column::ty_for_scope`] unwraps it), `T` is what appears
+/// here — `Scope::X(None)` is unspellable, and rows where the column is NULL
+/// are simply invisible to every scoped variant (only `All` sees them).
 pub struct ScopeType<'a> {
     entity: &'a syn::Ident,
     info: ScopeInfo<'a>,
@@ -160,7 +168,7 @@ impl ToTokens for ScopeType<'_> {
 
         let variants = self.info.cols.iter().map(|col| {
             let variant = &col.variant;
-            let column_ty = col.column_ty;
+            let column_ty = &col.column_ty;
             let vdoc = format!(
                 "Restricts every read to rows whose `{}` column equals the value.",
                 col.column_name,
@@ -173,7 +181,7 @@ impl ToTokens for ScopeType<'_> {
 
         let from_impls = self.info.cols.iter().map(|col| {
             let variant = &col.variant;
-            let column_ty = col.column_ty;
+            let column_ty = &col.column_ty;
             quote! {
                 impl From<#column_ty> for #scope_ty {
                     fn from(value: #column_ty) -> Self {
@@ -223,7 +231,7 @@ mod tests {
                     .map(|(name, ty)| ScopeCol {
                         variant: variant_ident(name),
                         column_name: name,
-                        column_ty: ty,
+                        column_ty: (*ty).clone(),
                     })
                     .collect(),
             },

--- a/migrations/20260826000000_nullable_scope_test.sql
+++ b/migrations/20260826000000_nullable_scope_test.sql
@@ -1,0 +1,22 @@
+-- Mirrors lana's core/party shape: `customer_id` is a scope column whose
+-- Rust type is `Option<CustomerId>`. NULL encodes "no customer owns this row
+-- directly" (e.g. an organization-member individual party) — such rows must
+-- be invisible to every `Customer(_)` scoped read and visible only under
+-- `All`.
+CREATE TABLE parties (
+  id UUID PRIMARY KEY,
+  customer_id UUID,
+  name VARCHAR NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_parties_customer_created_id ON parties (customer_id, created_at DESC, id DESC);
+
+CREATE TABLE party_events (
+  id UUID NOT NULL REFERENCES parties(id),
+  sequence INT NOT NULL,
+  event_type VARCHAR NOT NULL,
+  event JSONB NOT NULL,
+  context JSONB DEFAULT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(id, sequence)
+);

--- a/tests/entities/mod.rs
+++ b/tests/entities/mod.rs
@@ -3,6 +3,7 @@ pub mod customer;
 pub mod facility;
 pub mod order;
 pub mod partner;
+pub mod party;
 pub mod profile;
 pub mod task;
 pub mod transfer;

--- a/tests/entities/party.rs
+++ b/tests/entities/party.rs
@@ -1,0 +1,82 @@
+#![allow(dead_code)]
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use es_entity::*;
+
+es_entity::entity_id! { PartyId }
+es_entity::entity_id! { CustomerId }
+
+/// Mirrors lana's `core/party` shape: `customer_id` is a **nullable** scope
+/// column. `Some(id)` means the party is a customer's own party (owned);
+/// `None` means the party belongs to no customer directly (e.g. an
+/// organization-member individual party) — such rows must stay invisible to
+/// every `Customer(_)` scoped read.
+#[derive(EsEvent, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "PartyId")]
+pub enum PartyEvent {
+    Initialized {
+        id: PartyId,
+        customer_id: Option<CustomerId>,
+        name: String,
+    },
+}
+
+#[derive(EsEntity, Builder)]
+#[builder(pattern = "owned", build_fn(error = "EntityHydrationError"))]
+pub struct Party {
+    pub id: PartyId,
+    pub customer_id: Option<CustomerId>,
+    pub name: String,
+
+    events: EntityEvents<PartyEvent>,
+}
+
+impl TryFromEvents<PartyEvent> for Party {
+    fn try_from_events(events: EntityEvents<PartyEvent>) -> Result<Self, EntityHydrationError> {
+        let mut builder = PartyBuilder::default();
+        for event in events.iter_all() {
+            match event {
+                PartyEvent::Initialized {
+                    id,
+                    customer_id,
+                    name,
+                } => {
+                    builder = builder.id(*id).customer_id(*customer_id).name(name.clone());
+                }
+            }
+        }
+        builder.events(events).build()
+    }
+}
+
+#[derive(Debug, Builder)]
+pub struct NewParty {
+    #[builder(setter(into))]
+    pub id: PartyId,
+    #[builder(setter(into, strip_option), default)]
+    pub customer_id: Option<CustomerId>,
+    #[builder(setter(into))]
+    pub name: String,
+}
+
+impl NewParty {
+    pub fn builder() -> NewPartyBuilder {
+        NewPartyBuilder::default()
+    }
+}
+
+impl IntoEvents<PartyEvent> for NewParty {
+    fn into_events(self) -> EntityEvents<PartyEvent> {
+        EntityEvents::init(
+            self.id,
+            [PartyEvent::Initialized {
+                id: self.id,
+                customer_id: self.customer_id,
+                name: self.name,
+            }],
+        )
+    }
+}

--- a/tests/nullable_scoped_repo.rs
+++ b/tests/nullable_scoped_repo.rs
@@ -1,0 +1,216 @@
+mod entities;
+mod helpers;
+
+use sqlx::PgPool;
+
+use entities::party::*;
+use es_entity::*;
+
+/// Mirrors lana's `core/party` shape: `customer_id` is a **nullable** scope
+/// column (`Option<CustomerId>`). The generated `PartyScope::Customer`
+/// variant carries the bare `CustomerId`, never `Option<CustomerId>` — a
+/// scope value is always concrete. Rows whose `customer_id` is NULL (no
+/// customer owns them directly) are invisible to every `Customer(_)` scoped
+/// read; only `All` sees them.
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "Party",
+    columns(
+        customer_id(
+            ty = "Option<CustomerId>",
+            scope(variant = "Customer"),
+            update(persist = false)
+        ),
+        name(ty = "String"),
+    )
+)]
+pub struct Parties {
+    pool: PgPool,
+}
+
+impl Parties {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+async fn seed_owned(
+    repo: &Parties,
+    customer_id: CustomerId,
+    name: &str,
+) -> anyhow::Result<PartyId> {
+    let id = PartyId::new();
+    let new = NewParty::builder()
+        .id(id)
+        .customer_id(customer_id)
+        .name(name)
+        .build()
+        .unwrap();
+    repo.create(new).await?;
+    Ok(id)
+}
+
+async fn seed_unowned(repo: &Parties, name: &str) -> anyhow::Result<PartyId> {
+    let id = PartyId::new();
+    // No `.customer_id(..)` call — the field stays `None`, persisted as SQL
+    // NULL: this row belongs to no customer directly.
+    let new = NewParty::builder().id(id).name(name).build().unwrap();
+    repo.create(new).await?;
+    Ok(id)
+}
+
+/// The generated variant carries the inner `CustomerId`, not
+/// `Option<CustomerId>` — this is a compile-time property (the line below
+/// would not type-check if the variant were `Customer(Option<CustomerId>)`
+/// or if a `From<Option<CustomerId>>` impl existed), asserted here so it's
+/// exercised on every test run.
+#[tokio::test]
+async fn scope_variant_carries_inner_type_not_option() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let parties = Parties::new(pool);
+
+    let customer_id = CustomerId::new();
+    let id = seed_owned(&parties, customer_id, "acme individual").await?;
+
+    // raw CustomerId routes through `From<CustomerId> for PartyScope`
+    let found = parties.find_by_id(customer_id, id).await?;
+    assert_eq!(found.customer_id, Some(customer_id));
+
+    // explicit enum spelling: `PartyScope::Customer` takes `CustomerId`
+    // directly.
+    let scope = PartyScope::Customer(customer_id);
+    parties.find_by_id(scope, id).await?;
+
+    Ok(())
+}
+
+/// The defining nullable-scope semantics: a NULL-`customer_id` row is
+/// invisible under `Customer(_)` (looks exactly like a missing / foreign row)
+/// but visible under `All`.
+#[tokio::test]
+async fn null_scoped_row_invisible_to_customer_scope_visible_to_all() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let parties = Parties::new(pool);
+
+    let customer_id = CustomerId::new();
+    let unowned_id = seed_unowned(&parties, "org member individual").await?;
+
+    // NOT NotFound because of a real customer mismatch — NotFound because
+    // the row's customer_id is NULL and `customer_id = $1` never matches
+    // NULL, for any bound value.
+    let err = parties.find_by_id(customer_id, unowned_id).await;
+    assert!(matches!(err, Err(PartyFindError::NotFound { .. })));
+    assert!(
+        parties
+            .maybe_find_by_id(customer_id, unowned_id)
+            .await?
+            .is_none()
+    );
+
+    // a *different* customer scope value must fail identically — this is
+    // not "wrong id", it's "no id could ever match".
+    let other_customer_id = CustomerId::new();
+    assert!(
+        parties
+            .maybe_find_by_id(other_customer_id, unowned_id)
+            .await?
+            .is_none()
+    );
+
+    // `All` is the audited escape hatch: it still sees the row.
+    let found = parties.find_by_id(PartyScope::All, unowned_id).await?;
+    assert_eq!(found.customer_id, None);
+
+    Ok(())
+}
+
+/// `find_all` under a customer scope must silently drop NULL-scoped rows
+/// from a batch that mixes owned and unowned ids — never surface them, never
+/// error.
+#[tokio::test]
+async fn find_all_excludes_null_scoped_rows_under_customer_scope() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let parties = Parties::new(pool);
+
+    let customer_id = CustomerId::new();
+    let owned_id = seed_owned(&parties, customer_id, "owned").await?;
+    let unowned_id = seed_unowned(&parties, "unowned").await?;
+    let ids = vec![owned_id, unowned_id];
+
+    let found = parties.find_all::<Party>(customer_id, &ids).await?;
+    assert_eq!(found.len(), 1);
+    assert!(found.contains_key(&owned_id));
+    assert!(!found.contains_key(&unowned_id));
+
+    let found = parties.find_all::<Party>(PartyScope::All, &ids).await?;
+    assert_eq!(found.len(), 2);
+
+    Ok(())
+}
+
+/// `list_by_created_at` under a customer scope must never page in a
+/// NULL-scoped row — checked across the full paginated walk, not just a
+/// first page, since the nullable-aware `NULLS FIRST/LAST` cursor machinery
+/// used by ordinary (non-scope) nullable columns must not leak into the
+/// scope predicate itself.
+#[tokio::test]
+async fn list_excludes_null_scoped_rows_across_pagination() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let parties = Parties::new(pool);
+
+    let customer_id = CustomerId::new();
+    let owned_a = seed_owned(&parties, customer_id, "owned_a").await?;
+    let owned_b = seed_owned(&parties, customer_id, "owned_b").await?;
+    let _unowned = seed_unowned(&parties, "unowned").await?;
+    let _other_customer = seed_owned(&parties, CustomerId::new(), "other customer").await?;
+
+    let mut collected = Vec::new();
+    let mut after: Option<party_cursor::PartyByCreatedAtCursor> = None;
+    loop {
+        let ret = parties
+            .list_by_created_at(
+                customer_id,
+                PaginatedQueryArgs { first: 1, after },
+                ListDirection::Descending,
+            )
+            .await?;
+        collected.extend(ret.entities.iter().map(|p| p.id));
+        if !ret.has_next_page {
+            break;
+        }
+        after = ret.end_cursor;
+    }
+
+    let expected: std::collections::HashSet<_> = [owned_a, owned_b].into_iter().collect();
+    let collected: std::collections::HashSet<_> = collected.into_iter().collect();
+    assert_eq!(collected, expected);
+
+    Ok(())
+}
+
+/// `repo.scoped(customer_id)` — the bound view — inherits the same
+/// NULL-exclusion behavior as the scope-argument fns it delegates to.
+#[tokio::test]
+async fn bound_view_excludes_null_scoped_rows() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let parties = Parties::new(pool);
+
+    let customer_id = CustomerId::new();
+    let owned_id = seed_owned(&parties, customer_id, "owned").await?;
+    let _unowned_id = seed_unowned(&parties, "unowned").await?;
+
+    let view = parties.scoped(customer_id);
+    let ret = view
+        .list_by_created_at(
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert_eq!(ret.entities.len(), 1);
+    assert_eq!(ret.entities[0].id, owned_id);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

A scope column's Rust type may now be `Option<T>`. The generated `{Entity}Scope` enum variant still carries the bare inner `T` — never `Option<T>` — and the SQL conjunct stays `col = $n`. Since `=` never matches SQL NULL, a row whose scope column is NULL is simply invisible to every scoped variant with zero special-casing; only `All` sees it. There is still deliberately no `From<Option<T>>`: a scope value passed at a call site is always concrete.

This unblocks lana-bank's `core/party` customer-scope adoption, where `customer_id` is NULL for organization-member individual parties (no customer owns them directly) and must be non-null for prospect/customer parties.

## What NULL means

NULL on a scope column means **"this row belongs to no scope directly"** (ownership-absence) — not "not yet migrated," not "matches every scope." Every read path (`find_by_id`/`maybe_find_by_id`, `find_all`, `list_by_*`, `list_for_*`, `list_for_filters`, the `.scoped(...)` bound view) shares the same `col = $n` predicate, so all of them uniformly exclude NULL-scoped rows under any concrete scoped variant; only `All` (the audited escape hatch) sees them. No `From<Option<T>>` is generated, so a scope value can never be silently constructed from `None`.

## Changes

- `Column::ty_for_scope()` resolves the type that lands in the generated enum (the `Option`-unwrapped inner type for a nullable scope column, the declared type otherwise). Used by both the pairwise-distinct-type validation and the scope codegen — fixes a latent gap where `customer_id: Option<CustomerId>` + `other_id: CustomerId` on the same repo would not have been caught as conflicting by the macro's own validation (compared raw declared types), only by a confusing `rustc` E0119 on the generated `From` impls.
- `validate_scope()`: a `nullable`-annotated scope column is now rejected only when it is **not** syntactically `Option<T>` (no inner type to unwrap; scoping by the NULL-encoding value would silently match no rows).
- `ScopeCol::column_ty` is now the resolved (post-unwrap) type.
- `book/src/scoped-repositories.md`: new "Nullable scope columns" section + updated validation-rules bullet.

## Testing

- New macro unit tests (acceptance, narrowed rejection, resolved-type pairwise conflict) in `columns.rs` / `scope.rs` / `repo/mod.rs`; updated two now-stale tests (`optional_scope_column_is_error` → rewritten as `optional_scope_column_is_ok`, `nullable_annotated_scope_column_is_error`'s message assertion) that asserted the old blanket rejection.
- New live-DB integration test (`tests/nullable_scoped_repo.rs` + `migrations/20260826000000_nullable_scope_test.sql`, test-only): a `Party` entity with a nullable `customer_id` scope column proves NULL rows are invisible under `Customer(_)` (point reads, `find_all`, paginated `list_by`, the bound view) and visible under `All`.
- **Revert-to-red**: reinstating the old rejection produces a deterministic compile-time failure at the `#[derive(EsRepo)]` site with the old error message, cascading correctly; restoring the fix reproduces green.
- `es-entity-macros --lib`: 168/168 passing. All pre-existing scope integration tests (`multi_scoped_repo`, `scoped_repo`, `scoped_repo_by_id`, `scoped_repo_sargable`, `option_column_filter`) still pass.

## Notes for reviewers

- This repo has no `.sqlx` cache, and CI's offline `nix flake check` runs clippy without `--tests`, so it never compiles the sqlx-macro-using test code — that's only exercised by `nix run .#nextest` against a live database, which the testing above already matches. No `.sqlx` regeneration needed.
- The new migration is test-only (creates `parties`/`party_events` for the new integration test) — no consumer (obix/cala/lana) re-vendoring implication.
- Non-breaking: purely additive (a column that couldn't be `scope` before now can be); no `!` in the commit/PR title.
- lana-bank's actual `core/party` adoption (the `customer_id` column, migration, `AuthedScope::Customer` conversion) is separate consumer-side work, tracked against lana-bank PR #8470 / branch `task/use-case-context-01a03069`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-tenant read filtering semantics for nullable scope columns; incorrect NULL handling could hide rows from scoped queries, though behavior is additive and covered by integration tests.
> 
> **Overview**
> **Scoped repos** can now mark a column as `scope` when its Rust type is syntactic `Option<T>`. The macro generates `{Entity}Scope` variants and `From<T>` impls using the **unwrapped inner type** (`Customer(CustomerId)`), keeps SQL as plain `col = $n`, and still omits `From<Option<T>>` so scope values stay concrete.
> 
> **Validation** compares scope columns on `Column::ty_for_scope()` (fixing conflicts between `Option<CustomerId>` and bare `CustomerId` on the same repo). `nullable`-annotated non-`Option` scope columns remain rejected with a clearer error.
> 
> **Docs and tests**: new "Nullable scope columns" section in `scoped-repositories.md`; macro unit tests and a live-DB `Party` / `nullable_scoped_repo` integration suite assert NULL rows are invisible under scoped reads and only visible under `All`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f38c955f3b8a8bdeb119a1e2f0dc171f69da52b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->