### PR TITLE
feat(operation): batch isolation helpers (run_isolated, run_bisected)

### DIFF
--- a/migrations/20260903000000_batch_test.sql
+++ b/migrations/20260903000000_batch_test.sql
@@ -1,0 +1,9 @@
+-- Fixture for tests/batch.rs.
+--
+-- The batch-isolation tests need a table whose primary key they can violate on
+-- demand: a "culprit" item inserts a value the test seeded beforehand, which
+-- produces a real Postgres error that would abort the whole transaction without
+-- a savepoint. Integer keys keep the probe assertions readable.
+CREATE TABLE batch_items (
+  v INT PRIMARY KEY
+);

--- a/src/operation/batch/mod.rs
+++ b/src/operation/batch/mod.rs
@@ -1,0 +1,174 @@
+//! Running a batch of items in one transaction while isolating each failure.
+//!
+//! Two shapes, both built on [`SavepointOperation::with_savepoint`] and both
+//! available on every [`AtomicOperation`](super::AtomicOperation):
+//!
+//! - [`run_isolated`](BatchIsolation::run_isolated) — one savepoint per item.
+//!   Use it when each item needs its own logic and its own error isolation.
+//! - [`run_bisected`](BatchIsolation::run_bisected) — one probe over the whole
+//!   slice, splitting only on failure. Use it when the closure handles a whole
+//!   slice in set-based statements (`create_all` / `update_all` and friends),
+//!   so the happy path costs one probe.
+//!
+//! # The closure
+//!
+//! `AsyncFnOnce + Clone + Sync`, cloned once per probe so that each probe calls
+//! its own clone exactly once.
+//!
+//! Each such call has a single opaque future type, which auto-trait inference
+//! resolves at the call site. A closure that borrows `&self` therefore composes
+//! inside an `#[async_trait]` runner or a `tokio::spawn`.
+//!
+//! Cloning the closure clones its captures, so state shared *across* probes
+//! belongs behind something whose clone is the same underlying value: `Arc<…>`,
+//! or a borrowed `&Mutex<…>`. `Sync` holds callers to that — `Cell`, `RefCell`
+//! and `Rc` are not `Sync`, so the bound rejects them.
+//!
+//! # What `f` must tolerate
+//!
+//! A bisect calls `f` repeatedly over **arbitrary contiguous sub-slices, in
+//! non-positional order**, and may re-probe the same range after a transient
+//! failure. `f` must therefore be a function of the set it is handed, and of
+//! the database state at that moment: only `*_in_op` work against the probe's
+//! operation, so that a rollback undoes all of it.
+//!
+//! # Hooks
+//!
+//! Commit hooks registered inside a probe are staged on its savepoint: folded
+//! outward on success, dropped on failure. No hook callback runs at a savepoint
+//! boundary, so a rolled-back probe contributes exactly zero hook state to
+//! match its zero database state. See [`SavepointOp`].
+//!
+//! # Observability
+//!
+//! Tracing is left to the caller, since es-entity's `tracing` dependency is
+//! optional. [`BisectOutcomes`] carries `probes_used` and `transient_retries`
+//! for reporting under the caller's own target and field names.
+
+mod search;
+mod transient;
+
+use std::future::Future;
+
+use super::{SavepointOp, SavepointOperation};
+
+pub use search::*;
+pub use transient::*;
+
+/// Batch isolation for every [`AtomicOperation`](super::AtomicOperation).
+///
+/// Blanket-implemented, like [`SavepointOperation`], so `DbOp`, `SavepointOp`
+/// (nesting), `HookOperation`, and operation types defined outside this crate
+/// all get it without naming a concrete type — and so a function generic over
+/// `impl AtomicOperation` can use it.
+pub trait BatchIsolation: SavepointOperation {
+    /// Runs `f` once per item, each inside its own `SAVEPOINT`, in item order.
+    ///
+    /// A failing item unwinds only its own writes and staged hooks; the
+    /// transaction stays usable and the loop continues, so its healthy
+    /// batch-mates still commit. Outcomes are returned positionally: one entry
+    /// per input, `f`'s own `Ok`/`Err` preserved.
+    ///
+    /// The outer `Err(sqlx::Error)` means the savepoint machinery itself
+    /// failed, leaving the enclosing transaction in an indeterminate state:
+    /// abandon it.
+    fn run_isolated<'a, T, V, E, F>(
+        &'a mut self,
+        items: &'a [T],
+        f: F,
+    ) -> impl Future<Output = Result<Vec<Result<V, E>>, sqlx::Error>> + 'a
+    where
+        T: 'a,
+        V: 'a,
+        E: 'a,
+        F: AsyncFnOnce(&mut SavepointOp<'_>, &T) -> Result<V, E> + Clone + Sync + 'a,
+    {
+        async move {
+            let mut outcomes = Vec::with_capacity(items.len());
+            for item in items {
+                let f = f.clone();
+                outcomes.push(self.with_savepoint(async |sp| f(sp, item).await).await?);
+            }
+            Ok(outcomes)
+        }
+    }
+
+    /// Probes the whole slice at once, bisecting only on failure.
+    ///
+    /// The happy path costs **one** probe. On failure the slice splits and
+    /// pending ranges are probed largest-first (earliest start breaking ties)
+    /// until `budget` is spent, so clean siblings are salvaged and a culprit
+    /// resolves from its own single-item probe, where its error is
+    /// attributable to it.
+    ///
+    /// Deadlock victims and serialization failures re-probe the same range
+    /// unsplit and are refunded to the budget — see [`TransientPolicy`]. Use
+    /// [`run_bisected_with`](Self::run_bisected_with) to widen that class.
+    fn run_bisected<'a, T, E, F>(
+        &'a mut self,
+        items: &'a [T],
+        budget: BisectBudget,
+        f: F,
+    ) -> impl Future<Output = Result<BisectOutcomes<E>, sqlx::Error>> + 'a
+    where
+        T: 'a,
+        E: std::error::Error + 'static,
+        F: AsyncFnOnce(&mut SavepointOp<'_>, &[T]) -> Result<(), E> + Clone + Sync + 'a,
+    {
+        self.run_bisected_with(
+            items,
+            budget,
+            TransientPolicy::new(sqlstate_is_transient::<E> as fn(&E) -> bool),
+            f,
+        )
+    }
+
+    /// [`run_bisected`](Self::run_bisected) with a caller-supplied notion of
+    /// which failures are transient.
+    ///
+    /// Classification being the caller's, the error bound here is just
+    /// [`Display`](std::fmt::Display).
+    fn run_bisected_with<'a, T, E, F, P>(
+        &'a mut self,
+        items: &'a [T],
+        budget: BisectBudget,
+        policy: TransientPolicy<P>,
+        f: F,
+    ) -> impl Future<Output = Result<BisectOutcomes<E>, sqlx::Error>> + 'a
+    where
+        T: 'a,
+        E: std::fmt::Display + 'a,
+        P: Fn(&E) -> bool + 'a,
+        F: AsyncFnOnce(&mut SavepointOp<'_>, &[T]) -> Result<(), E> + Clone + Sync + 'a,
+    {
+        async move {
+            let mut search = BisectSearch::new(items.len(), budget)
+                .with_max_transient_retries(policy.max_retries);
+
+            while let Some(range) = search.next_range() {
+                let f = f.clone();
+                let slice = &items[range.clone()];
+
+                let verdict = match self.with_savepoint(async |sp| f(sp, slice).await).await? {
+                    Ok(()) => ProbeVerdict::Clean,
+                    Err(error) if (policy.is_transient)(&error) => ProbeVerdict::Transient(error),
+                    Err(error) => ProbeVerdict::Failed(error),
+                };
+
+                if let Err(limit) = search.report(range, verdict) {
+                    // The search learned nothing about the items, so there are
+                    // no per-item verdicts to return — the caller re-runs the
+                    // whole batch.
+                    return Err(sqlx::Error::Protocol(match search.last_error() {
+                        Some(error) => format!("{limit}; last error: {error}"),
+                        None => limit.to_string(),
+                    }));
+                }
+            }
+
+            Ok(search.into_outcomes())
+        }
+    }
+}
+
+impl<T: SavepointOperation + ?Sized> BatchIsolation for T {}

--- a/src/operation/batch/search.rs
+++ b/src/operation/batch/search.rs
@@ -1,0 +1,503 @@
+//! The bisect search, as a pure state machine.
+//!
+//! Index bookkeeping over the input's length: it decides *which contiguous
+//! range to probe next* and *what a probe's verdict means*, while the caller
+//! decides how a probe runs and where its transaction boundary sits. So both of
+//! these drive the same algorithm:
+//!
+//! - [`BatchIsolation::run_bisected`](super::BatchIsolation::run_bisected),
+//!   against `with_savepoint` inside a single enclosing transaction.
+//! - A caller that wants a transaction boundary *between* probes, committing
+//!   each clean range as it lands: it mints and commits its own operations
+//!   around [`next_range`](BisectSearch::next_range) and
+//!   [`report`](BisectSearch::report).
+//!
+//! Being plain bookkeeping, the probe sequence is also testable on its own.
+
+use std::{cmp::Ordering, collections::BinaryHeap, ops::Range};
+
+/// How many times a transiently-failed range may be re-probed before the search
+/// is abandoned.
+///
+/// A retry costs up to one `deadlock_timeout` wait, so this caps the time a
+/// search spends on contention.
+pub const DEFAULT_MAX_TRANSIENT_RETRIES: usize = 2;
+
+/// How many probes a bisect may spend before giving up on the ranges it has
+/// not yet resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BisectBudget {
+    /// `2·⌈log₂N⌉ + 1` — the depth needed to isolate one failing item and
+    /// resolve every other item as clean. 9 probes at N=10, 15 at N=100.
+    #[default]
+    Auto,
+    /// An explicit cap, clamped to at least 1. `MaxProbes(1)` probes once and
+    /// leaves every item unresolved if that probe fails.
+    MaxProbes(usize),
+    /// No cap: keep splitting until every item is resolved. Worst case
+    /// `2N - 1` probes for an all-bad batch.
+    FullResolution,
+}
+
+impl BisectBudget {
+    /// The probe cap this budget implies for a batch of `n` items.
+    pub fn effective_cap(self, n: usize) -> usize {
+        match self {
+            Self::Auto => 2 * ceil_log2(n) + 1,
+            Self::MaxProbes(max) => max.max(1),
+            Self::FullResolution => usize::MAX,
+        }
+    }
+}
+
+/// `ceil(log2(n))`, defined as `0` for `n <= 1`.
+fn ceil_log2(n: usize) -> usize {
+    if n <= 1 {
+        return 0;
+    }
+    (usize::BITS - (n - 1).leading_zeros()) as usize
+}
+
+/// A range still awaiting a probe.
+///
+/// The [`Ord`] impl is the search's determinism guarantee: a
+/// [`BinaryHeap`] pops the **largest** range, and among equal lengths the one
+/// with the **earliest start**. For a given input and budget the probe sequence
+/// — and therefore the probe count — is reproducible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PendingRange {
+    start: usize,
+    end: usize,
+}
+
+impl PendingRange {
+    fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+impl Ord for PendingRange {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.len()
+            .cmp(&other.len())
+            .then_with(|| other.start.cmp(&self.start))
+    }
+}
+
+impl PartialOrd for PendingRange {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// What a probe over one range turned out to be.
+#[derive(Debug)]
+pub enum ProbeVerdict<E> {
+    /// Every item in the range succeeded. They resolve here and are never
+    /// probed again.
+    Clean,
+    /// The range failed for a reason attributable to its contents. A
+    /// multi-item range splits; a single-item range resolves as that item's
+    /// failure.
+    Failed(E),
+    /// The failure describes contention: a deadlock victim, a serialization
+    /// failure, or a caller-classified conflict. The **same** range is
+    /// re-probed unsplit, and the probe is refunded to the budget.
+    Transient(E),
+}
+
+/// One input item's resolution. Positionally aligned with the input slice.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ItemOutcome<E> {
+    /// Resolved by a clean probe over a range containing it.
+    Complete,
+    /// Resolved by its own single-item probe, so the error is attributable to
+    /// this item alone.
+    Failed(E),
+    /// Never resolved: the budget ran out, or the search was abandoned, while
+    /// this item was still inside an unprobed range. See
+    /// [`BisectOutcomes::last_error`] for what the search last saw.
+    Unresolved,
+}
+
+/// The result of a completed search: one outcome per input item, plus what it
+/// cost.
+#[derive(Debug)]
+pub struct BisectOutcomes<E> {
+    /// One entry per input item, in input order.
+    pub items: Vec<ItemOutcome<E>>,
+    /// Probes actually spent, net of refunded transient re-probes.
+    pub probes_used: usize,
+    /// Transient re-probes taken (refunded, so not counted in `probes_used`).
+    pub transient_retries: usize,
+    /// The most recent error from a probe spanning more than one item — what a
+    /// caller quotes when explaining an [`ItemOutcome::Unresolved`].
+    ///
+    /// `None` when every failure reached a single-item probe, since each of
+    /// those hands its error to [`ItemOutcome::Failed`].
+    pub last_error: Option<E>,
+}
+
+/// The transient allowance ran out: the same range kept failing on contention.
+///
+/// The search has nothing to attribute to any item, so the caller abandons it
+/// and retries the whole batch later.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransientLimitExceeded {
+    /// Probes spent before abandoning.
+    pub probes_used: usize,
+    /// Transient re-probes taken before abandoning.
+    pub transient_retries: usize,
+}
+
+impl std::fmt::Display for TransientLimitExceeded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "bisect abandoned after {} probes and {} transient retries",
+            self.probes_used, self.transient_retries
+        )
+    }
+}
+
+impl std::error::Error for TransientLimitExceeded {}
+
+/// Drives a bisect over `n` items: which range to probe next, and what each
+/// verdict means for the ranges still outstanding.
+///
+/// ```rust,ignore
+/// let mut search = BisectSearch::new(items.len(), BisectBudget::Auto);
+/// while let Some(range) = search.next_range() {
+///     // The caller owns the operation — one shared transaction, or a fresh
+///     // one committed per range.
+///     let verdict = probe(&items[range.clone()]).await;
+///     search.report(range, verdict)?;
+/// }
+/// let outcomes = search.into_outcomes();
+/// ```
+#[derive(Debug)]
+pub struct BisectSearch<E> {
+    pending: BinaryHeap<PendingRange>,
+    resolved: Vec<Option<ItemOutcome<E>>>,
+    probes_used: usize,
+    cap: usize,
+    transient_retries: usize,
+    max_transient_retries: usize,
+    last_error: Option<E>,
+}
+
+impl<E> BisectSearch<E> {
+    /// Starts a search over `n` items with the whole range as the first probe.
+    pub fn new(n: usize, budget: BisectBudget) -> Self {
+        let mut pending = BinaryHeap::new();
+        if n > 0 {
+            pending.push(PendingRange { start: 0, end: n });
+        }
+        Self {
+            pending,
+            resolved: (0..n).map(|_| None).collect(),
+            probes_used: 0,
+            cap: budget.effective_cap(n),
+            transient_retries: 0,
+            max_transient_retries: DEFAULT_MAX_TRANSIENT_RETRIES,
+            last_error: None,
+        }
+    }
+
+    /// Overrides [`DEFAULT_MAX_TRANSIENT_RETRIES`] for this search.
+    #[must_use]
+    pub fn with_max_transient_retries(mut self, max: usize) -> Self {
+        self.max_transient_retries = max;
+        self
+    }
+
+    /// The next range to probe: the largest outstanding one, earliest start
+    /// breaking ties.
+    ///
+    /// `None` when everything is resolved or the budget is spent — items still
+    /// inside unprobed ranges resolve as [`ItemOutcome::Unresolved`].
+    pub fn next_range(&mut self) -> Option<Range<usize>> {
+        if self.probes_used >= self.cap {
+            return None;
+        }
+        let range = self.pending.pop()?;
+        self.probes_used += 1;
+        Some(range.start..range.end)
+    }
+
+    /// Records what a probe found.
+    ///
+    /// Errors once the transient allowance is exhausted, at which point the
+    /// search is over — see [`TransientLimitExceeded`].
+    pub fn report(
+        &mut self,
+        range: Range<usize>,
+        verdict: ProbeVerdict<E>,
+    ) -> Result<(), TransientLimitExceeded> {
+        let range = PendingRange {
+            start: range.start,
+            end: range.end,
+        };
+
+        match verdict {
+            ProbeVerdict::Clean => {
+                for slot in &mut self.resolved[range.start..range.end] {
+                    *slot = Some(ItemOutcome::Complete);
+                }
+            }
+
+            ProbeVerdict::Transient(error) => {
+                self.last_error = Some(error);
+                // Refunded: the budget pays for bisection, and this probe
+                // produced none.
+                self.probes_used = self.probes_used.saturating_sub(1);
+                if self.transient_retries >= self.max_transient_retries {
+                    return Err(TransientLimitExceeded {
+                        probes_used: self.probes_used,
+                        transient_retries: self.transient_retries,
+                    });
+                }
+                self.transient_retries += 1;
+                self.pending.push(range);
+            }
+
+            // A single item that failed on its own probe: the error is
+            // attributable to it, so it owns it.
+            ProbeVerdict::Failed(error) if range.len() == 1 => {
+                self.resolved[range.start] = Some(ItemOutcome::Failed(error));
+            }
+
+            ProbeVerdict::Failed(error) => {
+                self.last_error = Some(error);
+                let mid = range.start + range.len() / 2;
+                self.pending.push(PendingRange {
+                    start: range.start,
+                    end: mid,
+                });
+                self.pending.push(PendingRange {
+                    start: mid,
+                    end: range.end,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Probes spent so far, net of refunds.
+    pub fn probes_used(&self) -> usize {
+        self.probes_used
+    }
+
+    /// Transient re-probes taken so far.
+    pub fn transient_retries(&self) -> usize {
+        self.transient_retries
+    }
+
+    /// The most recent error from a probe spanning more than one item.
+    pub fn last_error(&self) -> Option<&E> {
+        self.last_error.as_ref()
+    }
+
+    /// Finishes the search, resolving anything still outstanding as
+    /// [`ItemOutcome::Unresolved`] so every input gets exactly one outcome.
+    pub fn into_outcomes(self) -> BisectOutcomes<E> {
+        let items = self
+            .resolved
+            .into_iter()
+            .map(|slot| slot.unwrap_or(ItemOutcome::Unresolved))
+            .collect();
+
+        BisectOutcomes {
+            items,
+            probes_used: self.probes_used,
+            transient_retries: self.transient_retries,
+            last_error: self.last_error,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Runs a search where `culprits` are the item indices that fail, recording
+    /// the probe sequence. No database, no operation — the algorithm alone.
+    fn run(
+        n: usize,
+        budget: BisectBudget,
+        culprits: &[usize],
+    ) -> (Vec<Range<usize>>, BisectOutcomes<String>) {
+        let mut search = BisectSearch::new(n, budget);
+        let mut probes = Vec::new();
+        while let Some(range) = search.next_range() {
+            probes.push(range.clone());
+            let verdict = if culprits.iter().any(|c| range.contains(c)) {
+                ProbeVerdict::Failed(format!("bad {range:?}"))
+            } else {
+                ProbeVerdict::Clean
+            };
+            search.report(range, verdict).expect("no transients here");
+        }
+        (probes, search.into_outcomes())
+    }
+
+    #[test]
+    fn auto_budget_matches_the_documented_formula() {
+        assert_eq!(BisectBudget::Auto.effective_cap(1), 1);
+        assert_eq!(BisectBudget::Auto.effective_cap(10), 9);
+        assert_eq!(BisectBudget::Auto.effective_cap(25), 11);
+        assert_eq!(BisectBudget::Auto.effective_cap(100), 15);
+    }
+
+    #[test]
+    fn max_probes_zero_clamps_to_one() {
+        assert_eq!(BisectBudget::MaxProbes(0).effective_cap(50), 1);
+        assert_eq!(BisectBudget::MaxProbes(3).effective_cap(50), 3);
+    }
+
+    #[test]
+    fn a_clean_batch_probes_exactly_once() {
+        let (probes, outcomes) = run(5, BisectBudget::Auto, &[]);
+        assert_eq!(probes, vec![0..5]);
+        assert_eq!(outcomes.probes_used, 1);
+        assert!(
+            outcomes
+                .items
+                .iter()
+                .all(|o| matches!(o, ItemOutcome::Complete))
+        );
+    }
+
+    #[test]
+    fn ranges_are_probed_largest_first_earliest_start_on_ties() {
+        let (probes, _) = run(8, BisectBudget::FullResolution, &[0]);
+        // Whole slice, then the split halves largest-first with the earlier
+        // start winning the tie, narrowing onto index 0.
+        assert_eq!(probes[0], 0..8);
+        assert_eq!(probes[1], 0..4);
+        assert_eq!(probes[2], 4..8);
+        assert!(
+            probes.windows(2).all(|w| {
+                let (a, b) = (w[0].len(), w[1].len());
+                a > b || (a == b && w[0].start < w[1].start) || a < b
+            }),
+            "probe order was {probes:?}"
+        );
+    }
+
+    #[test]
+    fn a_single_culprit_is_isolated_and_its_siblings_are_salvaged() {
+        let (_, outcomes) = run(8, BisectBudget::Auto, &[3]);
+        for (idx, outcome) in outcomes.items.iter().enumerate() {
+            if idx == 3 {
+                assert!(
+                    matches!(outcome, ItemOutcome::Failed(_)),
+                    "index 3: {outcome:?}"
+                );
+            } else {
+                assert_eq!(outcome, &ItemOutcome::Complete, "index {idx}");
+            }
+        }
+    }
+
+    #[test]
+    fn scattered_culprits_do_not_poison_their_clean_siblings() {
+        let (_, outcomes) = run(16, BisectBudget::FullResolution, &[0, 8]);
+        let completed = outcomes
+            .items
+            .iter()
+            .filter(|o| matches!(o, ItemOutcome::Complete))
+            .count();
+        assert_eq!(completed, 14);
+        assert!(matches!(outcomes.items[0], ItemOutcome::Failed(_)));
+        assert!(matches!(outcomes.items[8], ItemOutcome::Failed(_)));
+    }
+
+    #[test]
+    fn full_resolution_resolves_every_item_of_an_all_bad_batch() {
+        let (_, outcomes) = run(6, BisectBudget::FullResolution, &[0, 1, 2, 3, 4, 5]);
+        assert!(
+            outcomes
+                .items
+                .iter()
+                .all(|o| matches!(o, ItemOutcome::Failed(_)))
+        );
+    }
+
+    #[test]
+    fn max_probes_one_is_equivalent_to_resolving_nothing() {
+        let (probes, outcomes) = run(5, BisectBudget::MaxProbes(1), &[2]);
+        assert_eq!(probes, vec![0..5]);
+        assert!(
+            outcomes
+                .items
+                .iter()
+                .all(|o| matches!(o, ItemOutcome::Unresolved))
+        );
+        assert!(
+            outcomes.last_error.is_some(),
+            "the batch-level error is kept for the caller"
+        );
+    }
+
+    #[test]
+    fn every_input_gets_exactly_one_outcome_even_under_budget_exhaustion() {
+        let (_, outcomes) = run(10, BisectBudget::MaxProbes(3), &[0]);
+        assert_eq!(outcomes.items.len(), 10);
+    }
+
+    #[test]
+    fn a_transient_probe_is_re_run_whole_and_refunded() {
+        let mut search: BisectSearch<String> = BisectSearch::new(8, BisectBudget::MaxProbes(1));
+
+        let first = search.next_range().expect("a first probe");
+        assert_eq!(first, 0..8);
+        search
+            .report(first, ProbeVerdict::Transient("40P01".into()))
+            .expect("within the allowance");
+
+        // Refunded, so the budget of 1 still admits a probe, and it covers the
+        // same range.
+        let retry = search.next_range().expect("the refunded re-probe");
+        assert_eq!(retry, 0..8);
+        assert_eq!(search.transient_retries(), 1);
+
+        search.report(retry, ProbeVerdict::Clean).expect("clean");
+        let outcomes = search.into_outcomes();
+        assert_eq!(outcomes.probes_used, 1);
+        assert_eq!(outcomes.transient_retries, 1);
+        assert!(
+            outcomes
+                .items
+                .iter()
+                .all(|o| matches!(o, ItemOutcome::Complete))
+        );
+    }
+
+    #[test]
+    fn the_transient_allowance_is_bounded() {
+        let mut search: BisectSearch<String> =
+            BisectSearch::new(4, BisectBudget::FullResolution).with_max_transient_retries(2);
+
+        for _ in 0..2 {
+            let range = search.next_range().expect("a probe");
+            search
+                .report(range, ProbeVerdict::Transient("40001".into()))
+                .expect("within the allowance");
+        }
+
+        let range = search.next_range().expect("a probe");
+        let limit = search
+            .report(range, ProbeVerdict::Transient("40001".into()))
+            .expect_err("the allowance is spent");
+        assert_eq!(limit.transient_retries, 2);
+    }
+
+    #[test]
+    fn an_empty_batch_probes_nothing() {
+        let (probes, outcomes) = run(0, BisectBudget::Auto, &[]);
+        assert!(probes.is_empty());
+        assert!(outcomes.items.is_empty());
+    }
+}

--- a/src/operation/batch/transient.rs
+++ b/src/operation/batch/transient.rs
@@ -1,0 +1,77 @@
+//! Classifying a probe failure as transient.
+
+/// The Postgres sqlstate of a failure that says nothing about the statement
+/// that hit it, or `None`.
+///
+/// Walks the whole [`source`](std::error::Error::source) chain, so a
+/// [`sqlx::Error`] wrapped several layers deep in a caller's own error type is
+/// still recognised.
+///
+/// - `40P01` — deadlock detected. This transaction was chosen as the victim;
+///   another one made progress.
+/// - `40001` — serialization failure.
+///
+/// Both are properties of the contention, not of the items being probed, so a
+/// bisect re-probes the same range unsplit.
+pub fn retryable_conflict_code(err: &(dyn std::error::Error + 'static)) -> Option<&'static str> {
+    let mut source = Some(err);
+    while let Some(err) = source {
+        if let Some(db) = err
+            .downcast_ref::<sqlx::Error>()
+            .and_then(|err| err.as_database_error())
+        {
+            match db.code().as_deref() {
+                Some("40P01") => return Some("40P01"),
+                Some("40001") => return Some("40001"),
+                _ => {}
+            }
+        }
+        source = err.source();
+    }
+    None
+}
+
+/// [`retryable_conflict_code`] as a predicate.
+pub fn is_retryable_conflict(err: &(dyn std::error::Error + 'static)) -> bool {
+    retryable_conflict_code(err).is_some()
+}
+
+/// Which probe failures are transient, and how many re-probes they may buy.
+///
+/// The default classification is [`is_retryable_conflict`]. Override it to add
+/// error types of your own that describe contention — an optimistic-concurrency
+/// conflict, say — so the search re-probes their ranges too.
+#[derive(Debug, Clone, Copy)]
+pub struct TransientPolicy<P> {
+    /// Returns `true` when a probe failure carries no information about the
+    /// range's contents.
+    pub is_transient: P,
+    /// How many transient re-probes the whole search may take before it is
+    /// abandoned.
+    pub max_retries: usize,
+}
+
+impl<P> TransientPolicy<P> {
+    /// A policy with the default retry allowance.
+    pub fn new(is_transient: P) -> Self {
+        Self {
+            is_transient,
+            max_retries: super::DEFAULT_MAX_TRANSIENT_RETRIES,
+        }
+    }
+
+    /// Overrides the retry allowance.
+    #[must_use]
+    pub fn with_max_retries(self, max_retries: usize) -> Self {
+        Self {
+            max_retries,
+            ..self
+        }
+    }
+}
+
+/// The default classifier, as a plain function so it can be named in a
+/// [`TransientPolicy`] without boxing.
+pub(super) fn sqlstate_is_transient<E: std::error::Error + 'static>(error: &E) -> bool {
+    is_retryable_conflict(error)
+}

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -1,5 +1,6 @@
 //! Handle execution of database operations and transactions.
 
+mod batch;
 pub mod hooks;
 mod savepoint;
 mod with_time;
@@ -8,6 +9,7 @@ use sqlx::{Acquire, Transaction};
 
 use crate::{clock::ClockHandle, db, one_time_executor::OneTimeExecutor};
 
+pub use batch::*;
 pub use savepoint::*;
 pub use with_time::*;
 

--- a/tests/batch.rs
+++ b/tests/batch.rs
@@ -1,0 +1,435 @@
+//! Live-PG coverage for [`BatchIsolation`] — per-item and bisected failure
+//! isolation over real savepoints, plus the caller-driven commit-per-probe
+//! shape that drives [`BisectSearch`] directly.
+//!
+//! The search algorithm has its own unit tests in
+//! `src/operation/batch/search.rs`. What Postgres adds here: that a failed
+//! probe leaves the transaction usable, that a rolled-back probe's hooks are
+//! dropped, and that a closure borrowing `&self` composes inside an
+//! `#[async_trait]` runner.
+//!
+//! Each test owns a disjoint slice of `batch_items.v` so they can run in
+//! parallel against one database.
+
+mod helpers;
+
+use std::sync::{Arc, Mutex};
+
+use es_entity::operation::{
+    AtomicOperation, BatchIsolation, BisectBudget, BisectSearch, DbOp, ItemOutcome, ProbeVerdict,
+    SavepointOp,
+    hooks::{CommitHook, HookOperation, PreCommitRet},
+};
+
+async fn insert(op: &mut impl AtomicOperation, v: i32) -> Result<(), sqlx::Error> {
+    sqlx::query("INSERT INTO batch_items (v) VALUES ($1)")
+        .bind(v)
+        .execute(op.as_executor())
+        .await?;
+    Ok(())
+}
+
+/// Clears this test's slice of the table so a re-run starts from the same
+/// state as a first run.
+async fn reset(pool: &sqlx::PgPool, base: i32) -> anyhow::Result<()> {
+    sqlx::query("DELETE FROM batch_items WHERE v >= $1 AND v < $2")
+        .bind(base)
+        .bind(base + 100)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Pre-inserts `v`, so that a later insert of the same value raises a real
+/// primary-key violation.
+async fn seed(pool: &sqlx::PgPool, v: i32) -> anyhow::Result<()> {
+    sqlx::query("INSERT INTO batch_items (v) VALUES ($1)")
+        .bind(v)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+async fn present(pool: &sqlx::PgPool, range: std::ops::Range<i32>) -> anyhow::Result<Vec<i32>> {
+    let rows: Vec<(i32,)> =
+        sqlx::query_as("SELECT v FROM batch_items WHERE v >= $1 AND v < $2 ORDER BY v")
+            .bind(range.start)
+            .bind(range.end)
+            .fetch_all(pool)
+            .await?;
+    Ok(rows.into_iter().map(|(v,)| v).collect())
+}
+
+#[tokio::test]
+async fn run_isolated_keeps_batch_mates_committing_after_a_per_item_failure() -> anyhow::Result<()>
+{
+    const BASE: i32 = 1_000;
+    let pool = helpers::init_pool().await?;
+    reset(&pool, BASE).await?;
+    seed(&pool, BASE + 2).await?; // index 2 is the culprit
+
+    let items: Vec<i32> = (0..5).map(|i| BASE + i).collect();
+    let mut op = DbOp::init(&pool).await?;
+
+    let outcomes = op
+        .run_isolated(&items, async |sp, item| insert(sp, *item).await)
+        .await?;
+
+    assert_eq!(outcomes.len(), 5);
+    for (idx, outcome) in outcomes.iter().enumerate() {
+        if idx == 2 {
+            assert!(outcome.is_err(), "index 2 should have failed");
+        } else {
+            assert!(outcome.is_ok(), "index {idx} should have survived");
+        }
+    }
+
+    // The transaction is still usable, so its batch-mates commit.
+    op.commit().await?;
+    assert_eq!(
+        present(&pool, BASE..BASE + 5).await?,
+        vec![BASE, BASE + 1, BASE + 2, BASE + 3, BASE + 4],
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_clean_bisect_probes_exactly_once() -> anyhow::Result<()> {
+    const BASE: i32 = 2_000;
+    let pool = helpers::init_pool().await?;
+    reset(&pool, BASE).await?;
+
+    let items: Vec<i32> = (0..8).map(|i| BASE + i).collect();
+    let mut op = DbOp::init(&pool).await?;
+
+    let outcomes = op
+        .run_bisected(&items, BisectBudget::Auto, async |sp, slice| {
+            for item in slice {
+                insert(sp, *item).await?;
+            }
+            Ok::<_, sqlx::Error>(())
+        })
+        .await?;
+
+    assert_eq!(outcomes.probes_used, 1, "a clean batch must not bisect");
+    assert!(
+        outcomes
+            .items
+            .iter()
+            .all(|o| matches!(o, ItemOutcome::Complete))
+    );
+
+    op.commit().await?;
+    assert_eq!(present(&pool, BASE..BASE + 8).await?.len(), 8);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_bisect_isolates_its_culprit_and_salvages_the_siblings() -> anyhow::Result<()> {
+    const BASE: i32 = 3_000;
+    let pool = helpers::init_pool().await?;
+    reset(&pool, BASE).await?;
+    seed(&pool, BASE + 3).await?;
+
+    let items: Vec<i32> = (0..8).map(|i| BASE + i).collect();
+    let mut op = DbOp::init(&pool).await?;
+
+    let outcomes = op
+        .run_bisected(&items, BisectBudget::Auto, async |sp, slice| {
+            for item in slice {
+                insert(sp, *item).await?;
+            }
+            Ok::<_, sqlx::Error>(())
+        })
+        .await?;
+
+    assert!(
+        outcomes.probes_used > 1,
+        "a failing batch must have bisected"
+    );
+    for (idx, outcome) in outcomes.items.iter().enumerate() {
+        if idx == 3 {
+            assert!(
+                matches!(outcome, ItemOutcome::Failed(_)),
+                "index 3 should carry its own attributable error, got {outcome:?}"
+            );
+        } else {
+            assert!(
+                matches!(outcome, ItemOutcome::Complete),
+                "index {idx} should have been salvaged, got {outcome:?}"
+            );
+        }
+    }
+
+    op.commit().await?;
+    // Every clean sibling landed; the culprit's value is present only from the
+    // seed, so the row count is still 8.
+    assert_eq!(present(&pool, BASE..BASE + 8).await?.len(), 8);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn budget_exhaustion_leaves_unprobed_items_unresolved() -> anyhow::Result<()> {
+    const BASE: i32 = 4_000;
+    let pool = helpers::init_pool().await?;
+    reset(&pool, BASE).await?;
+    seed(&pool, BASE).await?;
+
+    let items: Vec<i32> = (0..6).map(|i| BASE + i).collect();
+    let mut op = DbOp::init(&pool).await?;
+
+    let outcomes = op
+        .run_bisected(&items, BisectBudget::MaxProbes(1), async |sp, slice| {
+            for item in slice {
+                insert(sp, *item).await?;
+            }
+            Ok::<_, sqlx::Error>(())
+        })
+        .await?;
+
+    assert_eq!(outcomes.probes_used, 1);
+    assert_eq!(outcomes.items.len(), 6, "every input gets one outcome");
+    assert!(
+        outcomes
+            .items
+            .iter()
+            .all(|o| matches!(o, ItemOutcome::Unresolved))
+    );
+    assert!(
+        outcomes.last_error.is_some(),
+        "the caller needs the batch-level error to explain the unresolved items"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Hooks staged inside a probe follow that probe's own fate.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default)]
+struct Probe {
+    pre: Arc<Mutex<Vec<i32>>>,
+    post: Arc<Mutex<Vec<i32>>>,
+    rolled_back: Arc<Mutex<Vec<i32>>>,
+}
+
+#[derive(Debug)]
+struct ProbeHook {
+    items: Vec<i32>,
+    probe: Probe,
+}
+
+impl CommitHook for ProbeHook {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        self.probe.pre.lock().unwrap().extend(self.items.clone());
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.probe.post.lock().unwrap().extend(self.items);
+    }
+
+    fn on_rollback(self) {
+        self.probe.rolled_back.lock().unwrap().extend(self.items);
+    }
+
+    fn merge(&mut self, other: &mut Self) -> bool {
+        self.items.append(&mut other.items);
+        true
+    }
+}
+
+#[tokio::test]
+async fn a_rolled_back_probe_contributes_no_hook_state() -> anyhow::Result<()> {
+    const BASE: i32 = 5_000;
+    let pool = helpers::init_pool().await?;
+    reset(&pool, BASE).await?;
+    seed(&pool, BASE + 1).await?;
+
+    let probe = Probe::default();
+    let items: Vec<i32> = (0..3).map(|i| BASE + i).collect();
+    let mut op = DbOp::init(&pool).await?;
+
+    let outcomes = op
+        .run_isolated(&items, async |sp, item| {
+            // Registered before the statement that may fail, matching where a
+            // repository registers its own post-persist hook.
+            let _ = sp.add_commit_hook(ProbeHook {
+                items: vec![*item],
+                probe: probe.clone(),
+            });
+            insert(sp, *item).await
+        })
+        .await?;
+
+    assert!(outcomes[1].is_err());
+    // Nothing fires at a savepoint boundary, rolled back or not.
+    assert!(probe.pre.lock().unwrap().is_empty());
+    assert!(probe.post.lock().unwrap().is_empty());
+
+    op.commit().await?;
+
+    // The surviving items' hooks folded outward and ran once, merged. The
+    // rolled-back item contributed nothing, and `on_rollback` stays reserved
+    // for a failed commit.
+    assert_eq!(*probe.pre.lock().unwrap(), vec![BASE, BASE + 2]);
+    assert_eq!(*probe.post.lock().unwrap(), vec![BASE, BASE + 2]);
+    assert!(probe.rolled_back.lock().unwrap().is_empty());
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The caller owns the transaction boundary, committing each clean range.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_caller_driven_search_commits_each_clean_range_as_it_lands() -> anyhow::Result<()> {
+    const BASE: i32 = 6_000;
+    let pool = helpers::init_pool().await?;
+    reset(&pool, BASE).await?;
+    seed(&pool, BASE + 3).await?;
+
+    let items: Vec<i32> = (0..8).map(|i| BASE + i).collect();
+    let mut search: BisectSearch<String> =
+        BisectSearch::new(items.len(), BisectBudget::FullResolution);
+    let mut committed: Vec<std::ops::Range<usize>> = Vec::new();
+
+    while let Some(range) = search.next_range() {
+        // A fresh transaction per probe, committed once the range is clean.
+        let mut op = DbOp::init(&pool).await?;
+
+        let mut failure = None;
+        for item in &items[range.clone()] {
+            if let Err(error) = insert(&mut op, *item).await {
+                failure = Some(error.to_string());
+                break;
+            }
+        }
+
+        match failure {
+            None => {
+                op.commit().await?;
+                committed.push(range.clone());
+                search.report(range, ProbeVerdict::Clean)?;
+            }
+            Some(error) => {
+                drop(op); // rolls back
+                search.report(range, ProbeVerdict::Failed(error))?;
+            }
+        }
+    }
+
+    let outcomes = search.into_outcomes();
+    for (idx, outcome) in outcomes.items.iter().enumerate() {
+        if idx == 3 {
+            assert!(matches!(outcome, ItemOutcome::Failed(_)));
+        } else {
+            assert_eq!(outcome, &ItemOutcome::Complete, "index {idx}");
+        }
+    }
+
+    assert!(
+        !committed.is_empty(),
+        "clean ranges must have committed while the search was still running"
+    );
+    // Each clean range was made durable by its own commit.
+    assert_eq!(present(&pool, BASE..BASE + 8).await?.len(), 8);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// A closure borrowing `&self`, inside `#[async_trait]`, with a caller-derived
+// wrapper context, spawned onto the runtime.
+// ---------------------------------------------------------------------------
+
+struct Ctx<'op, 'parent> {
+    op: &'op mut SavepointOp<'parent>,
+    label: String,
+}
+
+es_entity::delegate_atomic_operation!([<'op, 'parent>] Ctx<'op, 'parent>, { s => s.op });
+
+struct Runner {
+    offset: i32,
+}
+
+impl Runner {
+    async fn insert_one(
+        &self,
+        op: &mut impl AtomicOperation,
+        item: &i32,
+    ) -> Result<(), sqlx::Error> {
+        insert(op, item + self.offset).await
+    }
+}
+
+#[async_trait::async_trait]
+trait BatchRunner: Send + Sync {
+    async fn run(&self, op: &mut DbOp<'static>, items: &[i32]) -> Result<usize, sqlx::Error>;
+}
+
+#[async_trait::async_trait]
+impl BatchRunner for Runner {
+    async fn run(&self, op: &mut DbOp<'static>, items: &[i32]) -> Result<usize, sqlx::Error> {
+        // Borrows `&self` directly, with no owned clone, and builds a wrapper
+        // context per probe.
+        let isolated = op
+            .run_isolated(items, async |sp, item| {
+                let mut ctx = Ctx {
+                    op: sp,
+                    label: "batch".to_string(),
+                };
+                let _ = ctx.label.len();
+                self.insert_one(&mut ctx, item).await
+            })
+            .await?;
+
+        // ...and the bisected flavour, nesting an isolated loop inside a probe.
+        let bisected = op
+            .run_bisected(items, BisectBudget::Auto, async |sp, slice| {
+                sp.run_isolated(slice, async |sp, item| {
+                    let _ = self.offset;
+                    let _ = sp.maybe_now();
+                    Ok::<_, sqlx::Error>(*item)
+                })
+                .await?;
+                Ok::<_, sqlx::Error>(())
+            })
+            .await?;
+
+        Ok(isolated.iter().filter(|o| o.is_ok()).count() + bisected.probes_used)
+    }
+}
+
+#[tokio::test]
+async fn a_closure_borrowing_self_composes_inside_an_async_trait_runner() -> anyhow::Result<()> {
+    const BASE: i32 = 7_000;
+    let pool = helpers::init_pool().await?;
+    reset(&pool, BASE).await?;
+
+    let runner: Arc<dyn BatchRunner> = Arc::new(Runner { offset: BASE });
+    let items: Vec<i32> = (0..4).collect();
+
+    // Spawned, so the future is required to be `Send`.
+    let handle = tokio::spawn(async move {
+        let mut op = DbOp::init(&pool).await?;
+        let n = runner.run(&mut op, &items).await?;
+        op.commit().await?;
+        Ok::<_, sqlx::Error>((n, pool))
+    });
+
+    let (n, pool) = handle.await??;
+    assert_eq!(n, 5, "4 isolated successes + 1 clean bisect probe");
+    assert_eq!(present(&pool, BASE..BASE + 4).await?.len(), 4);
+
+    Ok(())
+}


### PR DESCRIPTION
Hoists the per-item savepoint loop and the auto-bisecting batch search out of the `job` crate — where they live on `CurrentBatchedJob` and are reachable only from a batched job runner — and onto every `AtomicOperation`.

Answers `es-entity-dev/requirements-batch-isolation-helpers.md` (rev 2026-09-03). Options and rationale: `es-entity-dev/design-options-batch-isolation-helpers.md`.

## The substance: the closure bound

```rust
f: impl AsyncFnOnce(&mut SavepointOp<'_>, &T) -> Result<V, E> + Clone + Sync
```

Not an `AsyncFn`, and the difference is the whole point rather than a detail.

A closure-taking method that is higher-ranked over `SavepointOp`'s lifetime **cannot have its future's `Send`-ness inferred when the closure borrows `&self`**. That is why lana's batch call sites each carry `let runner = self.clone();` with a comment naming the cause, plus a `ChildBoundary` snapshot to derive a context inside the closure. `AsyncFnOnce`'s `CallOnceFuture` is one opaque type per concrete call site — which inference handles fine, and always has, which is why `with_savepoint` accepts `&self`-borrowing closures today. `Clone` is what lets a loop make N such calls.

Verified, not argued: the tests include an `#[async_trait]` runner whose closure borrows `&self`, derives a wrapper context per probe, nests an isolated loop inside a bisected probe, and is `tokio::spawn`ed.

`Sync` guards the consequence. Cloning the closure clones its captures, so state shared *across* probes must genuinely be shared. `Arc<…>` and `&Mutex<…>` are `Sync` and clone to sharing; `Cell`/`RefCell`/`Rc` are not, and would silently hand each probe a private copy. The bound turns a wrong-answer bug into a compile error.

## The search is a separate, op-free layer

`BisectSearch` holds no operation, does no I/O and is not `async`. Two things fall out:

- The probe ordering and budget arithmetic are unit-tested **with no database** — 12 tests in `search.rs`.
- A caller that needs the transaction boundary *between* probes — commit each clean range the moment it lands, rather than holding a long search open — drives it directly, minting and committing its own operations. `run_bisected` is then literally implemented over it, so the two cannot drift.

## API

| Item | |
|---|---|
| `BatchIsolation` | blanket-impl'd trait; `run_isolated`, `run_bisected`, `run_bisected_with` |
| `BisectBudget` | `Auto` (`2·⌈log₂N⌉+1`), `MaxProbes(n)` (clamped ≥1), `FullResolution` |
| `BisectSearch` / `ProbeVerdict` / `ItemOutcome` / `BisectOutcomes` | the op-free search |
| `TransientPolicy` | caller-extensible "this failure says nothing about the items" |
| `retryable_conflict_code` / `is_retryable_conflict` | sqlstate `40P01`/`40001`, walking the `source()` chain |

Behaviour preserved from job's implementation: largest-first probe order with earliest-start tie-break, midpoint split, clean ranges resolving whole, culprits resolving from their own singleton probe so the error is attributable, transient failures re-probing the same range **unsplit** with the probe refunded to the budget, and a separate bounded allowance for those.

## Compatibility

**Purely additive.** No change to `AtomicOperation`, `SavepointOperation`, `savepoint_parts`, hook folding, or when events are persisted. No new obligation on wrapper op types — nothing here reintroduces the `&mut DbOp` accessor that #208 removed. No product schema (the new migration is a test fixture; es-entity ships no runtime schema, so no consumer re-vendors anything).

Hook semantics are unchanged and now pinned by a test at this layer too: hooks staged inside a probe fold outward on success and are dropped on rollback, no callback fires at a savepoint boundary, and `on_rollback` stays reserved for a failed *commit*.

## Follow-ups, not in this PR

- **job**: re-expose `CurrentBatchedJob::{run_isolated, run_bisected, run_bisected_with}` over these, mapping index → `JobId` and `ItemOutcome` → `BatchItemOutcome`; delete its own `retryable_conflict_code`; re-export `BisectBudget`. That is a source-breaking bound change (`+ Clone + Sync`) for closures moving non-`Clone` state — job's own 14 tests are unaffected, and lana has one such site (a `Mutex<HashMap>` rate cache), fixed by borrowing instead of moving.
- **lana**: `WriteContext::{run_isolated, run_bisected}` handing the closure a child context, then delete `ChildBoundary` / `child_boundary()` / `derive()` and the three `let runner = self.clone()` workarounds.
- **Flagged for a decision, not assumed here**: commit-per-probe means each committed range fires *its* hooks at *its* commit, so outbox events publish per range rather than once per batch. Nothing existing changes — single-transaction mode is bit-identical to today and the per-probe mode is opt-in — but a consumer adopting it on the path feeding the DW relay chain is a timing change that wants explicit sign-off.

## Observability

This layer emits no tracing of its own: es-entity's `tracing` dependency is optional, and the consumer that cares (`job.batch_bisect`) owns its target and field names. `BisectOutcomes` carries `probes_used` and `transient_retries` so a wrapper reports them without the primitive guessing at a schema. A deliberate deviation from the requirements' R9.1; called out rather than silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JarRxg9PcFFjRvarPeN6Z1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New transaction/savepoint batching primitives sit on the core operation layer; mistakes could affect partial-commit semantics, though the change is additive and heavily tested.
> 
> **Overview**
> Adds **`BatchIsolation`** on every **`SavepointOperation`**, exposing **`run_isolated`** (one savepoint per item, positional `Ok`/`Err`) and **`run_bisected`** / **`run_bisected_with`** (whole-slice probes that bisect on failure, with configurable **`BisectBudget`** and **`TransientPolicy`**). Closures use **`AsyncFnOnce + Clone + Sync`** so probes can borrow **`&self`** and run under **`tokio::spawn`** without extra runner clones.
> 
> The bisect path is split into a **sync, I/O-free `BisectSearch`** (largest-range-first ordering, budget caps, transient re-probes refunded) wired from **`run_bisected`** via **`with_savepoint`**, plus helpers for Postgres **`40P01`/`40001`** in the error chain. **`operation`** re-exports the new module; existing savepoint/hook behavior is unchanged but covered by new PG tests (including rolled-back probe hooks and caller-driven commit-per-probe).
> 
> A **test-only migration** adds **`batch_items`** for integration tests in **`tests/batch.rs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a19d92a0275e671a4898dcf9cf53110100e42b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->