### PR TITLE
feat(macros): relax generated _in_op operation bounds to ?Sized

### DIFF
--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -223,7 +223,7 @@ impl ToTokens for CreateAllFn<'_> {
                 new_entities: Vec<<#entity as es_entity::EsEntity>::New>
             ) -> Result<Vec<#entity>, #create_error>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<Vec<#entity>, #create_error> = async {
                     use es_entity::prelude::sqlx::{Arguments, Row};
@@ -348,7 +348,7 @@ mod tests {
                 new_entities: Vec<<Entity as es_entity::EsEntity>::New>
             ) -> Result<Vec<Entity>, EntityCreateError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<Vec<Entity>, EntityCreateError> = async {
                     use es_entity::prelude::sqlx::{Arguments, Row};

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -203,7 +203,7 @@ impl ToTokens for CreateFn<'_> {
                 new_entity: <#entity as es_entity::EsEntity>::New
             ) -> Result<#entity, #create_error>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<#entity, #create_error> = async {
                     use es_entity::prelude::sqlx::{Arguments, Row};
@@ -319,7 +319,7 @@ mod tests {
                 new_entity: <Entity as es_entity::EsEntity>::New
             ) -> Result<Entity, EntityCreateError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<Entity, EntityCreateError> = async {
                     use es_entity::prelude::sqlx::{Arguments, Row};
@@ -429,7 +429,7 @@ mod tests {
                 new_entity: <Entity as es_entity::EsEntity>::New
             ) -> Result<Entity, EntityCreateError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<Entity, EntityCreateError> = async {
                     use es_entity::prelude::sqlx::{Arguments, Row};

--- a/es-entity-macros/src/repo/delete_fn.rs
+++ b/es-entity-macros/src/repo/delete_fn.rs
@@ -170,7 +170,7 @@ impl ToTokens for DeleteFn<'_> {
                 mut entity: #entity
             ) -> Result<(), #modify_error>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<(), #modify_error> = async {
                     #(#nested_deletes)*
@@ -268,7 +268,7 @@ mod tests {
                 mut entity: Entity
             ) -> Result<(), EntityModifyError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<(), EntityModifyError> = async {
                     let id = &entity.id;
@@ -360,7 +360,7 @@ mod tests {
                 mut entity: Entity
             ) -> Result<(), EntityModifyError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<(), EntityModifyError> = async {
                     let id = &entity.id;
@@ -448,7 +448,7 @@ mod tests {
                 mut entity: Entity
             ) -> Result<(), EntityModifyError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<(), EntityModifyError> = async {
                     let id = &entity.id;

--- a/es-entity-macros/src/repo/forget_fn.rs
+++ b/es-entity-macros/src/repo/forget_fn.rs
@@ -233,7 +233,7 @@ impl ToTokens for ForgetFn<'_> {
                 mut entity: #entity_type
             ) -> Result<#entity_type, #error>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 #persist_staged
                 {
@@ -352,7 +352,7 @@ impl ForgetFn<'_> {
                 id: impl std::borrow::Borrow<#id_type>
             ) -> Result<(), #error>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let id = id.borrow();
                 let mut remnants = es_entity::ForgettableRemnants::default();

--- a/es-entity-macros/src/repo/hydrate_nested.rs
+++ b/es-entity-macros/src/repo/hydrate_nested.rs
@@ -128,7 +128,7 @@ impl ToTokens for HydrateNested<'_> {
                         parent_id: &#ty,
                     ) -> Result<(), __EsErr>
                     where
-                        OP: es_entity::AtomicOperation,
+                        OP: es_entity::AtomicOperation + ?Sized,
                         __EsErr: From<sqlx::Error> + Send,
                     {
                         #cascade

--- a/es-entity-macros/src/repo/nested.rs
+++ b/es-entity-macros/src/repo/nested.rs
@@ -39,10 +39,10 @@ impl ToTokens for Nested<'_> {
             // already holds scattered `&mut P` borrows (this same fn one
             // level up the nesting, recursing into grandchildren) can pass
             // them straight through without needing contiguous storage.
-            async fn #create_fn_name<OP, P>(&self, op: &mut OP, entities: &mut [&mut P]) -> Result<(), <#nested_repo_ty as es_entity::EsRepo>::CreateError>
+            async fn #create_fn_name<OP, P>(&self, mut op: &mut OP, entities: &mut [&mut P]) -> Result<(), <#nested_repo_ty as es_entity::EsRepo>::CreateError>
                 where
                     P: es_entity::Parent<<#nested_repo_ty as EsRepo>::Entity>,
-                    OP: es_entity::AtomicOperation
+                    OP: es_entity::AtomicOperation + ?Sized
             {
                 let counts: Vec<usize> = entities
                     .iter_mut()
@@ -57,7 +57,13 @@ impl ToTokens for Nested<'_> {
                     .flat_map(|entity| entity.new_children_mut().drain(..))
                     .collect();
 
-                let mut children = self.#repo_field.create_all_in_op(op, new_children).await?.into_iter();
+                // The child repo's own `create_all_in_op` may or may not have
+                // been generated `?Sized` — its bound depends on *its* hook and
+                // nesting configuration, which this macro invocation cannot
+                // see. Reborrowing through one more `&mut` satisfies either
+                // bound: `&mut OP` is always `Sized`, and implements
+                // `AtomicOperation` via the blanket impl whenever `OP` does.
+                let mut children = self.#repo_field.create_all_in_op(&mut op, new_children).await?.into_iter();
                 for (entity, n) in entities.iter_mut().zip(counts) {
                     entity.inject_children(children.by_ref().take(n));
                 }
@@ -68,17 +74,18 @@ impl ToTokens for Nested<'_> {
             // `update_all_mut_in_op` call on the child repo — one statement
             // for the whole parent batch, not one per child per parent — then
             // batches new children via `#create_fn_name`.
-            async fn #update_fn_name<OP, P>(&self, op: &mut OP, entities: &mut [&mut P]) -> Result<(), #parent_modify_error>
+            async fn #update_fn_name<OP, P>(&self, mut op: &mut OP, entities: &mut [&mut P]) -> Result<(), #parent_modify_error>
                 where
                     P: es_entity::Parent<<#nested_repo_ty as EsRepo>::Entity>,
-                    OP: es_entity::AtomicOperation
+                    OP: es_entity::AtomicOperation + ?Sized
             {
                 let persisted: Vec<_> = entities
                     .iter_mut()
                     .flat_map(|entity| entity.iter_persisted_children_mut())
                     .collect();
                 if !persisted.is_empty() {
-                    self.#repo_field.update_all_mut_in_op(op, persisted).await?;
+                    // See the comment in `#create_fn_name` above.
+                    self.#repo_field.update_all_mut_in_op(&mut op, persisted).await?;
                 }
                 self.#create_fn_name(op, entities).await?;
                 Ok(())
@@ -100,7 +107,7 @@ impl ToTokens for Nested<'_> {
 
             async fn #delete_fn_name<OP, P, __EsErr>(op: &mut OP, entity: &P) -> Result<(), __EsErr>
                 where
-                    OP: es_entity::AtomicOperation,
+                    OP: es_entity::AtomicOperation + ?Sized,
                     P: es_entity::EsEntity,
                     #nested_repo_ty: es_entity::CascadeDeleteNested<<<P as es_entity::EsEntity>::Event as es_entity::EsEvent>::EntityId>,
                     __EsErr: From<sqlx::Error> + Send,
@@ -141,10 +148,10 @@ mod tests {
         cursor.to_tokens(&mut tokens);
 
         let expected = quote! {
-            async fn create_nested_users_in_op<OP, P>(&self, op: &mut OP, entities: &mut [&mut P]) -> Result<(), <UserRepo as es_entity::EsRepo>::CreateError>
+            async fn create_nested_users_in_op<OP, P>(&self, mut op: &mut OP, entities: &mut [&mut P]) -> Result<(), <UserRepo as es_entity::EsRepo>::CreateError>
                 where
                     P: es_entity::Parent<<UserRepo as EsRepo>::Entity>,
-                    OP: es_entity::AtomicOperation
+                    OP: es_entity::AtomicOperation + ?Sized
             {
                 let counts: Vec<usize> = entities
                     .iter_mut()
@@ -159,24 +166,24 @@ mod tests {
                     .flat_map(|entity| entity.new_children_mut().drain(..))
                     .collect();
 
-                let mut children = self.users.create_all_in_op(op, new_children).await?.into_iter();
+                let mut children = self.users.create_all_in_op(&mut op, new_children).await?.into_iter();
                 for (entity, n) in entities.iter_mut().zip(counts) {
                     entity.inject_children(children.by_ref().take(n));
                 }
                 Ok(())
             }
 
-            async fn update_nested_users_in_op<OP, P>(&self, op: &mut OP, entities: &mut [&mut P]) -> Result<(), ParentModifyError>
+            async fn update_nested_users_in_op<OP, P>(&self, mut op: &mut OP, entities: &mut [&mut P]) -> Result<(), ParentModifyError>
                 where
                     P: es_entity::Parent<<UserRepo as EsRepo>::Entity>,
-                    OP: es_entity::AtomicOperation
+                    OP: es_entity::AtomicOperation + ?Sized
             {
                 let persisted: Vec<_> = entities
                     .iter_mut()
                     .flat_map(|entity| entity.iter_persisted_children_mut())
                     .collect();
                 if !persisted.is_empty() {
-                    self.users.update_all_mut_in_op(op, persisted).await?;
+                    self.users.update_all_mut_in_op(&mut op, persisted).await?;
                 }
                 self.create_nested_users_in_op(op, entities).await?;
                 Ok(())
@@ -198,7 +205,7 @@ mod tests {
 
             async fn delete_nested_users_in_op<OP, P, __EsErr>(op: &mut OP, entity: &P) -> Result<(), __EsErr>
                 where
-                    OP: es_entity::AtomicOperation,
+                    OP: es_entity::AtomicOperation + ?Sized,
                     P: es_entity::EsEntity,
                     UserRepo: es_entity::CascadeDeleteNested<<<P as es_entity::EsEntity>::Event as es_entity::EsEvent>::EntityId>,
                     __EsErr: From<sqlx::Error> + Send,

--- a/es-entity-macros/src/repo/persist_events_batch_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_batch_fn.rs
@@ -113,7 +113,7 @@ impl ToTokens for PersistEventsBatchFn<'_> {
                 all_events: &mut [B]
             ) -> Result<std::collections::HashMap<#id_type, usize>, sqlx::Error>
             where
-                OP: es_entity::AtomicOperation,
+                OP: es_entity::AtomicOperation + ?Sized,
                 B: std::borrow::BorrowMut<es_entity::EntityEvents<#event_type>>,
             {
                 use es_entity::prelude::sqlx::Row;
@@ -202,7 +202,7 @@ mod tests {
                 all_events: &mut [B]
             ) -> Result<std::collections::HashMap<EntityId, usize>, sqlx::Error>
             where
-                OP: es_entity::AtomicOperation,
+                OP: es_entity::AtomicOperation + ?Sized,
                 B: std::borrow::BorrowMut<es_entity::EntityEvents<EntityEvent>>,
             {
                 use es_entity::prelude::sqlx::Row;
@@ -291,7 +291,7 @@ mod tests {
                 all_events: &mut [B]
             ) -> Result<std::collections::HashMap<EntityId, usize>, sqlx::Error>
             where
-                OP: es_entity::AtomicOperation,
+                OP: es_entity::AtomicOperation + ?Sized,
                 B: std::borrow::BorrowMut<es_entity::EntityEvents<EntityEvent>>,
             {
                 use es_entity::prelude::sqlx::Row;

--- a/es-entity-macros/src/repo/persist_events_fn.rs
+++ b/es-entity-macros/src/repo/persist_events_fn.rs
@@ -90,7 +90,7 @@ impl ToTokens for PersistEventsFn<'_> {
                 events: &mut es_entity::EntityEvents<#event_type>
             ) -> Result<usize, sqlx::Error>
             where
-                OP: es_entity::AtomicOperation,
+                OP: es_entity::AtomicOperation + ?Sized,
             {
                 let id = events.id();
                 if !events.any_new() {
@@ -151,7 +151,7 @@ mod tests {
                 events: &mut es_entity::EntityEvents<EntityEvent>
             ) -> Result<usize, sqlx::Error>
             where
-                OP: es_entity::AtomicOperation,
+                OP: es_entity::AtomicOperation + ?Sized,
             {
                 let id = events.id();
                 if !events.any_new() {
@@ -208,7 +208,7 @@ mod tests {
                 events: &mut es_entity::EntityEvents<EntityEvent>
             ) -> Result<usize, sqlx::Error>
             where
-                OP: es_entity::AtomicOperation,
+                OP: es_entity::AtomicOperation + ?Sized,
             {
                 let id = events.id();
                 if !events.any_new() {

--- a/es-entity-macros/src/repo/post_persist_hook.rs
+++ b/es-entity-macros/src/repo/post_persist_hook.rs
@@ -26,15 +26,32 @@ impl ToTokens for PostPersistHook<'_> {
         let event = &self.event;
         let entity = &self.entity;
 
-        let (error_ty, hook) = if let Some(config) = self.hook {
+        let (error_ty, hook, op_param) = if let Some(config) = self.hook {
             let method = &config.method;
             let error = &config.error;
             (
                 quote! { #error },
                 quote! {
-                    self.#method(op, entity, new_events).await?;
+                    // The caller's hook method (`#method`) lives in the
+                    // consuming crate and, by every existing convention, is
+                    // generic over a plain (implicitly `Sized`) `impl
+                    // AtomicOperation` — its signature is out of this macro's
+                    // control and cannot be forced to add `?Sized`.
+                    //
+                    // Reborrowing through one more `&mut` sidesteps that: a
+                    // `&mut OP` is always `Sized` regardless of whether `OP`
+                    // itself is, and it implements `AtomicOperation` via the
+                    // blanket `impl<O: AtomicOperation + ?Sized> AtomicOperation
+                    // for &mut O`. So `&mut op` satisfies the hook method's
+                    // `Sized` bound no matter what `OP` is here, letting this
+                    // wrapper — and therefore every caller of it — stay
+                    // `?Sized` unconditionally.
+                    self.#method(&mut op, entity, new_events).await?;
                     Ok(())
                 },
+                // `mut` is only needed to take `&mut op` above; declaring it
+                // unconditionally would warn `unused_mut` on the no-hook path.
+                quote! { mut op: &mut OP },
             )
         } else {
             (
@@ -42,6 +59,7 @@ impl ToTokens for PostPersistHook<'_> {
                 quote! {
                     Ok(())
                 },
+                quote! { op: &mut OP },
             )
         };
 
@@ -49,12 +67,12 @@ impl ToTokens for PostPersistHook<'_> {
             #[inline(always)]
             async fn execute_post_persist_hook<OP>(
                 &self,
-                op: &mut OP,
+                #op_param,
                 entity: &#entity,
                 new_events: es_entity::LastPersisted<'_, #event>
             ) -> Result<(), #error_ty>
                 where
-                    OP: es_entity::AtomicOperation
+                    OP: es_entity::AtomicOperation + ?Sized
             {
                 #hook
             }
@@ -89,7 +107,7 @@ mod tests {
                 new_events: es_entity::LastPersisted<'_, EntityEvent>
             ) -> Result<(), sqlx::Error>
                 where
-                    OP: es_entity::AtomicOperation
+                    OP: es_entity::AtomicOperation + ?Sized
             {
                 Ok(())
             }
@@ -119,14 +137,14 @@ mod tests {
         let expected = quote! {
             #[inline(always)]
             async fn execute_post_persist_hook<OP>(&self,
-                op: &mut OP,
+                mut op: &mut OP,
                 entity: &Entity,
                 new_events: es_entity::LastPersisted<'_, EntityEvent>
             ) -> Result<(), MyPersistError>
                 where
-                    OP: es_entity::AtomicOperation
+                    OP: es_entity::AtomicOperation + ?Sized
             {
-                self.on_persist(op, entity, new_events).await?;
+                self.on_persist(&mut op, entity, new_events).await?;
                 Ok(())
             }
         };

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -335,7 +335,7 @@ impl UpdateAllFn<'_> {
                 #entities_param
             ) -> Result<usize, #modify_error>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<usize, #modify_error> = async {
                     use es_entity::prelude::sqlx::Row;
@@ -445,7 +445,7 @@ mod tests {
                 entities: &mut [Entity]
             ) -> Result<usize, EntityModifyError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<usize, EntityModifyError> = async {
                     use es_entity::prelude::sqlx::Row;
@@ -539,7 +539,7 @@ mod tests {
                 entities: impl IntoIterator<Item = &mut Entity>
             ) -> Result<usize, EntityModifyError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<usize, EntityModifyError> = async {
                     use es_entity::prelude::sqlx::Row;
@@ -678,7 +678,7 @@ mod tests {
                 entities: &mut [Entity]
             ) -> Result<usize, EntityModifyError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<usize, EntityModifyError> = async {
                     use es_entity::prelude::sqlx::Row;
@@ -732,7 +732,7 @@ mod tests {
                 entities: impl IntoIterator<Item = &mut Entity>
             ) -> Result<usize, EntityModifyError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<usize, EntityModifyError> = async {
                     use es_entity::prelude::sqlx::Row;

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -201,7 +201,7 @@ impl ToTokens for UpdateFn<'_> {
                 entity: &mut #entity
             ) -> Result<usize, #modify_error>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<usize, #modify_error> = async {
                     #record_id
@@ -290,7 +290,7 @@ mod tests {
                 entity: &mut Entity
             ) -> Result<usize, EntityModifyError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<usize, EntityModifyError> = async {
                     if !Self::extract_events(entity).any_new() {
@@ -386,7 +386,7 @@ mod tests {
                 entity: &mut Entity
             ) -> Result<usize, EntityModifyError>
             where
-                OP: es_entity::AtomicOperation
+                OP: es_entity::AtomicOperation + ?Sized
             {
                 let __result: Result<usize, EntityModifyError> = async {
                     if !Self::extract_events(entity).any_new() {

--- a/src/nested.rs
+++ b/src/nested.rs
@@ -127,7 +127,7 @@ pub trait CascadeDeleteNested<ID>: EsRepo {
         parent_id: &ID,
     ) -> impl Future<Output = Result<(), E>> + Send
     where
-        OP: AtomicOperation,
+        OP: AtomicOperation + ?Sized,
         E: From<sqlx::Error> + Send;
 }
 

--- a/src/one_time_executor.rs
+++ b/src/one_time_executor.rs
@@ -264,7 +264,7 @@ impl<'c> IntoOneTimeExecutorAt<'c> for &db::Pool {
 
 impl<'c, O> IntoOneTimeExecutorAt<'c> for &mut O
 where
-    O: AtomicOperation,
+    O: AtomicOperation + ?Sized,
 {
     type Executor = &'c mut db::Connection;
 

--- a/src/operation/hooks.rs
+++ b/src/operation/hooks.rs
@@ -327,7 +327,7 @@ pub trait CommitHook: Send + 'static + Sized {
     /// Useful when [`AtomicOperation::add_commit_hook()`] returns `Err(hook)`.
     fn force_execute_pre_commit(
         self,
-        op: &mut impl AtomicOperation,
+        op: &mut (impl AtomicOperation + ?Sized),
     ) -> impl Future<Output = Result<Self, sqlx::Error>> + Send {
         async {
             let hook_op = HookOperation::new(op);
@@ -363,7 +363,7 @@ pub struct HookOperation<'c> {
 impl<'c> HookOperation<'c> {
     /// Force-execute path: no commit pass to fold into, so registering further
     /// hooks stays unsupported.
-    fn new(op: &'c mut impl AtomicOperation) -> Self {
+    fn new(op: &'c mut (impl AtomicOperation + ?Sized)) -> Self {
         Self {
             now: op.maybe_now(),
             conn: op.connection(),

--- a/tests/dyn_repo_operations.rs
+++ b/tests/dyn_repo_operations.rs
@@ -1,0 +1,151 @@
+//! Pins the property the `_in_op` bound relaxation exists for: the derived
+//! `EsRepo` `_in_op` methods must accept a mutable reference to a
+//! `dyn AtomicOperation` **directly** — no `&mut &mut` double-reference
+//! workaround. A caller that only holds `&mut dyn AtomicOperation` (e.g. a job
+//! function relaxed to `impl AtomicOperation + ?Sized`) cannot manufacture a
+//! concrete, `Sized` operation type to satisfy an unrelaxed bound, so this
+//! must compile — and pass — with a single reference throughout.
+//!
+//! Every generated `_in_op` function is unconditionally `?Sized` — including
+//! ones with a nested field or a `post_persist_hook` configured, which
+//! internally reborrow through one more `&mut` at the boundary into a
+//! Sized-only callee (a sibling repo's method, or a user hook) rather than
+//! falling back to `Sized` themselves. `Users` here keeps neither, so it
+//! exercises the plain, unwrapped path.
+
+mod entities;
+mod helpers;
+
+use entities::user::*;
+use es_entity::{AtomicOperation, DbOp, *};
+use sqlx::PgPool;
+
+#[derive(EsRepo, Debug)]
+#[es_repo(entity = "User", columns(name(ty = "String", list_for)))]
+pub struct Users {
+    pool: PgPool,
+}
+
+impl Users {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[tokio::test]
+async fn generated_in_op_fns_accept_dyn_atomic_operation_directly() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let users = Users::new(pool.clone());
+    let mut db_op = DbOp::init(&pool).await?;
+
+    let new_user = NewUser::builder()
+        .id(UserId::new())
+        .name("Dyn Op")
+        .build()
+        .unwrap();
+
+    // `create_in_op` takes `op: &mut OP`. Passing a `&mut dyn AtomicOperation`
+    // straight through unifies `OP = dyn AtomicOperation` — only possible
+    // because the generated bound is `OP: AtomicOperation + ?Sized`.
+    let op: &mut dyn AtomicOperation = &mut db_op;
+    let mut user = users.create_in_op(op, new_user).await?;
+
+    let _ = user.update_name("Dyn Op Updated");
+    let op: &mut dyn AtomicOperation = &mut db_op;
+    users.update_in_op(op, &mut user).await?;
+
+    // The read-side `_in_op` methods ride on `IntoOneTimeExecutorAt`'s
+    // `impl<'c, O> IntoOneTimeExecutorAt<'c> for &mut O where O: AtomicOperation
+    // + ?Sized` — also directly callable with `&mut dyn AtomicOperation`.
+    let op: &mut dyn AtomicOperation = &mut db_op;
+    let found = users.find_by_id_in_op(op, user.id).await?;
+    assert_eq!(found.name, "Dyn Op Updated");
+
+    let op: &mut dyn AtomicOperation = &mut db_op;
+    let all: std::collections::HashMap<UserId, User> = users.find_all_in_op(op, &[user.id]).await?;
+    assert!(all.contains_key(&user.id));
+
+    db_op.commit().await?;
+    Ok(())
+}
+
+// --- The harder case: a `post_persist_hook` configured -------------------
+//
+// `execute_post_persist_hook` forwards `op` into this hook method, whose
+// signature — like every existing hook in this codebase and downstream —
+// is generic over a plain (implicitly `Sized`) `impl AtomicOperation`. The
+// generated wrapper reborrows through one more `&mut` before calling it
+// (see `post_persist_hook.rs`), so the hook method itself needs no changes
+// and `create_in_op` still accepts `&mut dyn AtomicOperation` directly.
+
+#[derive(Debug)]
+pub struct DummyHookError;
+
+impl std::fmt::Display for DummyHookError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "dummy hook error")
+    }
+}
+
+impl std::error::Error for DummyHookError {}
+
+// A second, distinct entity (`Task`) — `#[derive(EsRepo)]` generates
+// companion types named after the entity (`UserCreateError`, ...), so a
+// second repo over `User` in this same file would collide with `Users`'.
+use entities::task::*;
+
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "Task",
+    columns(status(ty = "String", create(accessor = "status"))),
+    post_persist_hook(method = "on_persist", error = "DummyHookError")
+)]
+pub struct TasksWithHook {
+    pool: PgPool,
+    hook_calls: std::sync::atomic::AtomicUsize,
+}
+
+impl TasksWithHook {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+            hook_calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    // Deliberately the plain, `Sized`-only shape every existing hook method
+    // uses — this must keep compiling unmodified.
+    async fn on_persist<OP: es_entity::AtomicOperation>(
+        &self,
+        _op: &mut OP,
+        _entity: &Task,
+        _new_events: es_entity::LastPersisted<'_, TaskEvent>,
+    ) -> Result<(), DummyHookError> {
+        self.hook_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn hook_configured_repo_still_accepts_dyn_atomic_operation_directly() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let tasks = TasksWithHook::new(pool.clone());
+    let mut db_op = DbOp::init(&pool).await?;
+
+    let new_task = NewTask::builder()
+        .id(TaskId::new())
+        .status("open")
+        .build()
+        .unwrap();
+
+    let op: &mut dyn AtomicOperation = &mut db_op;
+    let _task = tasks.create_in_op(op, new_task).await?;
+
+    db_op.commit().await?;
+    assert_eq!(
+        tasks.hook_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Every `EsRepo`-derived `_in_op` method (and the codegen it rides on) was generic over `OP: AtomicOperation` with an implicit `Sized` bound. A caller holding only `&mut dyn AtomicOperation` — e.g. a job function relaxed to `impl AtomicOperation + ?Sized` — could not pass it in directly; only the `&mut &mut dyn AtomicOperation` double-reference form (satisfied by the 0.12.19 blanket `impl AtomicOperation for &mut O`, #222) compiled.

This relaxes the bound to `OP: AtomicOperation + ?Sized` **unconditionally**, everywhere:

- `create_in_op`, `create_all_in_op`
- `update_in_op`, `update_all_in_op`, `update_all_mut_in_op`
- `delete_in_op`
- `forget_in_op`, `verify_forgotten_in_op`
- `persist_events`, `persist_events_batch`
- the generated `CascadeDeleteNested::cascade_delete_in_op` impl
- `find_by_*_in_op` / `find_all_in_op`, via `IntoOneTimeExecutorAt`'s `impl<'c, O> IntoOneTimeExecutorAt<'c> for &mut O where O: AtomicOperation + ?Sized`

Also relaxed: the `CascadeDeleteNested::cascade_delete_in_op` trait definition (`src/nested.rs`) that the generated impl above implements, and `CommitHook::force_execute_pre_commit` + `HookOperation::new` (`src/operation/hooks.rs`), which had the identical shape and are named directly in the motivating report.

## The two internal boundaries this can't see through

Two call sites cross into a bound the macro doesn't control:

1. A nested field's delegate (`nested.rs`) calling into a **sibling repo's** own generated method — whose `?Sized`-ness depends on *that* repo's own hook/nesting config, invisible to this macro invocation.
2. A configured `post_persist_hook`'s call into the **consuming crate's** hook method — conventionally `OP: AtomicOperation` with no `?Sized`, and out of the macro's control entirely.

Rather than falling back to `Sized` in either case (which would have required per-repo conditional bounds, and left hook-configured / nested repos permanently non-dyn-friendly), both are made unconditionally safe by reborrowing through one more `&mut` at the boundary: `&mut OP` is always `Sized` regardless of whether `OP` is, and it implements `AtomicOperation` via the existing blanket impl — so it satisfies *either* a `Sized`-only or a `?Sized` callee. This means every generated method is `?Sized` with **no exceptions** and **zero required changes to existing hook implementations**.

## Test

`tests/dyn_repo_operations.rs` constructs a `&mut dyn AtomicOperation` and calls generated `_in_op` methods on it **directly** (no double-reference) for:
- a plain repo (`create_in_op`, `update_in_op`, `find_by_id_in_op`, `find_all_in_op`)
- a repo with a `post_persist_hook` configured, whose hook method keeps the plain, pre-existing `OP: AtomicOperation` (Sized) signature unmodified — proving the reborrow trick, not a hook-signature convention change, is what makes this compile.

Revert-to-red: reverting `create_in_op`'s bound back to `OP: AtomicOperation` makes both call sites in the new test fail with `E0277: the size for values of type 'dyn AtomicOperation' cannot be known at compilation time`, pointing at the right lines.

## Breaking?

No. Confirmed rather than assumed:
- Relaxing a bound is additive — every `OP` that satisfied `Sized` still satisfies `?Sized`.
- A scratch external crate depending on this via a path dependency compiles clean against the new signatures (no E0603/E0624 or other privacy/visibility regressions).
- The full existing test suite (`cargo nextest run` against the live dev-env Postgres, 301 tests) passes unchanged, including `forgettable_hooks` (a real `post_persist_hook` consumer with a plain, `Sized`-only hook method) and `nested_entities` (nested cascade delegation).
- No SQL changed; `.sqlx` is untouched (verified via `git status`).

## Downstream (job) — not done here

Job's double-reference workaround (`spawner.rs`, `current.rs`, `batched.rs`, `finalizer.rs`, `keyed.rs`, plus `CommitHook::force_execute_pre_commit` in `insert.rs` and `promote.rs`) can be dropped once this is released. That's purely cosmetic — both the single- and double-reference forms compile and behave identically (the blanket impl only forwards every call) — so dropping it changes nothing functionally; it's a follow-up simplification to be scoped separately in job.

## Concurrent es-entity work

Checked before editing codegen, per the task brief:
- **AtomicOperation object-safety** (#221) and the **blanket `&mut O` impl** (#222) are already merged into `main`, well ahead of this branch's old base (0.12.18-dev) — rebased onto `origin/main` (0.12.20-dev) before starting.
- **PR #210** (`feat(macros)!: aggregate version for nested entities`, draft, unmerged) and the **single-query-nested-reads branch** (`task/es-entity-single-query-nested-reads-01a049de`, unmerged) both diverged from `main` months ago (before #221/#222/#220) and touch several of the same codegen files this PR does (`nested.rs`, `update_fn.rs`, `update_all_fn.rs`, `hydrate_nested.rs`, `post_persist_hook.rs` among them). Whoever rebases either of those will need to re-apply the `?Sized` + reborrow-wrap shape on top of their restructuring. Flagging here since I can't resolve that from this branch.
- Batch-isolation (#220) and nullable-scope-columns (#209) work is already merged into the base this branch is rebased on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111NDJBWuptikbpa7chgP5Z

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The change only widens generic bounds and uses forwarding reborrows; persistence SQL and runtime behavior are unchanged, with new compile-time tests covering `dyn AtomicOperation`.
> 
> **Overview**
> Generated **`EsRepo` `_in_op` APIs** (create/update/delete/forget, event persistence, nested cascade, etc.) now require **`OP: AtomicOperation + ?Sized`**, so callers can pass **`&mut dyn AtomicOperation`** directly instead of relying on a double `&mut` workaround.
> 
> **Nested child-repo calls** and **`post_persist_hook` invocations** reborrow the operation as **`&mut op`** at the boundary so existing **Sized-only** hook methods and sibling repos still compile while the public `_in_op` surface stays **`?Sized` everywhere**.
> 
> Matching relaxations land on **`CascadeDeleteNested`**, **`IntoOneTimeExecutorAt` for `&mut O`**, and commit-hook helpers **`HookOperation::new` / `force_execute_pre_commit`**. **`tests/dyn_repo_operations.rs`** locks in direct `dyn` usage for plain repos and hook-configured repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8225dccfb542dad6d42ce3d55d93858b4636540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->