### PR TITLE
feat(op): make AtomicOperation object-safe via type-erased commit hooks

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -654,15 +654,19 @@ macro_rules! delegate_atomic_operation {
                 match self { $($pat => $target.as_executor()),+ }
             }
 
-            fn add_commit_hook<__H: $crate::hooks::CommitHook>(
+            fn add_commit_hook_dyn(
                 &mut self,
-                hook: __H,
-            ) -> Result<(), __H> {
-                match self { $($pat => $target.add_commit_hook(hook)),+ }
+                type_id: std::any::TypeId,
+                hook: Box<dyn $crate::hooks::DynHook>,
+            ) -> Result<(), Box<dyn $crate::hooks::DynHook>> {
+                match self { $($pat => $target.add_commit_hook_dyn(type_id, hook)),+ }
             }
 
-            fn commit_hook<__H: $crate::hooks::CommitHook>(&self) -> Option<&__H> {
-                match self { $($pat => $target.commit_hook::<__H>()),+ }
+            fn commit_hook_dyn(
+                &self,
+                type_id: std::any::TypeId,
+            ) -> Option<&dyn $crate::hooks::DynHook> {
+                match self { $($pat => $target.commit_hook_dyn(type_id)),+ }
             }
 
             fn supports_hooks(&self) -> bool {

--- a/src/operation/hooks.rs
+++ b/src/operation/hooks.rs
@@ -397,18 +397,22 @@ impl<'c> AtomicOperation for HookOperation<'c> {
         self.conn
     }
 
-    fn add_commit_hook<H: CommitHook>(&mut self, hook: H) -> Result<(), H> {
+    fn add_commit_hook_dyn(
+        &mut self,
+        type_id: TypeId,
+        hook: Box<dyn DynHook>,
+    ) -> Result<(), Box<dyn DynHook>> {
         match self.staged.as_mut() {
             Some(staged) => {
-                staged.add(hook);
+                staged.push_or_merge(type_id, hook);
                 Ok(())
             }
             None => Err(hook),
         }
     }
 
-    fn commit_hook<H: CommitHook>(&self) -> Option<&H> {
-        self.staged.as_ref()?.get_last::<H>()
+    fn commit_hook_dyn(&self, type_id: TypeId) -> Option<&dyn DynHook> {
+        self.staged.as_ref()?.get_last_dyn(type_id)
     }
 
     fn supports_hooks(&self) -> bool {
@@ -452,7 +456,7 @@ impl<'c, H> PreCommitRet<'c, H> {
 }
 
 // --- Object-safe internal trait ---
-trait DynHook: Send {
+pub trait DynHook: Send {
     #[allow(clippy::type_complexity)]
     fn pre_commit_boxed<'c>(
         self: Box<Self>,
@@ -470,6 +474,8 @@ trait DynHook: Send {
     fn as_any(&self) -> &dyn Any;
 
     fn as_any_mut(&mut self) -> &mut dyn Any;
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
 }
 
 impl<H: CommitHook> DynHook for H {
@@ -512,6 +518,10 @@ impl<H: CommitHook> DynHook for H {
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
 }
 
 /// Hooks are stored in a single flat insertion-ordered vec so that
@@ -527,16 +537,13 @@ impl CommitHooks {
         Self { hooks: Vec::new() }
     }
 
-    pub(super) fn add<H: CommitHook>(&mut self, hook: H) {
-        self.push_or_merge(TypeId::of::<H>(), Box::new(hook));
-    }
-
     /// Folds the hooks staged by a released [`SavepointOp`] into this buffer.
     ///
-    /// Replays them through the same path as [`add`](Self::add), in their
-    /// staging order, so the result is indistinguishable from having registered
-    /// them on this operation directly: mergeable types accumulate into the
-    /// earlier instance (keeping its position), non-mergeable ones append.
+    /// Replays them through the same path as [`push_or_merge`](Self::push_or_merge),
+    /// in their staging order, so the result is indistinguishable from having
+    /// registered them on this operation directly: mergeable types accumulate
+    /// into the earlier instance (keeping its position), non-mergeable ones
+    /// append.
     ///
     /// [`SavepointOp`]: super::SavepointOp
     pub(super) fn absorb_staged(&mut self, staged: Self) {
@@ -545,7 +552,7 @@ impl CommitHooks {
         }
     }
 
-    fn push_or_merge(&mut self, type_id: TypeId, mut new_hook: Box<dyn DynHook>) {
+    pub(crate) fn push_or_merge(&mut self, type_id: TypeId, mut new_hook: Box<dyn DynHook>) {
         // Merge with the most recently added hook of the same type, keeping the
         // existing hook's original (earlier) position in the execution order.
         if let Some((_, existing)) = self.hooks.iter_mut().rev().find(|(t, _)| *t == type_id)
@@ -561,12 +568,12 @@ impl CommitHooks {
         self.hooks.is_empty()
     }
 
-    pub(super) fn get_last<H: CommitHook>(&self) -> Option<&H> {
+    pub(crate) fn get_last_dyn(&self, type_id: TypeId) -> Option<&dyn DynHook> {
         self.hooks
             .iter()
             .rev()
-            .find(|(t, _)| *t == TypeId::of::<H>())
-            .and_then(|(_, hook)| hook.as_any().downcast_ref::<H>())
+            .find(|(t, _)| *t == type_id)
+            .map(|(_, hook)| hook.as_ref())
     }
 
     /// Runs each hook's `pre_commit` in registration order.

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -243,13 +243,20 @@ impl<'o> AtomicOperation for DbOp<'o> {
         self.tx.connection()
     }
 
-    fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
-        self.commit_hooks.as_mut().expect("no hooks").add(hook);
+    fn add_commit_hook_dyn(
+        &mut self,
+        type_id: std::any::TypeId,
+        hook: Box<dyn hooks::DynHook>,
+    ) -> Result<(), Box<dyn hooks::DynHook>> {
+        self.commit_hooks
+            .as_mut()
+            .expect("no hooks")
+            .push_or_merge(type_id, hook);
         Ok(())
     }
 
-    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
-        self.commit_hooks.as_ref()?.get_last::<H>()
+    fn commit_hook_dyn(&self, type_id: std::any::TypeId) -> Option<&dyn hooks::DynHook> {
+        self.commit_hooks.as_ref()?.get_last_dyn(type_id)
     }
 
     fn supports_hooks(&self) -> bool {
@@ -333,12 +340,16 @@ impl<'o> AtomicOperation for DbOpWithTime<'o> {
         self.inner.connection()
     }
 
-    fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
-        self.inner.add_commit_hook(hook)
+    fn add_commit_hook_dyn(
+        &mut self,
+        type_id: std::any::TypeId,
+        hook: Box<dyn hooks::DynHook>,
+    ) -> Result<(), Box<dyn hooks::DynHook>> {
+        self.inner.add_commit_hook_dyn(type_id, hook)
     }
 
-    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
-        self.inner.commit_hook::<H>()
+    fn commit_hook_dyn(&self, type_id: std::any::TypeId) -> Option<&dyn hooks::DynHook> {
+        self.inner.commit_hook_dyn(type_id)
     }
 
     fn supports_hooks(&self) -> bool {
@@ -415,17 +426,45 @@ pub trait AtomicOperation: Send {
         OneTimeExecutor::new(self.connection(), now)
     }
 
+    /// Object-safe, type-erased form of [`add_commit_hook`](Self::add_commit_hook).
+    fn add_commit_hook_dyn(
+        &mut self,
+        _type_id: std::any::TypeId,
+        hook: Box<dyn hooks::DynHook>,
+    ) -> Result<(), Box<dyn hooks::DynHook>> {
+        Err(hook)
+    }
+
+    /// Object-safe, type-erased form of [`commit_hook`](Self::commit_hook).
+    fn commit_hook_dyn(&self, _type_id: std::any::TypeId) -> Option<&dyn hooks::DynHook> {
+        None
+    }
+
     /// Registers a commit hook that will run pre_commit before and post_commit after the transaction commits.
     /// Returns Ok(()) if the hook was registered, Err(hook) if hooks are not supported.
-    fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
-        Err(hook)
+    fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H>
+    where
+        Self: Sized,
+    {
+        self.add_commit_hook_dyn(std::any::TypeId::of::<H>(), Box::new(hook))
+            .map_err(|hook| {
+                *hook
+                    .into_any()
+                    .downcast::<H>()
+                    .unwrap_or_else(|_| panic!("hook type mismatch"))
+            })
     }
 
     /// Typed shared access to the currently-accumulating commit hook of type `H`,
     /// if this operation supports commit hooks and one is registered.
     /// Returns the hook a subsequent `add_commit_hook::<H>` call would merge into.
-    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
-        None
+    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H>
+    where
+        Self: Sized,
+    {
+        self.commit_hook_dyn(std::any::TypeId::of::<H>())?
+            .as_any()
+            .downcast_ref::<H>()
     }
 
     /// Whether this operation supports commit hooks.
@@ -500,5 +539,16 @@ pub trait AtomicOperation: Send {
 impl<'c> AtomicOperation for sqlx::Transaction<'c, db::Db> {
     fn connection(&mut self) -> &mut db::Connection {
         &mut *self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_operation_is_object_safe() {
+        fn assert_object_safe(_: &mut dyn AtomicOperation) {}
+        let _ = assert_object_safe as fn(&mut dyn AtomicOperation);
     }
 }

--- a/src/operation/savepoint.rs
+++ b/src/operation/savepoint.rs
@@ -230,11 +230,15 @@ impl AtomicOperation for SavepointOp<'_> {
     /// has nowhere to fold hooks — a savepoint over a bare [`sqlx::Transaction`]
     /// or any op that returned [`HookSlot::unsupported`], or one nested under a
     /// `HookOperation` on the `force_execute_pre_commit` path.
-    fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
+    fn add_commit_hook_dyn(
+        &mut self,
+        type_id: std::any::TypeId,
+        hook: Box<dyn hooks::DynHook>,
+    ) -> Result<(), Box<dyn hooks::DynHook>> {
         if self.parent_hooks.is_none() {
             return Err(hook);
         }
-        self.staged.add(hook);
+        self.staged.push_or_merge(type_id, hook);
         Ok(())
     }
 
@@ -243,10 +247,10 @@ impl AtomicOperation for SavepointOp<'_> {
     /// While a savepoint is open the two are not yet merged, so a hook type
     /// present in *both* reports only the staged instance here — they become
     /// one hook when the savepoint is released.
-    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
+    fn commit_hook_dyn(&self, type_id: std::any::TypeId) -> Option<&dyn hooks::DynHook> {
         self.staged
-            .get_last::<H>()
-            .or_else(|| self.parent_hooks.as_ref()?.get_last::<H>())
+            .get_last_dyn(type_id)
+            .or_else(|| self.parent_hooks.as_ref()?.get_last_dyn(type_id))
     }
 
     fn supports_hooks(&self) -> bool {

--- a/src/operation/with_time.rs
+++ b/src/operation/with_time.rs
@@ -68,12 +68,16 @@ impl<'a, Op: AtomicOperation + ?Sized> AtomicOperation for OpWithTime<'a, Op> {
         self.inner.connection()
     }
 
-    fn add_commit_hook<H: hooks::CommitHook>(&mut self, hook: H) -> Result<(), H> {
-        self.inner.add_commit_hook(hook)
+    fn add_commit_hook_dyn(
+        &mut self,
+        type_id: std::any::TypeId,
+        hook: Box<dyn hooks::DynHook>,
+    ) -> Result<(), Box<dyn hooks::DynHook>> {
+        self.inner.add_commit_hook_dyn(type_id, hook)
     }
 
-    fn commit_hook<H: hooks::CommitHook>(&self) -> Option<&H> {
-        self.inner.commit_hook::<H>()
+    fn commit_hook_dyn(&self, type_id: std::any::TypeId) -> Option<&dyn hooks::DynHook> {
+        self.inner.commit_hook_dyn(type_id)
     }
 
     fn supports_hooks(&self) -> bool {

--- a/tests/dyn_atomic_operation.rs
+++ b/tests/dyn_atomic_operation.rs
@@ -1,0 +1,115 @@
+mod helpers;
+
+use es_entity::operation::{
+    AtomicOperation, DbOp, SavepointOperation,
+    hooks::{CommitHook, HookOperation, PreCommitRet},
+};
+use std::{
+    any::TypeId,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Debug)]
+struct CountingHook {
+    label: String,
+    post: Arc<Mutex<Vec<String>>>,
+}
+
+impl CommitHook for CountingHook {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.post.lock().unwrap().push(self.label);
+    }
+}
+
+/// The pin: if `AtomicOperation` ever regains a method that is generic
+/// without `Self: Sized`, this stops compiling with E0038.
+fn assert_object_safe(op: &mut dyn AtomicOperation) -> &mut dyn AtomicOperation {
+    op
+}
+
+#[tokio::test]
+async fn dyn_atomic_operation_drives_hooks_and_savepoints() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let post = Arc::new(Mutex::new(Vec::new()));
+    let mut db_op = DbOp::init(&pool).await?;
+
+    {
+        let op: &mut dyn AtomicOperation = assert_object_safe(&mut db_op);
+
+        assert!(op.supports_hooks());
+        let _ = op.maybe_now();
+        let _ = op.clock();
+        let _ = op.connection();
+
+        let hook = CountingHook {
+            label: "root".to_string(),
+            post: post.clone(),
+        };
+        op.add_commit_hook_dyn(TypeId::of::<CountingHook>(), Box::new(hook))
+            .ok()
+            .expect("dyn op must accept a hook");
+
+        let registered = op
+            .commit_hook_dyn(TypeId::of::<CountingHook>())
+            .and_then(|h| h.as_any().downcast_ref::<CountingHook>())
+            .expect("the hook just registered must be readable back through the dyn op");
+        assert_eq!(registered.label, "root");
+
+        // Savepoints work uniformly through the trait object, too.
+        let result = op
+            .with_savepoint(async |sp| {
+                let sp_op: &mut dyn AtomicOperation = sp;
+                assert!(sp_op.supports_hooks());
+                sp_op
+                    .add_commit_hook_dyn(
+                        TypeId::of::<CountingHook>(),
+                        Box::new(CountingHook {
+                            label: "savepoint".to_string(),
+                            post: post.clone(),
+                        }),
+                    )
+                    .ok()
+                    .expect("savepoint must accept a hook via the dyn op");
+                Ok::<_, sqlx::Error>(())
+            })
+            .await?;
+        assert!(result.is_ok());
+    }
+
+    db_op.commit().await?;
+
+    let mut ran = post.lock().unwrap().clone();
+    ran.sort();
+    assert_eq!(ran, vec!["root".to_string(), "savepoint".to_string()]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn dyn_atomic_operation_generic_wrapper_still_works() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let post = Arc::new(Mutex::new(Vec::new()));
+    let mut db_op = DbOp::init(&pool).await?;
+
+    // The Sized-only generic wrappers are unaffected on a concrete (non-dyn)
+    // operation: they route through the same erased methods internally.
+    db_op
+        .add_commit_hook(CountingHook {
+            label: "typed".to_string(),
+            post: post.clone(),
+        })
+        .unwrap();
+    assert_eq!(db_op.commit_hook::<CountingHook>().unwrap().label, "typed");
+
+    db_op.commit().await?;
+    assert_eq!(post.lock().unwrap().clone(), vec!["typed".to_string()]);
+
+    Ok(())
+}

--- a/tests/savepoint.rs
+++ b/tests/savepoint.rs
@@ -2,7 +2,7 @@ mod helpers;
 
 use es_entity::operation::{
     AtomicOperation, DbOp, SavepointOperation,
-    hooks::{CommitHook, HookOperation, PreCommitRet},
+    hooks::{CommitHook, DynHook, HookOperation, PreCommitRet},
 };
 use std::sync::{Arc, Mutex};
 
@@ -1180,8 +1180,12 @@ impl AtomicOperation for ForgetfulWrapper<'_> {
         self.0.connection()
     }
 
-    fn add_commit_hook<H: CommitHook>(&mut self, hook: H) -> Result<(), H> {
-        self.0.add_commit_hook(hook)
+    fn add_commit_hook_dyn(
+        &mut self,
+        type_id: std::any::TypeId,
+        hook: Box<dyn DynHook>,
+    ) -> Result<(), Box<dyn DynHook>> {
+        self.0.add_commit_hook_dyn(type_id, hook)
     }
 
     fn supports_hooks(&self) -> bool {


### PR DESCRIPTION
## What

`add_commit_hook<H>` and `commit_hook<H>` were the only two generic methods on `AtomicOperation`; being generic, they're what made the trait non-object-safe (`dyn AtomicOperation` could not be named at all — verified below).

Internally, hooks were already stored type-erased (`Vec<(TypeId, Box<dyn DynHook>)>` behind an `as_any` downcast). This PR exposes that layer as two new trait methods, `add_commit_hook_dyn` / `commit_hook_dyn` (`TypeId` + `Box<dyn DynHook>` in, `&dyn DynHook` out) — each keeping the *same default* the generic methods had (`Err(hook)` / `None`), so no existing implementor is forced to change. `add_commit_hook`/`commit_hook` become provided wrappers, `where Self: Sized`, that box/downcast through the erased pair — identical signature and behaviour, just no longer required, and no longer callable through a trait object.

`DynHook` moves from module-private to `pub` (required — it now appears in a public trait signature). `delegate_atomic_operation!` forwards the two erased methods instead of the old generic pair; the wrappers no longer need macro support since they route through whichever `*_dyn` impl the macro emits.

## Premise-check (against current `main`)

- Confirmed `add_commit_hook`/`commit_hook` were the *only* two generic methods; everything else on the trait already satisfied object safety (no `Self`-by-value returns, no associated consts). These two were the sole violation.
- Confirmed the type-erased `DynHook`/`CommitHooks` storage already existed in `src/operation/hooks.rs`, module-private.
- Confirmed exactly **four** external `delegate_atomic_operation!` users: obix's `BatchOp`, `IsolatedOp`, `FlushOp` (`src/out/ctx.rs`) and lana-bank's `UseCaseOp` (`lib/use-case/src/op.rs`). obix's CHANGELOG confirms it moved off hand-written wrapper ops onto the macro in 0.12.14, so the macro edit covers all four.
- No PR/branch conflicts: PR #210 touches `macros.rs` but only the unrelated `es_query!` macro (different region of the file); the single-query-nested-reads and nullable-scope-columns branches are already merged into `main`.

## Is this breaking?

**No**, verified rather than assumed:

- Audited `cala`, `job`, `obix`, `lana-bank` and this crate's own tests for hand `impl AtomicOperation`: **none exist** outside the macro-generated impls and two in-tree test wrappers (`ForgetfulWrapper`, `HooklessOp` in `tests/savepoint.rs`, both updated). Every other reference is `&mut impl AtomicOperation` (a generic bound, not a hand impl), so the new `add_commit_hook_dyn`/`commit_hook_dyn` methods — which carry the old defaults — don't force any external type to change.
- Audited the same four repos plus this crate for `AtomicOperation + ?Sized` generic bounds that call the two generic hook methods (the only way the new `Self: Sized` requirement could break existing code). Found exactly one: this crate's own `OpWithTime<'a, Op: AtomicOperation + ?Sized>`, fixed as part of this change.
- Since the trait was **not** object-safe before this change, no `dyn AtomicOperation` could have existed anywhere prior to it — so nothing could already be calling `add_commit_hook`/`commit_hook` through a trait object for the `Sized` bound to break.
- Checked publicity of `DynHook` with the compiler (adding it as `pub` was required to satisfy E0446 "private type in public interface" the moment it appears in `AtomicOperation`'s signature — confirmed by `cargo check` failing without the `pub`, not by reasoning about privacy rules).

No `!`, ordinary `feat` release.

## The `delegate_atomic_operation!` trap

The macro generates `supports_hooks`, `savepoint_parts`, and now `add_commit_hook_dyn`/`commit_hook_dyn` together in one generated `impl` block per invocation, so they can never drift apart per wrapper type the way a hand-written impl could silently do (obix hit exactly that on 0.12.13). Nothing new to get wrong here — the three-way consistency was already structurally guaranteed by the macro emitting one impl for all of them; this change just adds the two new methods to that same block.

## Verification

- Compiler-proved object safety: `src/operation/mod.rs` has a `#[cfg(test)]` canary (`&mut dyn AtomicOperation` named in a function signature) that only compiles if the trait stays object-safe; `tests/dyn_atomic_operation.rs` drives real behaviour — register/read a commit hook and open a savepoint, entirely through `&mut dyn AtomicOperation`, then commits and asserts both the root and savepoint hooks actually ran `post_commit`.
- **Revert-to-red**: stashed the trait/impl changes while keeping the new test file — `cargo clippy` fails deterministically with E0038, naming `add_commit_hook` and `commit_hook` as the object-safety violations (exactly the two methods this PR fixes).
- `cargo nextest run` (live DB via `make start-deps`): 289/289 passing, no regressions.
- `cargo clippy --all-targets -- -D warnings`: no *new* warnings from this change (two pre-existing failures on `main` — `tests/hooks.rs:308` `drop_non_drop`, `tests/savepoint.rs:1013` `unused_mut` — reproduced identically on unmodified `main`, left untouched as out of scope).
- `cargo fmt` applied.
- `nix flake check --option eval-cache false` launched; will report back if it surfaces anything cargo/clippy/nextest didn't.

## Consumer-side adoption (out of scope here, for lana-bank to scope separately)

Not done in this PR (lana-bank/obix untouched, as directed). What it would look like:

- `UseCaseOp::isolated` in `lib/use-case/src/op.rs` currently returns an owned `SavepointOp<'_>` wrapped back into `UseCaseOp::Savepoint`. The three places `lana-bank`'s use-case layer holds a `&mut SavepointOp<'_>` (the `Savepoint`, `Flush`, `Isolated`/`Staged` arms use-case code touches only through `AtomicOperation` methods — never the type-specific `release`/`rollback`/`commit` verbs, which stay with the helper/command loop that owns the op) could instead coerce to `&mut dyn AtomicOperation` at the point `UseCaseOp` is constructed.
- `UseCaseOp<'op, 'parent>`'s two lifetime parameters exist because `SavepointOp` (and `FlushOp`/`IsolatedOp`/`StagedOp`) are invariant over the parent borrow. Erasing to `&mut dyn AtomicOperation` at construction drops the `'parent` lifetime from every variant (`Savepoint`, `Flush`, `Isolated`, `Staged` all become `&'op mut dyn AtomicOperation`), collapsing `UseCaseOp` to a single lifetime — with no change needed in obix, since obix's op types already only need to implement `AtomicOperation` (via `delegate_atomic_operation!`, now object-safe) for the coercion to type-check.
- The obix "own-and-hand-back" refactor stays explicitly out of scope/not a prerequisite, per the task; its `inv`-seal value should be re-evaluated independently once (if) this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the transaction commit-hook path and trait surface (`DynHook` is now public), but behavior for concrete ops is intended to be unchanged via the Sized wrappers; risk is mainly regressions in hook ordering/merging or downstream code that assumed a non-object-safe trait.
> 
> **Overview**
> **`AtomicOperation` can now be used as `&mut dyn AtomicOperation`** because the generic commit-hook methods are no longer part of the object-safe surface.
> 
> The trait gains **`add_commit_hook_dyn` / `commit_hook_dyn`** (`TypeId` + `Box<dyn DynHook>`), with the same defaults as before (`Err(hook)` / `None`). **`add_commit_hook` / `commit_hook` stay the public typed API** as default methods with `where Self: Sized`, boxing and downcasting through the erased pair. Hook storage already used type erasure; **`CommitHooks`** now routes registration through **`push_or_merge` / `get_last_dyn`**, and **`DynHook` is public** with a new **`into_any`** for error recovery on the typed path.
> 
> **`delegate_atomic_operation!`** and all in-crate **`AtomicOperation`** impls (`DbOp`, savepoints, `HookOperation`, `OpWithTime`, etc.) forward the dyn methods instead of implementing the generics directly.
> 
> **Tests** add a compile-time object-safety canary in `mod.rs`, integration coverage in **`tests/dyn_atomic_operation.rs`** (hooks + savepoints through a trait object), and update **`ForgetfulWrapper`** in savepoint tests to use the dyn hook API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ead83346e179fa72ee0c2d3ea6ff6bf8c994527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->