### PR TITLE
feat(op): blanket AtomicOperation impl for &mut O

### DIFF
--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -542,6 +542,44 @@ impl<'c> AtomicOperation for sqlx::Transaction<'c, db::Db> {
     }
 }
 
+impl<O: AtomicOperation + ?Sized> AtomicOperation for &mut O {
+    fn maybe_now(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        O::maybe_now(&**self)
+    }
+
+    fn clock(&self) -> &ClockHandle {
+        O::clock(&**self)
+    }
+
+    fn connection(&mut self) -> &mut db::Connection {
+        O::connection(&mut **self)
+    }
+
+    fn as_executor(&mut self) -> OneTimeExecutor<'_, &mut db::Connection> {
+        O::as_executor(&mut **self)
+    }
+
+    fn add_commit_hook_dyn(
+        &mut self,
+        type_id: std::any::TypeId,
+        hook: Box<dyn hooks::DynHook>,
+    ) -> Result<(), Box<dyn hooks::DynHook>> {
+        O::add_commit_hook_dyn(&mut **self, type_id, hook)
+    }
+
+    fn commit_hook_dyn(&self, type_id: std::any::TypeId) -> Option<&dyn hooks::DynHook> {
+        O::commit_hook_dyn(&**self, type_id)
+    }
+
+    fn supports_hooks(&self) -> bool {
+        O::supports_hooks(&**self)
+    }
+
+    fn savepoint_parts(&mut self) -> (&mut db::Connection, savepoint::HookSlot<'_>) {
+        O::savepoint_parts(&mut **self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/mut_ref_atomic_operation.rs
+++ b/tests/mut_ref_atomic_operation.rs
@@ -1,0 +1,171 @@
+mod helpers;
+
+use es_entity::{
+    clock::ClockHandle,
+    operation::{
+        AtomicOperation, DbOp, SavepointOperation,
+        hooks::{CommitHook, HookOperation, PreCommitRet},
+    },
+};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+struct CountingHook {
+    label: String,
+    post: Arc<Mutex<Vec<String>>>,
+}
+
+impl CommitHook for CountingHook {
+    async fn pre_commit(
+        self,
+        op: HookOperation<'_>,
+    ) -> Result<PreCommitRet<'_, Self>, sqlx::Error> {
+        PreCommitRet::ok(self, op)
+    }
+
+    fn post_commit(self) {
+        self.post.lock().unwrap().push(self.label);
+    }
+}
+
+async fn touch(op: &mut impl AtomicOperation) -> Result<(), sqlx::Error> {
+    sqlx::query!("SELECT 1 as one")
+        .fetch_one(op.as_executor())
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn generic_callee_accepts_a_mut_borrow() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut db_op = DbOp::init(&pool).await?;
+
+    touch(&mut &mut db_op).await?;
+
+    let result = db_op
+        .with_savepoint(async |mut sp| touch(&mut sp).await)
+        .await?;
+    assert!(result.is_ok());
+
+    db_op.commit().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn clock_and_cached_time_forward_through_mut_ref() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let (clock, _ctrl) = ClockHandle::manual();
+    let mut db_op = DbOp::init_with_clock(&pool, &clock).await?;
+
+    let inner_maybe_now = db_op.maybe_now();
+    assert!(
+        inner_maybe_now.is_some(),
+        "a manual clock must cache the time on init"
+    );
+    let inner_clock_now = db_op.clock().now();
+
+    fn read_clock_state(
+        op: &mut impl AtomicOperation,
+    ) -> (
+        Option<chrono::DateTime<chrono::Utc>>,
+        chrono::DateTime<chrono::Utc>,
+    ) {
+        (op.maybe_now(), op.clock().now())
+    }
+    let (borrowed_maybe_now, borrowed_clock_now) = read_clock_state(&mut &mut db_op);
+
+    assert_eq!(borrowed_maybe_now, inner_maybe_now);
+    assert_eq!(borrowed_clock_now, inner_clock_now);
+
+    db_op.commit().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn hooks_register_through_mut_ref() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let post = Arc::new(Mutex::new(Vec::new()));
+    let mut db_op = DbOp::init(&pool).await?;
+
+    fn register(op: &mut impl AtomicOperation, hook: CountingHook) -> Result<(), CountingHook> {
+        op.add_commit_hook(hook)
+    }
+    register(
+        &mut &mut db_op,
+        CountingHook {
+            label: "via-borrow".to_string(),
+            post: post.clone(),
+        },
+    )
+    .expect("the borrow must forward hook registration, not fall to the Err default");
+
+    assert_eq!(
+        db_op.commit_hook::<CountingHook>().unwrap().label,
+        "via-borrow"
+    );
+
+    db_op.commit().await?;
+    assert_eq!(post.lock().unwrap().clone(), vec!["via-borrow".to_string()]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn savepoint_through_mut_ref_keeps_hook_support() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let post = Arc::new(Mutex::new(Vec::new()));
+    let mut db_op = DbOp::init(&pool).await?;
+
+    async fn isolate_and_hook(
+        op: &mut impl AtomicOperation,
+        hook: CountingHook,
+    ) -> Result<Result<(), sqlx::Error>, sqlx::Error> {
+        op.with_savepoint(async |sp| {
+            sp.add_commit_hook(hook)
+                .expect("savepoint reached through the borrow must accept a hook");
+            Ok::<_, sqlx::Error>(())
+        })
+        .await
+    }
+
+    let result = isolate_and_hook(
+        &mut &mut db_op,
+        CountingHook {
+            label: "savepoint".to_string(),
+            post: post.clone(),
+        },
+    )
+    .await?;
+    assert!(result.is_ok());
+
+    db_op.commit().await?;
+    assert_eq!(post.lock().unwrap().clone(), vec!["savepoint".to_string()]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mut_ref_to_dyn_atomic_operation_is_itself_an_operation() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let post = Arc::new(Mutex::new(Vec::new()));
+    let mut db_op = DbOp::init(&pool).await?;
+
+    {
+        let mut dynamic: &mut dyn AtomicOperation = &mut db_op;
+        touch(&mut dynamic).await?;
+
+        fn register(op: &mut impl AtomicOperation, hook: CountingHook) -> Result<(), CountingHook> {
+            op.add_commit_hook(hook)
+        }
+        register(
+            &mut dynamic,
+            CountingHook {
+                label: "via-dyn".to_string(),
+                post: post.clone(),
+            },
+        )
+        .expect("add_commit_hook must still reach a &mut dyn AtomicOperation");
+    }
+
+    db_op.commit().await?;
+    assert_eq!(post.lock().unwrap().clone(), vec!["via-dyn".to_string()]);
+    Ok(())
+}


### PR DESCRIPTION
## What

`impl<O: AtomicOperation + ?Sized> AtomicOperation for &mut O`, forwarding every method to the wrapped operation. A mutable borrow of any operation — including `&mut dyn AtomicOperation`, via the `?Sized` bound — is now itself an operation, so a caller generic over `impl AtomicOperation` can be handed a re-borrow instead of the original.

Source: `drua-library/spaces/es-entity-dev/handoff-atomic-operation-for-mut-ref.md`.

## Why

lana's `lib/use-case` is moving `WriteContext` from an enum-wrapped operation to a type parameter, `WriteContext<T, Op: AtomicOperation>`. An owned boundary is `Op = DbOp<'static>`; a lent one is `Op = &'op mut DbOp<'static>`, `&'op mut SavepointOp<'t>`, `&'op mut obix::FlushOp<'t>`, etc. That only type-checks if `&mut O` implements `AtomicOperation`. The orphan rule stops lana adding the impl itself (foreign trait, foreign type), so it has to live here.

Baseline: es-entity `0.12.18` (`AtomicOperation` object-safe as of #221).

## `?Sized`: verified purely additive

`Self` in this impl is `&mut O` — the reference — not `O`. A reference is always `Sized` even when its referent isn't (`&mut dyn AtomicOperation` is a fat pointer, itself a fixed-size value), so the two Sized-gated provided methods (`add_commit_hook`/`commit_hook`) were never restricted by `O`'s own sizedness in the first place: reaching them through this blanket always needed the call site to unify the generic parameter as exactly `&mut O`, sized or not (see the tests below). `?Sized` only widens which `O` the impl covers — it costs nothing for the existing `Sized` cases and adds `O = dyn AtomicOperation`.

Checked this with the compiler rather than assuming: a *direct* `d.add_commit_hook(h)` on a bare `d: &mut dyn AtomicOperation` variable resolves to `Self = dyn AtomicOperation` (the trait object itself, unsized) and is rejected — Rust's method resolution commits to that "zero extra ref" interpretation and doesn't backtrack to try `Self = &mut dyn AtomicOperation` (this blanket) instead. Routing the same call through a generic `fn f(op: &mut impl AtomicOperation)` invoked as `f(&mut d, h)` does reach it. That's not a new restriction — it's the identical "force the generic parameter via an extra `&mut`" shape every other test here already uses for `Sized` operations.

## Implementation notes

- Placed in `src/operation/mod.rs` next to the `DbOp`/`DbOpWithTime`/`sqlx::Transaction` impls.
- Every object-safe method is forwarded explicitly; the two generic provided methods (`add_commit_hook`, `commit_hook`) come for free through `add_commit_hook_dyn`/`commit_hook_dyn`, exactly as for every other implementor.
- **Forwards use `O::method(&**self)` / `O::method(&mut **self)`, never `self.method()`.** With `self: &mut &mut O`, `self.method()` resolves back to *this same impl* (`<&mut O as AtomicOperation>::method` itself takes `&mut &mut O`) and recurses forever. `delegate_atomic_operation!`'s `$target.method()` form has the identical problem for a reference target, so this impl is hand-written rather than macro-generated.
- No coherence conflict: no existing impl is for a reference type (`DbOp<'o>`, `DbOpWithTime<'o>`, `OpWithTime<'a, Op>`, `SavepointOp<'_>`, `HookOperation<'c>`, `sqlx::Transaction<'c, Db>`).
- The `SavepointOperation` blanket (`impl<T: AtomicOperation + ?Sized> SavepointOperation for T`) picks the new impl up automatically — `(&mut op).with_savepoint(...)` and savepoints through `&mut dyn AtomicOperation` both work with no further changes.
- `Send`: `&mut O: Send` iff `O: Send`, already guaranteed by the `AtomicOperation: Send` supertrait bound on `O`.

## Tests (`tests/mut_ref_atomic_operation.rs`)

Each is a behavioural check that forwarding actually reaches the inner op rather than silently falling to the trait's defaults (the real trap — a missed forward yields `maybe_now() == None`, `supports_hooks() == false`, or an unsupported `HookSlot`, not a compile error):

1. A generic `touch(op: &mut impl AtomicOperation)` accepts a re-borrow of a `DbOp` and, inside `with_savepoint`, of a `SavepointOp`.
2. `clock()`/`maybe_now()` forward through the borrow — checked against a manual clock so the cached-time path is exercised, not just the realtime default.
3. `add_commit_hook` through a re-borrow returns `Ok(())` (not the `Err(hook)` default), and the inner op reads the hook back via `commit_hook::<H>()`.
4. A savepoint opened through a re-borrow keeps real hook support: `savepoint_parts` was forwarded rather than defaulted to `HookSlot::unsupported()`, which would otherwise trip the "reports `supports_hooks()` but yields no buffer" protocol error the moment `add_commit_hook` is called inside it.
5. `&mut dyn AtomicOperation` itself satisfies `AtomicOperation` — the `?Sized` bound — and `add_commit_hook` (the Sized-gated provided method) still reaches it via the generic-forcing call shape from the `?Sized` discussion above.

**Revert-to-red**: reverting to `O: AtomicOperation` (no `?Sized`) while keeping the dyn test fails deterministically with `the size for values of type 'dyn AtomicOperation' cannot be known at compilation time` plus `the trait bound '&mut dyn AtomicOperation: AtomicOperation' is not satisfied`, restored clean by `git checkout`.

## Verification

- `cargo nextest run` (live DB via `make start-deps`): 294/294 passing, no regressions.
- `cargo clippy --all-targets -- -D warnings`: no new warnings from this change.
- `cargo fmt` applied.
- `nix flake check --option eval-cache false`: all checks passed on the prior (Sized-only) revision; rerunning is not expected to change the result since only the bound and one additive test changed.

## Release

Semver-minor per the handoff doc (new impl, no signature changes) — ordinary `feat`, no `!`.

## Downstream

Per the handoff doc: lana bumps to the release containing this and executes `lana-dev/handoff-use-case-generic-write-context.md`. Nothing in obix or cala needs to change; both already compile against `0.12.18`. Not done here — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)