### PR TITLE
feat(macros)!: add fail-closed None variant to generated scopes

### DIFF
--- a/book/src/scoped-repositories.md
+++ b/book/src/scoped-repositories.md
@@ -32,6 +32,7 @@ per scope column (UpperCamel of the column name):
 ```rust,ignore
 pub enum CustomerScope {
     All,                     // no filter — reads across all scopes
+    None,                    // no scope established — every read fail-closes
     PartnerId(PartnerId),    // restricts every read to this scope value
 }
 
@@ -39,9 +40,11 @@ impl From<PartnerId> for CustomerScope { /* => PartnerId */ }
 impl From<&PartnerId> for CustomerScope { /* => PartnerId */ }
 ```
 
-There is deliberately **no** `From<Option<PartnerId>>`: mapping `None` to
-`All` would turn a stray `None` into silent all-scope access. All-scope reads
-must be written explicitly — `CustomerScope::All` is greppable and auditable.
+There is deliberately **no** `From<Option<PartnerId>>`: mapping `None` (the
+value) to `All` would turn a stray `None` into silent all-scope access.
+All-scope reads must be written explicitly — `CustomerScope::All` is
+greppable and auditable. `CustomerScope::None` is the reserved, explicit
+opposite — see [Fail-closed: `None`](#fail-closed-none) below.
 
 ### Overriding the variant name
 
@@ -75,7 +78,7 @@ The override only renames the enum variant and its `From` impl target — the
 underlying SQL conjunct is still keyed off the real column (`partner_id = $n`).
 Overridden and defaulted scope columns compose freely on the same repo.
 Variant names, whether defaulted or overridden, must still be pairwise
-distinct and may not collide with the reserved `All` variant (see
+distinct and may not collide with the reserved `All` or `None` variants (see
 "Validation rules" below).
 
 ## Nullable scope columns
@@ -113,6 +116,29 @@ scope value is always concrete, so `PartyScope::Customer(None)` is unspellable
 — and a column marked `nullable` (the opt-in flag for a non-`Option` Rust type
 backed by a nullable SQL column) is still rejected as a scope column, since
 there is no inner type to unwrap.
+
+## Fail-closed: `None`
+
+`All` is the audited "read across every scope" escape hatch. `None` is its
+fail-closed opposite: the reserved variant for a caller that could not
+establish any scope at all — no authenticated principal, no tenant resolved
+on the request. Every generated scope enum carries it alongside `All`:
+
+```rust,ignore
+customers.find_by_id(CustomerScope::None, id).await;   // NotFound
+```
+
+`None` dispatches exactly like a scope value that matches no rows —
+`find_by_*` returns `NotFound`, `maybe_find_by_*` returns `None`, `find_all`
+omits every id, and lists come back empty with no next page — **except the
+dispatch never reaches the database**. The SQL for that arm is never built or
+executed; `None` short-circuits before the query would run. This extends
+"missing and not-yours look identical" (see below) one step further: "no
+scope" and "not-yours" look identical too, and neither one costs a query.
+
+`None` is reserved the same way `All` is: a scope column's variant name
+(defaulted or `scope(variant = "...")`-overridden) may not collide with
+either.
 
 ## Tenancy roots: `id(scope)`
 
@@ -195,17 +221,20 @@ customers.find_by_id(id).await?;  // does not exist — compile error
 ```
 
 At runtime each function dispatches between static, compile-time-checked SQL
-variants — one per scope column plus `All`:
+variants — one per scope column plus `All` and `None`:
 
 - `All` executes exactly the SQL an unscoped repo would.
 - Each column's variant (e.g. `PartnerId(value)`) executes a variant with an
   additional `partner_id = $n` conjunct in every `WHERE` clause.
+- `None` executes no SQL at all — see [Fail-closed:
+  `None`](#fail-closed-none) above.
 
 Every arm is a plain equality predicate — sargable against a scope-column-led
 index (see below). Under any scoped variant, a row from another scope behaves
 exactly like a missing row: `find_by_*` returns `NotFound`, `maybe_find_by_*`
 returns `None`, `find_all` silently omits the id, and lists never contain the
-row. **Missing and not-yours look identical.**
+row. **Missing and not-yours look identical** — and, thanks to `None`,
+neither one costs a query.
 
 ## The bound view: `repo.scoped(scope)`
 
@@ -278,7 +307,7 @@ non-sargable `COALESCE` query until its indexes exist.
 Scope column Rust types must be pairwise distinct (the generated `From<T>`
 conversions dispatch on type — two same-typed scope columns would produce
 conflicting impls) and their UpperCamel variant names must not collide with
-each other or with the reserved `All` variant.
+each other or with the reserved `All` or `None` variants.
 
 ## Writes are custody-guarded
 
@@ -359,8 +388,8 @@ The macro rejects at compile time:
   two scope columns that resolve to the same type would produce conflicting
   impls)
 - scope columns whose variant names collide with each other or with the
-  reserved `All` variant — whether the name is the UpperCamel default or an
-  explicit `scope(variant = "...")` override
+  reserved `All` or `None` variants — whether the name is the UpperCamel
+  default or an explicit `scope(variant = "...")` override
 - a `scope(variant = "...")` value that isn't a valid Rust identifier
 - a `nullable`-annotated scope column whose Rust type is not syntactically
   `Option<T>` (see [Nullable scope columns](#nullable-scope-columns) above —

--- a/es-entity-macros/src/repo/find_all_fn.rs
+++ b/es-entity-macros/src/repo/find_all_fn.rs
@@ -118,6 +118,7 @@ impl ToTokens for FindAllFn<'_> {
         let fetch_call = if let Some(scope) = &self.scope {
             scope.dispatch(
                 quote! { #es_query_call.fetch_n(op, ids.len()).await? },
+                quote! { (Vec::new(), false) },
                 |col| {
                     let scoped_query = format!(
                         "SELECT id FROM {} WHERE id = ANY($1) AND {}",

--- a/es-entity-macros/src/repo/find_by_fn.rs
+++ b/es-entity-macros/src/repo/find_by_fn.rs
@@ -219,22 +219,27 @@ impl ToTokens for FindByFn<'_> {
                     quote! { fetch_optional }
                 };
                 let fetch_optional_call = if let Some(scope) = &self.scope {
-                    scope.dispatch(quote! { #es_query_call.#fetch_method(op).await? }, |col| {
-                        let scoped_query = format!(
-                            r#"SELECT id FROM {} WHERE {} {} $1 AND {}{}"#,
-                            self.table_name,
-                            column_name,
-                            filter_op,
-                            col.predicate(2),
-                            if delete == DeleteOption::No {
-                                self.delete.not_deleted_condition()
-                            } else {
-                                ""
-                            }
-                        );
-                        let scoped_es_query_call = make_es_query(&scoped_query, &col.arg_tokens());
-                        quote! { #scoped_es_query_call.#fetch_method(op).await? }
-                    })
+                    scope.dispatch(
+                        quote! { #es_query_call.#fetch_method(op).await? },
+                        quote! { None },
+                        |col| {
+                            let scoped_query = format!(
+                                r#"SELECT id FROM {} WHERE {} {} $1 AND {}{}"#,
+                                self.table_name,
+                                column_name,
+                                filter_op,
+                                col.predicate(2),
+                                if delete == DeleteOption::No {
+                                    self.delete.not_deleted_condition()
+                                } else {
+                                    ""
+                                }
+                            );
+                            let scoped_es_query_call =
+                                make_es_query(&scoped_query, &col.arg_tokens());
+                            quote! { #scoped_es_query_call.#fetch_method(op).await? }
+                        },
+                    )
                 } else {
                     quote! { #es_query_call.#fetch_method(op).await? }
                 };

--- a/es-entity-macros/src/repo/list_by_fn.rs
+++ b/es-entity-macros/src/repo/list_by_fn.rs
@@ -575,6 +575,7 @@ impl ToTokens for ListByFn<'_> {
                             #query_arms
                         }
                     },
+                    quote! { (Vec::new(), false) },
                     |col| {
                         let scoped_query_arms = build_query_arms(Some(col));
                         quote! {

--- a/es-entity-macros/src/repo/list_for_filters_fn.rs
+++ b/es-entity-macros/src/repo/list_for_filters_fn.rs
@@ -781,6 +781,7 @@ impl<'a> ListForFiltersFn<'a> {
         let match_expr = if let Some(scope) = &self.scope {
             scope.dispatch(
                 direction_match(&asc_arms, &asc_fallback_arm, &desc_arms, &desc_fallback_arm),
+                quote! { (Vec::new(), false) },
                 |col| {
                     let (scoped_asc_arms, scoped_desc_arms, scoped_all_specialized) =
                         build_specialized_arms(Some(col));

--- a/es-entity-macros/src/repo/list_for_fn.rs
+++ b/es-entity-macros/src/repo/list_for_fn.rs
@@ -268,6 +268,7 @@ impl ToTokens for ListForFn<'_> {
                             #query_arms
                         }
                     },
+                    quote! { (Vec::new(), false) },
                     |col| {
                         let scoped_query_arms = build_query_arms(Some(col));
                         quote! {

--- a/es-entity-macros/src/repo/options/columns.rs
+++ b/es-entity-macros/src/repo/options/columns.rs
@@ -64,7 +64,7 @@ impl Columns {
     ///   resolve to the same type would produce conflicting impls. Variant
     ///   names (UpperCamel of the column name, or `scope(variant = "...")`)
     ///   must also be pairwise-distinct and not collide with the reserved
-    ///   `All` variant
+    ///   `All` or `None` variants
     /// - a `nullable`-annotated scope column whose Rust type is not
     ///   syntactically `Option<T>` is rejected: there is no inner type to
     ///   unwrap, and scoping by the NULL-encoding value would silently match
@@ -131,10 +131,11 @@ impl Columns {
         let mut variant_names: Vec<String> = Vec::new();
         for col in &scope_columns {
             let variant = col.scope_variant().to_string();
-            if variant == "All" {
+            if variant == "All" || variant == "None" {
                 return Err(darling::Error::custom(format!(
-                    "scope column '{}' maps to the reserved variant name 'All'",
+                    "scope column '{}' maps to the reserved variant name '{}'",
                     col.name(),
+                    variant,
                 )));
             }
             if variant_names.contains(&variant) {
@@ -1502,6 +1503,21 @@ mod tests {
         let input: syn::Meta = parse_quote!(columns(partner_id(
             ty = "PartnerId",
             scope(variant = "All")
+        )));
+        let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
+        let err = columns.validate_scope().unwrap_err().to_string();
+        assert!(
+            err.contains("reserved variant name"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn overridden_variant_colliding_with_none_is_rejected() {
+        // `None` is reserved for the fail-closed variant, same as `All`.
+        let input: syn::Meta = parse_quote!(columns(partner_id(
+            ty = "PartnerId",
+            scope(variant = "None")
         )));
         let columns = Columns::from_meta(&input).expect("Failed to parse Fields");
         let err = columns.validate_scope().unwrap_err().to_string();

--- a/es-entity-macros/src/repo/scope.rs
+++ b/es-entity-macros/src/repo/scope.rs
@@ -103,12 +103,16 @@ impl<'a> ScopeInfo<'a> {
         quote! { let __scope = scope.into(); }
     }
 
-    /// Runtime dispatch between the unscoped (`All`) query variant and one
-    /// variant per scope column. `scoped_arm` is invoked once per column to
-    /// build that column's arm body; the arm pattern binds `__scope_val: &T`.
+    /// Runtime dispatch between the unscoped (`All`) query variant, the
+    /// fail-closed `None` variant, and one variant per scope column.
+    /// `none_arm` is the early-return value for `None` — it must never touch
+    /// the database (see [`ScopeType`]'s doc for why). `scoped_arm` is
+    /// invoked once per column to build that column's arm body; the arm
+    /// pattern binds `__scope_val: &T`.
     pub fn dispatch(
         &self,
         all_arm: TokenStream,
+        none_arm: TokenStream,
         scoped_arm: impl Fn(&ScopeCol<'a>) -> TokenStream,
     ) -> TokenStream {
         let scope_ty = &self.scope_ty;
@@ -120,6 +124,7 @@ impl<'a> ScopeInfo<'a> {
         quote! {
             match &__scope {
                 #scope_ty::All => #all_arm,
+                #scope_ty::None => #none_arm,
                 #(#arms)*
             }
         }
@@ -131,6 +136,7 @@ impl<'a> ScopeInfo<'a> {
 /// ```ignore
 /// pub enum UserScope {
 ///     All,
+///     None,
 ///     PartnerId(PartnerId),
 ///     CustomerId(CustomerId),
 /// }
@@ -138,11 +144,23 @@ impl<'a> ScopeInfo<'a> {
 ///
 /// plus `From<T>` / `From<&T>` conversions into each column's variant so call
 /// sites can pass a scope value directly. Deliberately **no**
-/// `From<Option<T>>`: mapping `None` to `All` would turn a stray `None` into
-/// silent all-scope access. For a scope column whose declared Rust type is
-/// `Option<T>` ([`Column::ty_for_scope`] unwraps it), `T` is what appears
-/// here — `Scope::X(None)` is unspellable, and rows where the column is NULL
-/// are simply invisible to every scoped variant (only `All` sees them).
+/// `From<Option<T>>`: mapping `None` (the value) to `All` would turn a stray
+/// `None` into silent all-scope access. For a scope column whose declared
+/// Rust type is `Option<T>` ([`Column::ty_for_scope`] unwraps it), `T` is
+/// what appears here — `Scope::X(None)` is unspellable, and rows where the
+/// column is NULL are simply invisible to every scoped variant (only `All`
+/// sees them).
+///
+/// `None` is the fail-closed counterpart to `All`: it is for a caller that
+/// could not establish any scope at all (no authenticated principal, no
+/// tenant on the request). Every read dispatches on it exactly like a scope
+/// value that matches no rows — `find_by_*` returns `NotFound`,
+/// `maybe_find_by_*` returns `None`, `find_all` omits every id, lists come
+/// back empty — except the dispatch never reaches the database: the SQL
+/// query for that arm is never built or executed. This mirrors "missing and
+/// not-yours look identical" (see the scoped-repositories book chapter) one
+/// step further: "no scope" and "not-yours" look identical too, and neither
+/// one costs a round trip.
 pub struct ScopeType<'a> {
     entity: &'a syn::Ident,
     info: ScopeInfo<'a>,
@@ -162,7 +180,8 @@ impl ToTokens for ScopeType<'_> {
         let scope_ty = &self.info.scope_ty;
         let doc = format!(
             "Scope argument for [`{}`] repository reads: each column variant filters every \
-             query by that scope column, `All` reads across all scopes (audited escape hatch).",
+             query by that scope column, `All` reads across all scopes (audited escape hatch), \
+             `None` fail-closes every read without touching the database.",
             self.entity,
         );
 
@@ -203,6 +222,9 @@ impl ToTokens for ScopeType<'_> {
             pub enum #scope_ty {
                 /// No scope filter — reads across all scopes.
                 All,
+                /// No scope established — every read fail-closes: it early-returns
+                /// as though nothing matched, without executing any query.
+                None,
                 #(#variants)*
             }
 
@@ -255,6 +277,7 @@ mod tests {
 
         assert!(token_str.contains("pub enum EntityScope"));
         assert!(token_str.contains("PartnerId (PartnerId)"));
+        assert!(token_str.contains("None ,"));
         assert!(!token_str.contains("Only"));
         assert!(token_str.contains("impl From < PartnerId > for EntityScope"));
         assert!(token_str.contains("impl From < & PartnerId > for EntityScope"));
@@ -280,6 +303,7 @@ mod tests {
         assert!(token_str.contains("pub enum EntityScope"));
         assert!(token_str.contains("PartnerId (PartnerId)"));
         assert!(token_str.contains("CustomerId (CustomerId)"));
+        assert!(token_str.contains("None ,"));
         assert!(token_str.contains("impl From < PartnerId > for EntityScope"));
         assert!(token_str.contains("impl From < CustomerId > for EntityScope"));
         assert!(token_str.contains("impl From < & CustomerId > for EntityScope"));
@@ -304,12 +328,13 @@ mod tests {
         let (info, _entity) = test_info(&[(&partner, &partner_ty), (&customer, &customer_ty)]);
 
         let tokens = info
-            .dispatch(quote! { all() }, |col| {
+            .dispatch(quote! { all() }, quote! { none() }, |col| {
                 let p = col.predicate(2);
                 quote! { scoped(#p) }
             })
             .to_string();
         assert!(tokens.contains("EntityScope :: All => all ()"));
+        assert!(tokens.contains("EntityScope :: None => none ()"));
         assert!(
             tokens
                 .contains("EntityScope :: PartnerId (__scope_val) => scoped (\"partner_id = $2\")")

--- a/tests/scoped_repo.rs
+++ b/tests/scoped_repo.rs
@@ -747,3 +747,160 @@ async fn scope_column_filter_cursor_pagination() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// `ContactScope::None` is the fail-closed counterpart to `All`: a caller
+/// that could not establish any scope. Every read must dispatch on it exactly
+/// like a scope value that matches no rows — the negative case that matters
+/// here is that a row a *real* scope would return is still denied under
+/// `None`.
+#[tokio::test]
+async fn none_scope_denies_access_like_a_foreign_scope() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let contacts = Contacts::new(pool);
+
+    let partner_a = PartnerId::new();
+    let ids_a = seed_contacts(
+        &contacts,
+        partner_a,
+        &[("none1", "active"), ("none2", "inactive")],
+    )
+    .await?;
+    let id_a = ids_a[0];
+
+    // positive control: under the row's own scope (or `All`) it is visible —
+    // proves the row genuinely exists and would be returned under a real
+    // scope, so the `None` denial below is not vacuous.
+    assert_eq!(
+        contacts.find_by_id(partner_a, id_a).await?.id,
+        id_a,
+        "sanity check: the row must be visible under its own scope"
+    );
+    assert_eq!(contacts.find_by_id(ContactScope::All, id_a).await?.id, id_a);
+
+    // `None`: point reads deny — indistinguishable from a foreign scope
+    let err = contacts.find_by_id(ContactScope::None, id_a).await;
+    assert!(matches!(err, Err(ContactFindError::NotFound { .. })));
+    assert!(
+        contacts
+            .maybe_find_by_id(ContactScope::None, id_a)
+            .await?
+            .is_none()
+    );
+    let err = contacts
+        .find_by_partner_id(ContactScope::None, partner_a)
+        .await;
+    assert!(matches!(err, Err(ContactFindError::NotFound { .. })));
+
+    // `find_all` omits every id, even ones that exist under a real scope
+    let found = contacts
+        .find_all::<Contact>(ContactScope::None, &ids_a)
+        .await?;
+    assert!(found.is_empty());
+
+    // lists come back empty, with no next page and no cursor
+    let ret = contacts
+        .list_by_created_at(
+            ContactScope::None,
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert!(ret.entities.is_empty());
+    assert!(!ret.has_next_page);
+    assert!(ret.end_cursor.is_none());
+
+    let ret = contacts
+        .list_for_status_by_created_at(
+            ContactScope::None,
+            "active",
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert!(ret.entities.is_empty());
+
+    let ret = contacts
+        .list_for_filters(
+            ContactScope::None,
+            ContactFilters::default(),
+            Sort {
+                by: ContactSortBy::CreatedAt,
+                direction: ListDirection::Descending,
+            },
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+        )
+        .await?;
+    assert!(ret.entities.is_empty());
+
+    // the bound view denies too — it just forwards to the scope-argument fns
+    let none_view = contacts.scoped(ContactScope::None);
+    assert!(none_view.maybe_find_by_id(id_a).await?.is_none());
+    assert_eq!(none_view.find_all::<Contact>(&ids_a).await?.len(), 0);
+
+    Ok(())
+}
+
+/// The defining property of `None`: it never reaches the database. Closing
+/// the pool after seeding turns any attempted query into a hard connection
+/// error, so a `None`-scoped read succeeding at all (with the *correct*
+/// fail-closed result, not just "didn't panic") is direct evidence the SQL
+/// for that arm was never built or executed. Contrast with the same read
+/// under a real scope, which does try to reach the (now-closed) database and
+/// fails.
+#[tokio::test]
+async fn none_scope_never_executes_a_query() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let contacts = Contacts::new(pool);
+
+    let partner_a = PartnerId::new();
+    let ids_a = seed_contacts(&contacts, partner_a, &[("closed", "active")]).await?;
+    let id_a = ids_a[0];
+
+    contacts.pool.close().await;
+    assert!(contacts.pool.is_closed());
+
+    // control: a real scope on a closed pool surfaces a connection error —
+    // proving the pool closure is actually in effect and would be observed
+    // if the None arm tried to query.
+    let err = contacts.find_by_id(partner_a, id_a).await;
+    assert!(
+        matches!(err, Err(ContactFindError::Sqlx(_))),
+        "expected a connection error against the closed pool"
+    );
+
+    // `None`: no connection is ever acquired, so the fail-closed result comes
+    // back cleanly instead of erroring.
+    let err = contacts.find_by_id(ContactScope::None, id_a).await;
+    assert!(
+        matches!(err, Err(ContactFindError::NotFound { .. })),
+        "expected NotFound (not a connection error) under None scope"
+    );
+    assert!(
+        contacts
+            .maybe_find_by_id(ContactScope::None, id_a)
+            .await?
+            .is_none()
+    );
+    let ret = contacts
+        .list_by_created_at(
+            ContactScope::None,
+            PaginatedQueryArgs {
+                first: 100,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert!(ret.entities.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds a `None` variant to every generated `{Entity}Scope` enum, alongside the existing `All`. `None` is the fail-closed counterpart: for a caller that could not establish any scope at all (no authenticated principal, no tenant resolved on the request), every generated read function dispatches on it exactly like a scope value that matches no rows — `find_by_*` returns `NotFound`, `maybe_find_by_*` returns `None`, `find_all` omits every id, lists come back empty with no next page — **except the dispatch never reaches the database**. The SQL for that arm is never built or executed.

## Why fail-closed (not fail-open)

This was discoverable from the existing code, not a coin-flip judgement call:

- The scope enum's own doc comment already states: *"Deliberately no `From<Option<T>>`: mapping `None` to `All` would turn a stray `None` into silent all-scope access."*
- Nullable (`Option<T>`) scope columns, already shipped on `main`, already establish that an absent/NULL scope value is **invisible** to every scoped variant (only `All` sees it) — the same fail-closed philosophy, one layer down.
- The book's own framing: *"missing and not-yours look identical"* for any scoped variant.

`None` extends that same philosophy: "no scope at all" behaves like "not yours", not like "all-access". I did not find any place in this codebase where "absence" is treated as "unrestricted" — so I implemented fail-closed rather than stopping to ask, per the fail-closed default described in the task.

## Breaking change — confirmed with the compiler

Adding a variant to a `pub enum` without `#[non_exhaustive]` breaks any downstream exhaustive `match` without a wildcard arm. I verified this concretely: a scratch exhaustive match against the generated `ContactScope` (from this repo's own integration test fixtures) hits:

```
error[E0004]: non-exhaustive patterns: `ContactScope::None` not covered
```

(scratch probe deleted after capturing the error — not part of the committed diff). es-entity is pre-1.0, so this is cargo's own compatibility boundary; consumers matching exhaustively on a generated scope enum must add a `None` arm (or a wildcard) when they bump.

## Collision check

- **PR #210** (`aggregate version for nested entities`) doesn't touch any scope-related files — no collision.
- **Nullable scope columns** (the other candidate "absent scope" representation) already merged to `main` via #209, ahead of this branch. I checked: `main` already has it, the leftover `task/es-entity-nullable-scope-columns-*` branch is just one stale unmerged docs commit sitting on top. No contradiction — nullable columns and `None` are complementary, not overlapping: a nullable column encodes "this **row** has no owner" (SQL NULL, invisible to every scoped variant), `None` encodes "this **caller** has no scope" (Rust-side, short-circuits before any query). Both already agree on the fail-closed reading.

## Implementation

- `ScopeInfo::dispatch` gains a `none_arm: TokenStream` parameter (alongside the existing `all_arm`), fed through by all five read-fn generators: `find_by_fn`, `find_all_fn`, `list_by_fn`, `list_for_fn`, `list_for_filters_fn`.
- `None`/`All` are both reserved variant names — extended the existing collision validation (previously `All`-only) and added a test.
- No SQL or migration changes — this is purely a new Rust-side enum variant and match arm; `.sqlx` is untouched.

## Testing

Ran against a live Postgres via `nix run .#nextest` (avoided `SQLX_OFFLINE` — this repo's own `.sqlx` cache is stale for several pre-existing integration tests, confirmed reproducible on a clean `main` checkout before touching anything, unrelated to this change). **440/440 passing.**

Two new tests in `tests/scoped_repo.rs`:
1. `none_scope_denies_access_like_a_foreign_scope` — the negative case: seeds a row, confirms it **is** visible under its own scope and under `All` (positive control, so the denial below isn't vacuous), then asserts `None` denies it across every read shape (`find_by_id`, `maybe_find_by_id`, `find_by_partner_id`, `find_all`, `list_by_created_at`, `list_for_status_by_created_at`, `list_for_filters`, and the bound view).
2. `none_scope_never_executes_a_query` — proves the *early* part of "early return": closes the connection pool after seeding, then shows a `None`-scoped read still succeeds with the correct fail-closed result (no connection ever acquired), while the same read under a real scope on the same closed pool surfaces a hard connection error (control, proving the closure is actually in effect).

**Revert-to-red**: temporarily routed the `None` dispatch arm to `all_arm` (simulating the dangerous fail-open reading) and re-ran — both new tests failed deterministically for the expected reason (`none_scope_denies_access_like_a_foreign_scope` failed because a row visible under `All` was also visible under `None`). Reverted before committing.

Also updated `book/src/scoped-repositories.md` with a `Fail-closed: None` section and touched up the `All`-only mentions of the reserved-variant rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)