### PR TITLE
feat(macros): add in_op_only option to generate only _in_op repo fns

### DIFF
--- a/es-entity-macros/src/repo/create_all_fn.rs
+++ b/es-entity-macros/src/repo/create_all_fn.rs
@@ -8,6 +8,7 @@ use super::{
 };
 
 pub struct CreateAllFn<'a> {
+    in_op_only: bool,
     entity: &'a syn::Ident,
     id: &'a syn::Ident,
     event: &'a syn::Ident,
@@ -27,6 +28,7 @@ pub struct CreateAllFn<'a> {
 impl<'a> From<&'a RepositoryOptions> for CreateAllFn<'a> {
     fn from(opts: &'a RepositoryOptions) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             table_name: opts.table_name(),
             entity: opts.entity(),
             id: opts.id(),
@@ -205,16 +207,22 @@ impl ToTokens for CreateAllFn<'_> {
                 }
             };
 
-        tokens.append_all(quote! {
-            pub async fn create_all(
-                &self,
-                new_entities: Vec<<#entity as es_entity::EsEntity>::New>
-            ) -> Result<Vec<#entity>, #create_error> {
-                let mut op = self.begin_op().await?;
-                let res = self.create_all_in_op(&mut op, new_entities).await?;
-                op.commit().await?;
-                Ok(res)
+        let standalone = (!self.in_op_only).then(|| {
+            quote! {
+                pub async fn create_all(
+                    &self,
+                    new_entities: Vec<<#entity as es_entity::EsEntity>::New>
+                ) -> Result<Vec<#entity>, #create_error> {
+                    let mut op = self.begin_op().await?;
+                    let res = self.create_all_in_op(&mut op, new_entities).await?;
+                    op.commit().await?;
+                    Ok(res)
+                }
             }
+        });
+
+        tokens.append_all(quote! {
+            #standalone
 
             #instrument_attr
             pub async fn create_all_in_op<OP>(
@@ -312,6 +320,7 @@ mod tests {
         columns.set_id_column(&id);
 
         let create_fn = CreateAllFn {
+            in_op_only: false,
             table_name: "entities",
             entity: &entity,
             id: &id,

--- a/es-entity-macros/src/repo/create_fn.rs
+++ b/es-entity-macros/src/repo/create_fn.rs
@@ -8,6 +8,7 @@ use super::{
 };
 
 pub struct CreateFn<'a> {
+    in_op_only: bool,
     entity: &'a syn::Ident,
     id: &'a syn::Ident,
     event: &'a syn::Ident,
@@ -27,6 +28,7 @@ pub struct CreateFn<'a> {
 impl<'a> From<&'a RepositoryOptions> for CreateFn<'a> {
     fn from(opts: &'a RepositoryOptions) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             table_name: opts.table_name(),
             entity: opts.entity(),
             id: opts.id(),
@@ -167,6 +169,20 @@ impl ToTokens for CreateFn<'_> {
             quote! {}
         };
 
+        let standalone = (!self.in_op_only).then(|| {
+            quote! {
+                pub async fn create(
+                    &self,
+                    new_entity: <#entity as es_entity::EsEntity>::New
+                ) -> Result<#entity, #create_error> {
+                    let mut op = self.begin_op().await?;
+                    let res = self.create_in_op(&mut op, new_entity).await?;
+                    op.commit().await?;
+                    Ok(res)
+                }
+            }
+        });
+
         tokens.append_all(quote! {
             #[inline(always)]
             fn convert_new<Entity, Event>(item: Entity) -> es_entity::EntityEvents<Event>
@@ -186,15 +202,7 @@ impl ToTokens for CreateFn<'_> {
                 Entity::try_from_events(events)
             }
 
-            pub async fn create(
-                &self,
-                new_entity: <#entity as es_entity::EsEntity>::New
-            ) -> Result<#entity, #create_error> {
-                let mut op = self.begin_op().await?;
-                let res = self.create_in_op(&mut op, new_entity).await?;
-                op.commit().await?;
-                Ok(res)
-            }
+            #standalone
 
             #instrument_attr
             pub async fn create_in_op<OP>(
@@ -265,6 +273,7 @@ mod tests {
         columns.set_id_column(&id);
 
         let create_fn = CreateFn {
+            in_op_only: false,
             table_name: "entities",
             entity: &entity,
             id: &id,
@@ -375,6 +384,7 @@ mod tests {
         columns.set_id_column(&id);
 
         let create_fn = CreateFn {
+            in_op_only: false,
             table_name: "entities",
             entity: &entity,
             id: &id,

--- a/es-entity-macros/src/repo/delete_fn.rs
+++ b/es-entity-macros/src/repo/delete_fn.rs
@@ -8,6 +8,7 @@ use super::{
 };
 
 pub struct DeleteFn<'a> {
+    in_op_only: bool,
     id: &'a syn::Ident,
     event: &'a syn::Ident,
     modify_error: syn::Ident,
@@ -27,6 +28,7 @@ pub struct DeleteFn<'a> {
 impl<'a> DeleteFn<'a> {
     pub fn from(opts: &'a RepositoryOptions) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             id: opts.id(),
             event: opts.event(),
             entity: opts.entity(),
@@ -153,16 +155,22 @@ impl ToTokens for DeleteFn<'_> {
             None => quote! {},
         };
 
-        tokens.append_all(quote! {
-            pub async fn delete(
-                &self,
-                entity: #entity
-            ) -> Result<(), #modify_error> {
-                let mut op = self.begin_op().await?;
-                let res = self.delete_in_op(&mut op, entity).await?;
-                op.commit().await?;
-                Ok(res)
+        let standalone = (!self.in_op_only).then(|| {
+            quote! {
+                pub async fn delete(
+                    &self,
+                    entity: #entity
+                ) -> Result<(), #modify_error> {
+                    let mut op = self.begin_op().await?;
+                    let res = self.delete_in_op(&mut op, entity).await?;
+                    op.commit().await?;
+                    Ok(res)
+                }
             }
+        });
+
+        tokens.append_all(quote! {
+            #standalone
 
             #instrument_attr
             pub async fn delete_in_op<OP>(&self,
@@ -232,6 +240,7 @@ mod tests {
 
         let event = Ident::new("EntityEvent", Span::call_site());
         let delete_fn = DeleteFn {
+            in_op_only: false,
             id: &id,
             event: &event,
             entity: &entity,
@@ -324,6 +333,7 @@ mod tests {
 
         let event = Ident::new("EntityEvent", Span::call_site());
         let delete_fn = DeleteFn {
+            in_op_only: false,
             id: &id,
             event: &event,
             entity: &entity,
@@ -412,6 +422,7 @@ mod tests {
 
         let event = Ident::new("EntityEvent", Span::call_site());
         let delete_fn = DeleteFn {
+            in_op_only: false,
             id: &id,
             event: &event,
             entity: &entity,

--- a/es-entity-macros/src/repo/find_all_fn.rs
+++ b/es-entity-macros/src/repo/find_all_fn.rs
@@ -5,6 +5,7 @@ use quote::{TokenStreamExt, quote};
 use super::{options::*, scope::ScopeInfo};
 
 pub struct FindAllFn<'a> {
+    in_op_only: bool,
     prefix: Option<&'a syn::LitStr>,
     id: &'a syn::Ident,
     entity: &'a syn::Ident,
@@ -20,6 +21,7 @@ pub struct FindAllFn<'a> {
 impl<'a> From<&'a RepositoryOptions> for FindAllFn<'a> {
     fn from(opts: &'a RepositoryOptions) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             prefix: opts.table_prefix(),
             id: opts.id(),
             entity: opts.entity(),
@@ -49,13 +51,19 @@ impl FindAllFn<'_> {
         let generics = quote! { <'a, Out: From<#entity>> };
         let op_param = quote! { op: impl #query_fn_op_traits };
 
-        quote! {
-            pub async fn find_all<Out: From<#entity>>(
-                &self,
-                ids: &[#id]
-            ) -> Result<std::collections::HashMap<#id, Out>, #query_error> {
-                self.repo.find_all(self.scope, ids).await
+        let standalone = (!self.in_op_only).then(|| {
+            quote! {
+                pub async fn find_all<Out: From<#entity>>(
+                    &self,
+                    ids: &[#id]
+                ) -> Result<std::collections::HashMap<#id, Out>, #query_error> {
+                    self.repo.find_all(self.scope, ids).await
+                }
             }
+        });
+
+        quote! {
+            #standalone
 
             pub async fn find_all_in_op #generics(
                 &self,
@@ -156,14 +164,20 @@ impl ToTokens for FindAllFn<'_> {
             quote! {}
         };
 
-        tokens.append_all(quote! {
-            pub async fn find_all<Out: From<#entity>>(
-                &self,
-                #scope_fn_arg
-                ids: &[#id]
-            ) -> Result<std::collections::HashMap<#id, Out>, #query_error> {
-                self.find_all_in_op(#query_fn_get_op, #scope_fn_pass ids).await
+        let standalone = (!self.in_op_only).then(|| {
+            quote! {
+                pub async fn find_all<Out: From<#entity>>(
+                    &self,
+                    #scope_fn_arg
+                    ids: &[#id]
+                ) -> Result<std::collections::HashMap<#id, Out>, #query_error> {
+                    self.find_all_in_op(#query_fn_get_op, #scope_fn_pass ids).await
+                }
             }
+        });
+
+        tokens.append_all(quote! {
+            #standalone
 
             #instrument_attr
             pub async fn find_all_in_op #generics(
@@ -194,6 +208,7 @@ mod tests {
         let query_error = syn::Ident::new("EntityQueryError", Span::call_site());
 
         let persist_fn = FindAllFn {
+            in_op_only: false,
             prefix: None,
             id: &id_type,
             entity: &entity,

--- a/es-entity-macros/src/repo/find_by_fn.rs
+++ b/es-entity-macros/src/repo/find_by_fn.rs
@@ -6,6 +6,7 @@ use quote::{TokenStreamExt, quote};
 use super::{options::*, scope::ScopeInfo};
 
 pub struct FindByFn<'a> {
+    in_op_only: bool,
     prefix: Option<&'a syn::LitStr>,
     entity: &'a syn::Ident,
     column: &'a Column,
@@ -25,6 +26,7 @@ pub struct FindByFn<'a> {
 impl<'a> FindByFn<'a> {
     pub fn new(column: &'a Column, opts: &'a RepositoryOptions) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             prefix: opts.table_prefix(),
             column,
             entity: opts.entity(),
@@ -88,13 +90,19 @@ impl<'a> FindByFn<'a> {
                     Span::call_site(),
                 );
 
-                tokens.append_all(quote! {
-                    pub async fn #fn_name(
-                        &self,
-                        #column_name: #impl_expr
-                    ) -> Result<#result_type, #error> {
-                        self.repo.#fn_name(self.scope, #column_name).await
+                let standalone = (!self.in_op_only).then(|| {
+                    quote! {
+                        pub async fn #fn_name(
+                            &self,
+                            #column_name: #impl_expr
+                        ) -> Result<#result_type, #error> {
+                            self.repo.#fn_name(self.scope, #column_name).await
+                        }
                     }
+                });
+
+                tokens.append_all(quote! {
+                    #standalone
 
                     pub async fn #fn_in_op #query_fn_generics(
                         &self,
@@ -309,14 +317,20 @@ impl ToTokens for FindByFn<'_> {
                 let (instrument_attr_in_op, record_field, error_recording) =
                     (quote! {}, quote! {}, quote! {});
 
-                tokens.append_all(quote! {
-                    pub async fn #fn_name(
-                        &self,
-                        #scope_fn_arg
-                        #column_name: #impl_expr
-                    ) -> Result<#result_type, #error> {
-                        self.#fn_in_op(#query_fn_get_op, #scope_fn_pass #column_name).await
+                let standalone = (!self.in_op_only).then(|| {
+                    quote! {
+                        pub async fn #fn_name(
+                            &self,
+                            #scope_fn_arg
+                            #column_name: #impl_expr
+                        ) -> Result<#result_type, #error> {
+                            self.#fn_in_op(#query_fn_get_op, #scope_fn_pass #column_name).await
+                        }
                     }
+                });
+
+                tokens.append_all(quote! {
+                    #standalone
 
                     #instrument_attr_in_op
                     pub async fn #fn_in_op #query_fn_generics(
@@ -360,6 +374,7 @@ mod tests {
         let entity = Ident::new("Entity", Span::call_site());
 
         let persist_fn = FindByFn {
+            in_op_only: false,
             prefix: None,
             column: &column,
             entity: &entity,
@@ -458,6 +473,7 @@ mod tests {
         let entity = Ident::new("Entity", Span::call_site());
 
         let persist_fn = FindByFn {
+            in_op_only: false,
             prefix: None,
             column: &column,
             entity: &entity,
@@ -553,6 +569,7 @@ mod tests {
         let entity = Ident::new("Entity", Span::call_site());
 
         let persist_fn = FindByFn {
+            in_op_only: false,
             prefix: None,
             column: &column,
             entity: &entity,
@@ -648,6 +665,7 @@ mod tests {
         let entity = Ident::new("Entity", Span::call_site());
 
         let persist_fn = FindByFn {
+            in_op_only: false,
             prefix: None,
             column: &column,
             entity: &entity,
@@ -678,6 +696,7 @@ mod tests {
         let entity = Ident::new("Entity", Span::call_site());
 
         let persist_fn = FindByFn {
+            in_op_only: false,
             prefix: None,
             column: &column,
             entity: &entity,
@@ -710,6 +729,7 @@ mod tests {
         let entity = Ident::new("Entity", Span::call_site());
 
         let persist_fn = FindByFn {
+            in_op_only: false,
             prefix: None,
             column: &column,
             entity: &entity,

--- a/es-entity-macros/src/repo/forget_fn.rs
+++ b/es-entity-macros/src/repo/forget_fn.rs
@@ -330,9 +330,7 @@ impl ForgetFn<'_> {
             quote! {
                 /// Verifies at the **storage level** that all configured
                 /// forgettable data for `id` is physically absent — i.e. that
-                /// `forget()` has fully taken effect. See
-                /// [`Self::verify_forgotten_in_op`] for the details of what is
-                /// checked; this variant opens and commits its own operation.
+                /// `forget()` has fully taken effect.
                 pub async fn verify_forgotten(
                     &self,
                     id: impl std::borrow::Borrow<#id_type>

--- a/es-entity-macros/src/repo/forget_fn.rs
+++ b/es-entity-macros/src/repo/forget_fn.rs
@@ -9,6 +9,7 @@ use super::{
 };
 
 pub struct ForgetFn<'a> {
+    in_op_only: bool,
     id: &'a syn::Ident,
     entity: &'a syn::Ident,
     event: &'a syn::Ident,
@@ -24,6 +25,7 @@ pub struct ForgetFn<'a> {
 impl<'a> ForgetFn<'a> {
     pub fn from(opts: &'a RepositoryOptions) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             id: opts.id(),
             entity: opts.entity(),
             event: opts.event(),
@@ -181,19 +183,25 @@ impl ToTokens for ForgetFn<'_> {
             quote! {}
         };
 
-        tokens.append_all(quote! {
-            /// Permanently forgets the entity's forgettable data. Consumes the
-            /// entity and returns the rebuilt (forgotten) entity. On any error
-            /// the potentially-inconsistent copy is dropped — reload and retry.
-            pub async fn forget(
-                &self,
-                entity: #entity_type
-            ) -> Result<#entity_type, #error> {
-                let mut op = self.begin_op().await?;
-                let entity = self.forget_in_op(&mut op, entity).await?;
-                op.commit().await?;
-                Ok(entity)
+        let standalone = (!self.in_op_only).then(|| {
+            quote! {
+                /// Permanently forgets the entity's forgettable data. Consumes the
+                /// entity and returns the rebuilt (forgotten) entity. On any error
+                /// the potentially-inconsistent copy is dropped — reload and retry.
+                pub async fn forget(
+                    &self,
+                    entity: #entity_type
+                ) -> Result<#entity_type, #error> {
+                    let mut op = self.begin_op().await?;
+                    let entity = self.forget_in_op(&mut op, entity).await?;
+                    op.commit().await?;
+                    Ok(entity)
+                }
             }
+        });
+
+        tokens.append_all(quote! {
+            #standalone
 
             /// Permanently forgets the entity's forgettable data — all in one
             /// transaction: persists any staged (unpersisted) events, deletes
@@ -318,7 +326,28 @@ impl ForgetFn<'_> {
             }
         };
 
+        let standalone = (!self.in_op_only).then(|| {
+            quote! {
+                /// Verifies at the **storage level** that all configured
+                /// forgettable data for `id` is physically absent — i.e. that
+                /// `forget()` has fully taken effect. See
+                /// [`Self::verify_forgotten_in_op`] for the details of what is
+                /// checked; this variant opens and commits its own operation.
+                pub async fn verify_forgotten(
+                    &self,
+                    id: impl std::borrow::Borrow<#id_type>
+                ) -> Result<(), #error> {
+                    let mut op = self.begin_op().await?;
+                    let res = self.verify_forgotten_in_op(&mut op, id).await?;
+                    op.commit().await?;
+                    Ok(res)
+                }
+            }
+        });
+
         tokens.append_all(quote! {
+            #standalone
+
             /// Verifies at the **storage level** that all configured
             /// forgettable data for `id` is physically absent — i.e. that
             /// `forget()` has fully taken effect. Unlike inspecting a hydrated
@@ -333,19 +362,9 @@ impl ForgetFn<'_> {
             ///
             /// Returns `Err(NotForgotten(remnants))` describing anything still
             /// present. An entity that was never persisted verifies trivially.
-            pub async fn verify_forgotten(
-                &self,
-                id: impl std::borrow::Borrow<#id_type>
-            ) -> Result<(), #error> {
-                let mut op = self.begin_op().await?;
-                let res = self.verify_forgotten_in_op(&mut op, id).await?;
-                op.commit().await?;
-                Ok(res)
-            }
-
-            /// Same as [`Self::verify_forgotten`] but runs on an existing
-            /// operation, so the check can share the erasure (or a follow-up)
-            /// transaction.
+            ///
+            /// Runs on an existing operation, so the check can share the
+            /// erasure (or a follow-up) transaction.
             pub async fn verify_forgotten_in_op<OP>(
                 &self,
                 op: &mut OP,
@@ -413,6 +432,7 @@ mod tests {
         let error = Ident::new("EntityForgetError", Span::call_site());
 
         let forget_fn = ForgetFn {
+            in_op_only: false,
             id: &id,
             entity: &entity,
             event: &event,
@@ -463,6 +483,7 @@ mod tests {
         let email = Ident::new("email", Span::call_site());
 
         let forget_fn = ForgetFn {
+            in_op_only: false,
             id: &id,
             entity: &entity,
             event: &event,
@@ -508,6 +529,7 @@ mod tests {
         let hook_error: syn::Type = syn::parse_str("MyHookError").unwrap();
 
         let forget_fn = ForgetFn {
+            in_op_only: false,
             id: &id,
             entity: &entity,
             event: &event,
@@ -555,6 +577,7 @@ mod tests {
         let hook_error: syn::Type = syn::parse_str("MyHookError").unwrap();
 
         let forget_fn = ForgetFn {
+            in_op_only: false,
             id: &id,
             entity: &entity,
             event: &event,

--- a/es-entity-macros/src/repo/list_by_fn.rs
+++ b/es-entity-macros/src/repo/list_by_fn.rs
@@ -347,6 +347,7 @@ impl ToTokens for CursorStruct<'_> {
 }
 
 pub struct ListByFn<'a> {
+    in_op_only: bool,
     ignore_prefix: Option<&'a syn::LitStr>,
     id: &'a syn::Ident,
     entity: &'a syn::Ident,
@@ -365,6 +366,7 @@ pub struct ListByFn<'a> {
 impl<'a> ListByFn<'a> {
     pub fn new(column: &'a Column, opts: &'a RepositoryOptions) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             ignore_prefix: opts.table_prefix(),
             column,
             id: opts.id(),
@@ -425,14 +427,20 @@ impl<'a> ListByFn<'a> {
                 Span::call_site(),
             );
 
-            tokens.append_all(quote! {
-                pub async fn #fn_name(
-                    &self,
-                    cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
-                    direction: es_entity::ListDirection,
-                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #query_error> {
-                    self.repo.#fn_name(self.scope, cursor, direction).await
+            let standalone = (!self.in_op_only).then(|| {
+                quote! {
+                    pub async fn #fn_name(
+                        &self,
+                        cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                        direction: es_entity::ListDirection,
+                    ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #query_error> {
+                        self.repo.#fn_name(self.scope, cursor, direction).await
+                    }
                 }
+            });
+
+            tokens.append_all(quote! {
+                #standalone
 
                 pub async fn #fn_in_op #query_fn_generics(
                     &self,
@@ -648,15 +656,21 @@ impl ToTokens for ListByFn<'_> {
                 quote! {}
             };
 
-            tokens.append_all(quote! {
-                pub async fn #fn_name(
-                    &self,
-                    #scope_fn_arg
-                    cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
-                    direction: es_entity::ListDirection,
-                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #query_error> {
-                    self.#fn_in_op(#query_fn_get_op, #scope_fn_pass cursor, direction).await
+            let standalone = (!self.in_op_only).then(|| {
+                quote! {
+                    pub async fn #fn_name(
+                        &self,
+                        #scope_fn_arg
+                        cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                        direction: es_entity::ListDirection,
+                    ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #query_error> {
+                        self.#fn_in_op(#query_fn_get_op, #scope_fn_pass cursor, direction).await
+                    }
                 }
+            });
+
+            tokens.append_all(quote! {
+                #standalone
 
                 #instrument_attr
                 pub async fn #fn_in_op #query_fn_generics(
@@ -791,6 +805,7 @@ mod tests {
         let cursor_mod = Ident::new("cursor_mod", Span::call_site());
 
         let persist_fn = ListByFn {
+            in_op_only: false,
             ignore_prefix: None,
             column: &column,
             id: &id_type,
@@ -882,6 +897,7 @@ mod tests {
         let cursor_mod = Ident::new("cursor_mod", Span::call_site());
 
         let persist_fn = ListByFn {
+            in_op_only: false,
             ignore_prefix: None,
             column: &column,
             id: &id_type,
@@ -916,6 +932,7 @@ mod tests {
         let cursor_mod = Ident::new("cursor_mod", Span::call_site());
 
         let persist_fn = ListByFn {
+            in_op_only: false,
             ignore_prefix: None,
             column: &column,
             id: &id_type,
@@ -1012,6 +1029,7 @@ mod tests {
         let cursor_mod = Ident::new("cursor_mod", Span::call_site());
 
         let persist_fn = ListByFn {
+            in_op_only: false,
             ignore_prefix: None,
             column: &column,
             id: &id_type,
@@ -1127,6 +1145,7 @@ mod tests {
         let cursor_mod = Ident::new("cursor_mod", Span::call_site());
 
         let persist_fn = ListByFn {
+            in_op_only: false,
             ignore_prefix: None,
             column: &column,
             id: &id_type,

--- a/es-entity-macros/src/repo/list_for_filters_fn.rs
+++ b/es-entity-macros/src/repo/list_for_filters_fn.rs
@@ -403,12 +403,6 @@ impl<'a> ListForFiltersFn<'a> {
         )
     }
 
-    /// Body of one dispatch arm: picks the single sibling fn that serves this
-    /// filter combination and calls it.
-    ///
-    /// `in_op` selects the `_in_op` siblings and threads the caller's `op`
-    /// into them. Every path below is mutually exclusive (one match arm, one
-    /// if/else branch), so the one-shot `op` is consumed exactly once.
     fn generate_proxy_body(
         &self,
         by_col: &Column,
@@ -978,9 +972,7 @@ impl ToTokens for ListForFiltersFn<'_> {
 
             tokens.append_all(by_fns);
 
-            // Generate dispatch function. The `_in_op` build threads the
-            // caller's one-shot executor into whichever sibling the arm picks;
-            // the standalone build is a thin delegate that hands it the pool.
+            // Generate dispatch function
             let dispatch_arms = |in_op: bool| -> TokenStream {
                 self
                 .by_columns
@@ -1388,9 +1380,6 @@ mod tests {
                 __result
             }
 
-            // The dispatcher is now a thin delegate over its `_in_op` twin,
-            // like every other read fn: it hands the pool in as the one-shot
-            // executor and the `_in_op` body does the dispatching.
             pub async fn list_for_filters(
                 &self,
                 filters: OrderFilters,
@@ -1421,8 +1410,6 @@ mod tests {
                             let after = after.map(cursor_mod::OrderByIdCursor::try_from).transpose()?;
                             let query = es_entity::PaginatedQueryArgs { first, after };
 
-                            // Each branch is exclusive, so the one-shot `op` is
-                            // moved into exactly one of them.
                             let es_entity::PaginatedQueryRet {
                                 entities,
                                 has_next_page,

--- a/es-entity-macros/src/repo/list_for_filters_fn.rs
+++ b/es-entity-macros/src/repo/list_for_filters_fn.rs
@@ -161,6 +161,7 @@ impl ToTokens for FiltersStruct<'_> {
 }
 
 pub struct ListForFiltersFn<'a> {
+    in_op_only: bool,
     pub filters_struct: FiltersStruct<'a>,
     entity: &'a syn::Ident,
     query_error: syn::Ident,
@@ -188,6 +189,7 @@ impl<'a> ListForFiltersFn<'a> {
         cursor: &'a ComboCursor<'a>,
     ) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             filters_struct: FiltersStruct::new(opts, for_columns.clone()),
             entity: opts.entity(),
             query_error: opts.query_error(),
@@ -249,15 +251,21 @@ impl<'a> ListForFiltersFn<'a> {
                     Span::call_site(),
                 );
 
-                tokens.append_all(quote! {
-                    pub async fn #fn_name(
-                        &self,
-                        filters: #filters_ident,
-                        cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
-                        direction: es_entity::ListDirection,
-                    ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> {
-                        self.repo.#fn_name(self.scope, filters, cursor, direction).await
+                let standalone = (!self.in_op_only).then(|| {
+                    quote! {
+                        pub async fn #fn_name(
+                            &self,
+                            filters: #filters_ident,
+                            cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                            direction: es_entity::ListDirection,
+                        ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> {
+                            self.repo.#fn_name(self.scope, filters, cursor, direction).await
+                        }
                     }
+                });
+
+                tokens.append_all(quote! {
+                    #standalone
 
                     pub async fn #fn_in_op #query_fn_generics(
                         &self,
@@ -275,17 +283,39 @@ impl<'a> ListForFiltersFn<'a> {
             }
 
             let dispatch_fn = syn::Ident::new(
-                &format!("list_for_filters{}", delete_postfix),
+                &format!("list_for_filters{delete_postfix}"),
                 Span::call_site(),
             );
+            let dispatch_fn_in_op = syn::Ident::new(
+                &format!("list_for_filters{delete_postfix}_in_op"),
+                Span::call_site(),
+            );
+            let standalone_dispatch = (!self.in_op_only).then(|| {
+                quote! {
+                    pub async fn #dispatch_fn(
+                        &self,
+                        filters: #filters_ident,
+                        sort: es_entity::Sort<#sort_by_name>,
+                        cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#combo_cursor_ident>,
+                    ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#combo_cursor_ident>, #error> {
+                        self.repo.#dispatch_fn(self.scope, filters, sort, cursor).await
+                    }
+                }
+            });
             tokens.append_all(quote! {
-                pub async fn #dispatch_fn(
+                #standalone_dispatch
+
+                pub async fn #dispatch_fn_in_op #query_fn_generics(
                     &self,
+                    #query_fn_op_arg,
                     filters: #filters_ident,
                     sort: es_entity::Sort<#sort_by_name>,
                     cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#combo_cursor_ident>,
-                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#combo_cursor_ident>, #error> {
-                    self.repo.#dispatch_fn(self.scope, filters, sort, cursor).await
+                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#combo_cursor_ident>, #error>
+                    where
+                        OP: #query_fn_op_traits
+                {
+                    self.repo.#dispatch_fn_in_op(op, self.scope, filters, sort, cursor).await
                 }
             });
 
@@ -373,7 +403,18 @@ impl<'a> ListForFiltersFn<'a> {
         )
     }
 
-    fn generate_proxy_body(&self, by_col: &Column, delete: DeleteOption) -> TokenStream {
+    /// Body of one dispatch arm: picks the single sibling fn that serves this
+    /// filter combination and calls it.
+    ///
+    /// `in_op` selects the `_in_op` siblings and threads the caller's `op`
+    /// into them. Every path below is mutually exclusive (one match arm, one
+    /// if/else branch), so the one-shot `op` is consumed exactly once.
+    fn generate_proxy_body(
+        &self,
+        by_col: &Column,
+        delete: DeleteOption,
+        in_op: bool,
+    ) -> TokenStream {
         let by_col_name = by_col.name();
         let delete_postfix = delete.include_deletion_fn_postfix();
 
@@ -383,13 +424,20 @@ impl<'a> ListForFiltersFn<'a> {
             quote! {}
         };
 
+        let in_op_postfix = if in_op { "_in_op" } else { "" };
+        let op_pass = if in_op {
+            quote! { op, }
+        } else {
+            quote! {}
+        };
+
         let list_by_fn = syn::Ident::new(
-            &format!("list_by_{}{}", by_col_name, delete_postfix),
+            &format!("list_by_{by_col_name}{delete_postfix}{in_op_postfix}"),
             Span::call_site(),
         );
 
         if self.for_columns.is_empty() {
-            return quote! { self.#list_by_fn(#scope_pass query, direction).await? };
+            return quote! { self.#list_by_fn(#op_pass #scope_pass query, direction).await? };
         }
 
         let all_none_checks: Vec<_> = self
@@ -424,8 +472,7 @@ impl<'a> ListForFiltersFn<'a> {
                 let for_col_name = for_col.name();
                 let fn_name = syn::Ident::new(
                     &format!(
-                        "list_for_{}_by_{}{}",
-                        for_col_name, by_col_name, delete_postfix
+                        "list_for_{for_col_name}_by_{by_col_name}{delete_postfix}{in_op_postfix}"
                     ),
                     Span::call_site(),
                 );
@@ -433,13 +480,13 @@ impl<'a> ListForFiltersFn<'a> {
                 if others_none.is_empty() {
                     quote! {
                         else {
-                            self.#fn_name(#scope_pass filters.#for_col_name.unwrap(), query, direction).await?
+                            self.#fn_name(#op_pass #scope_pass filters.#for_col_name.unwrap(), query, direction).await?
                         }
                     }
                 } else {
                     quote! {
                         else if #(#others_none)&&* {
-                            self.#fn_name(#scope_pass filters.#for_col_name.unwrap(), query, direction).await?
+                            self.#fn_name(#op_pass #scope_pass filters.#for_col_name.unwrap(), query, direction).await?
                         }
                     }
                 }
@@ -454,12 +501,12 @@ impl<'a> ListForFiltersFn<'a> {
         let needs_fallback = has_unpaired || self.for_columns.len() >= 2;
         let multi_filter_fallback = if needs_fallback {
             let list_for_filters_fn = syn::Ident::new(
-                &format!("list_for_filters_by_{}{}", by_col_name, delete_postfix),
+                &format!("list_for_filters_by_{by_col_name}{delete_postfix}{in_op_postfix}"),
                 Span::call_site(),
             );
             quote! {
                 else {
-                    self.#list_for_filters_fn(#scope_pass filters, query, direction).await?
+                    self.#list_for_filters_fn(#op_pass #scope_pass filters, query, direction).await?
                 }
             }
         } else {
@@ -468,7 +515,7 @@ impl<'a> ListForFiltersFn<'a> {
 
         quote! {
             if #(#all_none_checks)&&* {
-                self.#list_by_fn(#scope_pass query, direction).await?
+                self.#list_by_fn(#op_pass #scope_pass query, direction).await?
             }
             #single_filter_branches
             #multi_filter_fallback
@@ -849,16 +896,22 @@ impl<'a> ListForFiltersFn<'a> {
             quote! {}
         };
 
-        quote! {
-            pub async fn #fn_name(
-                &self,
-                #scope_fn_arg
-                filters: #filters_ident,
-                cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
-                direction: es_entity::ListDirection,
-            ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> {
-                self.#fn_in_op(#query_fn_get_op, #scope_fn_pass filters, cursor, direction).await
+        let standalone = (!self.in_op_only).then(|| {
+            quote! {
+                pub async fn #fn_name(
+                    &self,
+                    #scope_fn_arg
+                    filters: #filters_ident,
+                    cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                    direction: es_entity::ListDirection,
+                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> {
+                    self.#fn_in_op(#query_fn_get_op, #scope_fn_pass filters, cursor, direction).await
+                }
             }
+        });
+
+        quote! {
+            #standalone
 
             #instrument_attr
             pub async fn #fn_in_op #query_fn_generics(
@@ -925,8 +978,11 @@ impl ToTokens for ListForFiltersFn<'_> {
 
             tokens.append_all(by_fns);
 
-            // Generate dispatch function
-            let dispatch_arms: TokenStream = self
+            // Generate dispatch function. The `_in_op` build threads the
+            // caller's one-shot executor into whichever sibling the arm picks;
+            // the standalone build is a thin delegate that hands it the pool.
+            let dispatch_arms = |in_op: bool| -> TokenStream {
+                self
                 .by_columns
                 .iter()
                 .map(|by_col| {
@@ -942,7 +998,7 @@ impl ToTokens for ListForFiltersFn<'_> {
                             Span::call_site(),
                         )
                     };
-                    let proxy_body = self.generate_proxy_body(by_col, delete);
+                    let proxy_body = self.generate_proxy_body(by_col, delete, in_op);
                     quote! {
                         #sort_by_name::#by_variant => {
                             let after = after.map(#cursor_mod::#inner_cursor_ident::try_from).transpose()?;
@@ -961,10 +1017,19 @@ impl ToTokens for ListForFiltersFn<'_> {
                         }
                     }
                 })
-                .collect();
+                .collect()
+            };
+            let dispatch_arms = dispatch_arms(true);
 
             let fn_name = syn::Ident::new(
                 &format!("list_for_filters{}", delete.include_deletion_fn_postfix()),
+                Span::call_site(),
+            );
+            let fn_in_op = syn::Ident::new(
+                &format!(
+                    "list_for_filters{}_in_op",
+                    delete.include_deletion_fn_postfix()
+                ),
                 Span::call_site(),
             );
 
@@ -1014,15 +1079,44 @@ impl ToTokens for ListForFiltersFn<'_> {
                 error_recording,
             ) = (quote! {}, quote! {}, quote! {}, quote! {}, quote! {});
 
+            let query_fn_generics = RepositoryOptions::query_fn_generics();
+            let query_fn_op_arg = RepositoryOptions::query_fn_op_arg();
+            let query_fn_op_traits = RepositoryOptions::query_fn_op_traits();
+            let query_fn_get_op = RepositoryOptions::query_fn_get_op();
+            let scope_fn_pass = match &self.scope {
+                Some(scope) => scope.fn_pass(),
+                None => quote! {},
+            };
+
+            let standalone = (!self.in_op_only).then(|| {
+                quote! {
+                    pub async fn #fn_name(
+                        &self,
+                        #scope_fn_arg
+                        filters: #filters_name,
+                        sort: es_entity::Sort<#sort_by_name>,
+                        cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                    ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error>
+                    {
+                        self.#fn_in_op(#query_fn_get_op, #scope_fn_pass filters, sort, cursor).await
+                    }
+                }
+            });
+
             tokens.append_all(quote! {
+                #standalone
+
                 #instrument_attr
-                pub async fn #fn_name(
+                pub async fn #fn_in_op #query_fn_generics(
                     &self,
+                    #query_fn_op_arg,
                     #scope_fn_arg
                     filters: #filters_name,
                     sort: es_entity::Sort<#sort_by_name>,
                     cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
                 ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error>
+                    where
+                        OP: #query_fn_op_traits
                 {
                     let __result: Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> = async {
                         #scope_convert
@@ -1129,6 +1223,7 @@ mod tests {
         let combo_cursor = ComboCursor::new_test(&entity, vec![id_cursor]);
 
         let list_for_filters_fn = ListForFiltersFn {
+            in_op_only: false,
             filters_struct: FiltersStruct::new_test(&entity, for_columns.clone()),
             entity: &entity,
             query_error,
@@ -1293,12 +1388,28 @@ mod tests {
                 __result
             }
 
+            // The dispatcher is now a thin delegate over its `_in_op` twin,
+            // like every other read fn: it hands the pool in as the one-shot
+            // executor and the `_in_op` body does the dispatching.
             pub async fn list_for_filters(
                 &self,
                 filters: OrderFilters,
                 sort: es_entity::Sort<OrderSortBy>,
                 cursor: es_entity::PaginatedQueryArgs<cursor_mod::OrderCursor>,
             ) -> Result<es_entity::PaginatedQueryRet<Order, cursor_mod::OrderCursor>, OrderQueryError>
+            {
+                self.list_for_filters_in_op(self.pool(), filters, sort, cursor).await
+            }
+
+            pub async fn list_for_filters_in_op<'a, OP>(
+                &self,
+                op: OP,
+                filters: OrderFilters,
+                sort: es_entity::Sort<OrderSortBy>,
+                cursor: es_entity::PaginatedQueryArgs<cursor_mod::OrderCursor>,
+            ) -> Result<es_entity::PaginatedQueryRet<Order, cursor_mod::OrderCursor>, OrderQueryError>
+                where
+                    OP: es_entity::IntoOneTimeExecutor<'a>
             {
                 let __result: Result<es_entity::PaginatedQueryRet<Order, cursor_mod::OrderCursor>, OrderQueryError> = async {
                     let es_entity::Sort { by, direction } = sort;
@@ -1310,18 +1421,20 @@ mod tests {
                             let after = after.map(cursor_mod::OrderByIdCursor::try_from).transpose()?;
                             let query = es_entity::PaginatedQueryArgs { first, after };
 
+                            // Each branch is exclusive, so the one-shot `op` is
+                            // moved into exactly one of them.
                             let es_entity::PaginatedQueryRet {
                                 entities,
                                 has_next_page,
                                 end_cursor,
                             } = if filters.customer_id.is_none() && filters.status.is_none() {
-                                self.list_by_id(query, direction).await?
+                                self.list_by_id_in_op(op, query, direction).await?
                             } else if filters.status.is_none() {
-                                self.list_for_customer_id_by_id(filters.customer_id.unwrap(), query, direction).await?
+                                self.list_for_customer_id_by_id_in_op(op, filters.customer_id.unwrap(), query, direction).await?
                             } else if filters.customer_id.is_none() {
-                                self.list_for_status_by_id(filters.status.unwrap(), query, direction).await?
+                                self.list_for_status_by_id_in_op(op, filters.status.unwrap(), query, direction).await?
                             } else {
-                                self.list_for_filters_by_id(filters, query, direction).await?
+                                self.list_for_filters_by_id_in_op(op, filters, query, direction).await?
                             };
                             es_entity::PaginatedQueryRet {
                                 entities,
@@ -1375,6 +1488,7 @@ mod tests {
         let combo_cursor = ComboCursor::new_test(&entity, vec![id_cursor]);
 
         let list_for_filters_fn = ListForFiltersFn {
+            in_op_only: false,
             filters_struct: FiltersStruct::new_test(&entity, for_columns.clone()),
             entity: &entity,
             query_error,
@@ -1444,6 +1558,7 @@ mod tests {
         let combo_cursor = ComboCursor::new_test(&entity, vec![id_cursor]);
 
         let list_for_filters_fn = ListForFiltersFn {
+            in_op_only: false,
             filters_struct: FiltersStruct::new_test(&entity, for_columns.clone()),
             entity: &entity,
             query_error,
@@ -1529,6 +1644,7 @@ mod tests {
         let combo_cursor = ComboCursor::new_test(&entity, vec![id_cursor]);
 
         let list_for_filters_fn = ListForFiltersFn {
+            in_op_only: false,
             filters_struct: FiltersStruct::new_test(&entity, for_columns.clone()),
             entity: &entity,
             query_error,
@@ -1613,6 +1729,7 @@ mod tests {
         let combo_cursor = ComboCursor::new_test(&entity, vec![id_cursor]);
 
         let list_for_filters_fn = ListForFiltersFn {
+            in_op_only: false,
             filters_struct: FiltersStruct::new_test(&entity, for_columns.clone()),
             entity: &entity,
             query_error,
@@ -1712,6 +1829,7 @@ mod tests {
         let combo_cursor = ComboCursor::new_test(&entity, vec![id_cursor]);
 
         let list_for_filters_fn = ListForFiltersFn {
+            in_op_only: false,
             filters_struct: FiltersStruct::new_test(&entity, for_columns.clone()),
             entity: &entity,
             query_error,
@@ -1801,6 +1919,7 @@ mod tests {
 
         let build = |index_catalog: crate::index_catalog::IndexCatalog| -> String {
             let fn_ = ListForFiltersFn {
+                in_op_only: false,
                 filters_struct: FiltersStruct::new_test(&entity, for_columns.clone()),
                 entity: &entity,
                 query_error: query_error.clone(),

--- a/es-entity-macros/src/repo/list_for_fn.rs
+++ b/es-entity-macros/src/repo/list_for_fn.rs
@@ -9,6 +9,7 @@ use super::{
 };
 
 pub struct ListForFn<'a> {
+    in_op_only: bool,
     ignore_prefix: Option<&'a syn::LitStr>,
     pub for_column: &'a Column,
     pub by_column: &'a Column,
@@ -28,6 +29,7 @@ pub struct ListForFn<'a> {
 impl<'a> ListForFn<'a> {
     pub fn new(for_column: &'a Column, by_column: &'a Column, opts: &'a RepositoryOptions) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             ignore_prefix: opts.table_prefix(),
             for_column,
             by_column,
@@ -98,15 +100,21 @@ impl<'a> ListForFn<'a> {
                 Span::call_site(),
             );
 
-            tokens.append_all(quote! {
-                pub async fn #fn_name(
-                    &self,
-                    #filter_arg_name: #for_impl_expr,
-                    cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
-                    direction: es_entity::ListDirection,
-                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> {
-                    self.repo.#fn_name(self.scope, #filter_arg_name, cursor, direction).await
+            let standalone = (!self.in_op_only).then(|| {
+                quote! {
+                    pub async fn #fn_name(
+                        &self,
+                        #filter_arg_name: #for_impl_expr,
+                        cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                        direction: es_entity::ListDirection,
+                    ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> {
+                        self.repo.#fn_name(self.scope, #filter_arg_name, cursor, direction).await
+                    }
                 }
+            });
+
+            tokens.append_all(quote! {
+                #standalone
 
                 pub async fn #fn_in_op #query_fn_generics(
                     &self,
@@ -348,16 +356,22 @@ impl ToTokens for ListForFn<'_> {
                 quote! {}
             };
 
-            tokens.append_all(quote! {
-                pub async fn #fn_name(
-                    &self,
-                    #scope_fn_arg
-                    #filter_arg_name: #for_impl_expr,
-                    cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
-                    direction: es_entity::ListDirection,
-                ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> {
-                    self.#fn_in_op(#query_fn_get_op, #scope_fn_pass #filter_arg_name, cursor, direction).await
+            let standalone = (!self.in_op_only).then(|| {
+                quote! {
+                    pub async fn #fn_name(
+                        &self,
+                        #scope_fn_arg
+                        #filter_arg_name: #for_impl_expr,
+                        cursor: es_entity::PaginatedQueryArgs<#cursor_mod::#cursor_ident>,
+                        direction: es_entity::ListDirection,
+                    ) -> Result<es_entity::PaginatedQueryRet<#entity, #cursor_mod::#cursor_ident>, #error> {
+                        self.#fn_in_op(#query_fn_get_op, #scope_fn_pass #filter_arg_name, cursor, direction).await
+                    }
                 }
+            });
+
+            tokens.append_all(quote! {
+                #standalone
 
                 #instrument_attr
                 pub async fn #fn_in_op #query_fn_generics(
@@ -423,6 +437,7 @@ mod tests {
         let cursor_mod = Ident::new("cursor_mod", Span::call_site());
 
         let persist_fn = ListForFn {
+            in_op_only: false,
             ignore_prefix: None,
             entity: &entity,
             id: &id,
@@ -522,6 +537,7 @@ mod tests {
         let cursor_mod = Ident::new("cursor_mod", Span::call_site());
 
         let persist_fn = ListForFn {
+            in_op_only: false,
             ignore_prefix: None,
             entity: &entity,
             id: &id,

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -59,8 +59,6 @@ pub struct EsRepo<'a> {
     find_all_fn: find_all_fn::FindAllFn<'a>,
     post_hydrate_hook: post_hydrate_hook::PostHydrateHook<'a>,
     post_persist_hook: post_persist_hook::PostPersistHook<'a>,
-    /// `None` for a pool-less (`in_op_only`) repo: `begin_op` manufactures a
-    /// `DbOp` from the pool, so there is nothing to generate it from.
     begin: Option<begin::Begin<'a>>,
     list_by_fns: Vec<list_by_fn::ListByFn<'a>>,
     list_for_fns: Vec<list_for_fn::ListForFn<'a>>,
@@ -220,8 +218,6 @@ impl ToTokens for EsRepo<'_> {
         let nested = &self.nested;
         let hydrate_nested = &self.hydrate_nested;
 
-        // A pool-less (`in_op_only`) repo exposes no pool accessor: there is no
-        // field to return, and nothing generated reaches for one.
         let pool_fn = self.opts.pool_field().map(|pool_field| {
             quote! {
                 #[inline(always)]
@@ -922,14 +918,6 @@ mod tests {
         );
     }
 
-    /// The standalone (non-`_in_op`) fns every write and read path generates
-    /// by default. Each entry is the *exact* token-stream prefix of the
-    /// generated signature, so an accidental re-emission cannot slip past by
-    /// being reformatted.
-    ///
-    /// Shared by the suppression test and its regression twin below so the two
-    /// can never drift apart: whatever `in_op_only` is asserted to remove, a
-    /// default repo is asserted to keep.
     const STANDALONE_FN_SIGNATURES: &[&str] = &[
         "pub async fn create (& self ,",
         "pub async fn create_all (& self ,",
@@ -939,16 +927,12 @@ mod tests {
         "pub async fn find_by_id (& self ,",
         "pub async fn maybe_find_by_id (& self ,",
         "pub async fn find_by_name (& self ,",
-        // stops before the nested `>>`, whose token spacing is not stable
         "pub async fn find_all < Out : From < User",
         "pub async fn list_by_id (& self ,",
         "pub async fn list_for_name_by_id (& self ,",
         "pub async fn list_for_filters (& self ,",
     ];
 
-    /// A repo exercising every generated fn family: writes, soft delete (so
-    /// the `_include_deleted` siblings are emitted too), find-by, list-by,
-    /// list-for and the `list_for_filters` dispatcher.
     fn every_fn_family_repo(extra_opts: proc_macro2::TokenStream) -> syn::DeriveInput {
         parse_quote! {
             #[es_repo(
@@ -975,13 +959,10 @@ mod tests {
                 "`in_op_only` must not generate the standalone fn `{sig}`"
             );
         }
-        // The soft-delete siblings go too.
         assert!(!tokens.contains("pub async fn find_by_id_include_deleted (& self ,"));
         assert!(!tokens.contains("pub async fn list_by_id_include_deleted (& self ,"));
         assert!(!tokens.contains("pub async fn list_for_filters_include_deleted (& self ,"));
 
-        // ...while every `_in_op` twin remains, including the dispatcher's,
-        // which had no `_in_op` form before this option existed.
         assert!(tokens.contains("pub async fn create_in_op"));
         assert!(tokens.contains("pub async fn update_in_op"));
         assert!(tokens.contains("pub async fn delete_in_op"));
@@ -991,9 +972,6 @@ mod tests {
         assert!(tokens.contains("pub async fn list_for_filters_in_op"));
     }
 
-    /// The regression twin: a repo *without* the option keeps every standalone
-    /// fn, the pool accessor and `begin_op`. Guards against the gating leaking
-    /// into the default path.
     #[test]
     fn repo_without_in_op_only_keeps_every_standalone_fn() {
         let tokens = derive(every_fn_family_repo(quote! {}))
@@ -1024,14 +1002,10 @@ mod tests {
         assert!(!tokens.contains("pub fn pool (& self)"));
         assert!(!tokens.contains("begin_op"));
         assert!(!tokens.contains("self . pool ()"));
-        // The op-taking surface is untouched.
         assert!(tokens.contains("pub async fn create_in_op"));
         assert!(tokens.contains("pub async fn find_by_id_in_op"));
     }
 
-    /// `in_op_only` only *permits* dropping the pool — a repo that keeps one
-    /// keeps `pool()`/`begin_op` too. Holding a pool does not weaken the
-    /// discipline: the op still has to be passed explicitly.
     #[test]
     fn in_op_only_with_pool_field_keeps_begin_op() {
         let tokens = derive(every_fn_family_repo(quote! { in_op_only, }))
@@ -1058,11 +1032,9 @@ mod tests {
             .to_string();
 
         assert!(tokens.contains("pub struct ScopedUsers"));
-        // the standalone delegates are gone...
         assert!(!tokens.contains("self . repo . find_by_id (self . scope"));
         assert!(!tokens.contains("self . repo . find_all (self . scope"));
         assert!(!tokens.contains("self . repo . list_for_filters (self . scope"));
-        // ...and the `_in_op` delegates, including the dispatcher's, remain.
         assert!(tokens.contains("self . repo . find_by_id_in_op (op , self . scope"));
         assert!(tokens.contains("self . repo . list_for_filters_in_op (op , self . scope"));
     }

--- a/es-entity-macros/src/repo/mod.rs
+++ b/es-entity-macros/src/repo/mod.rs
@@ -34,6 +34,7 @@ pub fn derive(ast: syn::DeriveInput) -> darling::Result<proc_macro2::TokenStream
     opts.columns.validate_list_for_by_columns()?;
     opts.columns.validate_scope()?;
     opts.validate_forgettable()?;
+    opts.validate_in_op_only()?;
     // `include_bytes!` the resolved migrations so Cargo re-runs this derive when
     // they change (keeps the migration-derived index catalog and error mapping
     // in sync even for an auto-discovered ancestor `migrations/`).
@@ -58,7 +59,9 @@ pub struct EsRepo<'a> {
     find_all_fn: find_all_fn::FindAllFn<'a>,
     post_hydrate_hook: post_hydrate_hook::PostHydrateHook<'a>,
     post_persist_hook: post_persist_hook::PostPersistHook<'a>,
-    begin: begin::Begin<'a>,
+    /// `None` for a pool-less (`in_op_only`) repo: `begin_op` manufactures a
+    /// `DbOp` from the pool, so there is nothing to generate it from.
+    begin: Option<begin::Begin<'a>>,
     list_by_fns: Vec<list_by_fn::ListByFn<'a>>,
     list_for_fns: Vec<list_for_fn::ListForFn<'a>>,
     hydrate_nested_fns: Vec<syn::Ident>,
@@ -145,7 +148,10 @@ impl<'a> From<&'a RepositoryOptions> for EsRepo<'a> {
             find_all_fn: find_all_fn::FindAllFn::from(opts),
             post_hydrate_hook: post_hydrate_hook::PostHydrateHook::from(opts),
             post_persist_hook: post_persist_hook::PostPersistHook::from(opts),
-            begin: begin::Begin::from(opts),
+            begin: opts
+                .pool_field()
+                .is_some()
+                .then(|| begin::Begin::from(opts)),
             list_by_fns,
             list_for_fns,
             hydrate_nested_fns,
@@ -214,7 +220,16 @@ impl ToTokens for EsRepo<'_> {
         let nested = &self.nested;
         let hydrate_nested = &self.hydrate_nested;
 
-        let pool_field = self.opts.pool_field();
+        // A pool-less (`in_op_only`) repo exposes no pool accessor: there is no
+        // field to return, and nothing generated reaches for one.
+        let pool_fn = self.opts.pool_field().map(|pool_field| {
+            quote! {
+                #[inline(always)]
+                pub fn pool(&self) -> &es_entity::db::Pool {
+                    &self.#pool_field
+                }
+            }
+        });
         let has_tbl_prefix = self.opts.table_prefix().is_some();
         let es_query_flavor = if hydrate_nested_fns.is_empty() {
             quote! {
@@ -376,10 +391,7 @@ impl ToTokens for EsRepo<'_> {
             #sort_by
 
              impl #impl_generics #repo #ty_generics #where_clause {
-                #[inline(always)]
-                pub fn pool(&self) -> &es_entity::db::Pool {
-                    &self.#pool_field
-                }
+                #pool_fn
 
                 #scoped_fn
 
@@ -906,6 +918,181 @@ mod tests {
         let msg = err.to_string();
         assert!(
             msg.contains("Forgettable") || msg.contains("non-nullable"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// The standalone (non-`_in_op`) fns every write and read path generates
+    /// by default. Each entry is the *exact* token-stream prefix of the
+    /// generated signature, so an accidental re-emission cannot slip past by
+    /// being reformatted.
+    ///
+    /// Shared by the suppression test and its regression twin below so the two
+    /// can never drift apart: whatever `in_op_only` is asserted to remove, a
+    /// default repo is asserted to keep.
+    const STANDALONE_FN_SIGNATURES: &[&str] = &[
+        "pub async fn create (& self ,",
+        "pub async fn create_all (& self ,",
+        "pub async fn update (& self ,",
+        "pub async fn update_all (& self ,",
+        "pub async fn delete (& self ,",
+        "pub async fn find_by_id (& self ,",
+        "pub async fn maybe_find_by_id (& self ,",
+        "pub async fn find_by_name (& self ,",
+        // stops before the nested `>>`, whose token spacing is not stable
+        "pub async fn find_all < Out : From < User",
+        "pub async fn list_by_id (& self ,",
+        "pub async fn list_for_name_by_id (& self ,",
+        "pub async fn list_for_filters (& self ,",
+    ];
+
+    /// A repo exercising every generated fn family: writes, soft delete (so
+    /// the `_include_deleted` siblings are emitted too), find-by, list-by,
+    /// list-for and the `list_for_filters` dispatcher.
+    fn every_fn_family_repo(extra_opts: proc_macro2::TokenStream) -> syn::DeriveInput {
+        parse_quote! {
+            #[es_repo(
+                entity = "User",
+                delete = "soft",
+                #extra_opts
+                columns(name(ty = "String", list_by, list_for))
+            )]
+            struct Users {
+                pool: sqlx::PgPool,
+            }
+        }
+    }
+
+    #[test]
+    fn in_op_only_suppresses_every_standalone_fn() {
+        let tokens = derive(every_fn_family_repo(quote! { in_op_only, }))
+            .expect("in_op_only repo should derive")
+            .to_string();
+
+        for sig in STANDALONE_FN_SIGNATURES {
+            assert!(
+                !tokens.contains(sig),
+                "`in_op_only` must not generate the standalone fn `{sig}`"
+            );
+        }
+        // The soft-delete siblings go too.
+        assert!(!tokens.contains("pub async fn find_by_id_include_deleted (& self ,"));
+        assert!(!tokens.contains("pub async fn list_by_id_include_deleted (& self ,"));
+        assert!(!tokens.contains("pub async fn list_for_filters_include_deleted (& self ,"));
+
+        // ...while every `_in_op` twin remains, including the dispatcher's,
+        // which had no `_in_op` form before this option existed.
+        assert!(tokens.contains("pub async fn create_in_op"));
+        assert!(tokens.contains("pub async fn update_in_op"));
+        assert!(tokens.contains("pub async fn delete_in_op"));
+        assert!(tokens.contains("pub async fn find_by_id_in_op"));
+        assert!(tokens.contains("pub async fn find_all_in_op"));
+        assert!(tokens.contains("pub async fn list_by_id_in_op"));
+        assert!(tokens.contains("pub async fn list_for_filters_in_op"));
+    }
+
+    /// The regression twin: a repo *without* the option keeps every standalone
+    /// fn, the pool accessor and `begin_op`. Guards against the gating leaking
+    /// into the default path.
+    #[test]
+    fn repo_without_in_op_only_keeps_every_standalone_fn() {
+        let tokens = derive(every_fn_family_repo(quote! {}))
+            .expect("default repo should derive")
+            .to_string();
+
+        for sig in STANDALONE_FN_SIGNATURES {
+            assert!(
+                tokens.contains(sig),
+                "a repo without `in_op_only` must still generate `{sig}`"
+            );
+        }
+        assert!(tokens.contains("pub fn pool (& self)"));
+        assert!(tokens.contains("pub async fn begin_op (& self)"));
+        assert!(tokens.contains("pub async fn begin_op_with_clock"));
+    }
+
+    #[test]
+    fn in_op_only_without_pool_field_drops_pool_accessor_and_begin_op() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[es_repo(entity = "User", in_op_only, columns(name(ty = "String")))]
+            struct Users {}
+        };
+        let tokens = derive(input)
+            .expect("pool-less in_op_only repo should derive")
+            .to_string();
+
+        assert!(!tokens.contains("pub fn pool (& self)"));
+        assert!(!tokens.contains("begin_op"));
+        assert!(!tokens.contains("self . pool ()"));
+        // The op-taking surface is untouched.
+        assert!(tokens.contains("pub async fn create_in_op"));
+        assert!(tokens.contains("pub async fn find_by_id_in_op"));
+    }
+
+    /// `in_op_only` only *permits* dropping the pool — a repo that keeps one
+    /// keeps `pool()`/`begin_op` too. Holding a pool does not weaken the
+    /// discipline: the op still has to be passed explicitly.
+    #[test]
+    fn in_op_only_with_pool_field_keeps_begin_op() {
+        let tokens = derive(every_fn_family_repo(quote! { in_op_only, }))
+            .expect("in_op_only repo with a pool should derive")
+            .to_string();
+
+        assert!(tokens.contains("pub fn pool (& self)"));
+        assert!(tokens.contains("pub async fn begin_op (& self)"));
+        assert!(!tokens.contains("pub async fn create (& self ,"));
+    }
+
+    #[test]
+    fn in_op_only_suppresses_scoped_view_standalone_delegates() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[es_repo(
+                entity = "User",
+                in_op_only,
+                columns(partner_id(ty = "PartnerId", scope), name(ty = "String"))
+            )]
+            struct Users {}
+        };
+        let tokens = derive(input)
+            .expect("scoped in_op_only repo should derive")
+            .to_string();
+
+        assert!(tokens.contains("pub struct ScopedUsers"));
+        // the standalone delegates are gone...
+        assert!(!tokens.contains("self . repo . find_by_id (self . scope"));
+        assert!(!tokens.contains("self . repo . find_all (self . scope"));
+        assert!(!tokens.contains("self . repo . list_for_filters (self . scope"));
+        // ...and the `_in_op` delegates, including the dispatcher's, remain.
+        assert!(tokens.contains("self . repo . find_by_id_in_op (op , self . scope"));
+        assert!(tokens.contains("self . repo . list_for_filters_in_op (op , self . scope"));
+    }
+
+    #[test]
+    fn missing_pool_without_in_op_only_is_error() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[es_repo(entity = "User", columns(name(ty = "String")))]
+            struct Users {}
+        };
+        let err = derive(input).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no pool field") && msg.contains("in_op_only"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn clock_field_without_pool_is_error() {
+        let input: syn::DeriveInput = parse_quote! {
+            #[es_repo(entity = "User", in_op_only, columns(name(ty = "String")))]
+            struct Users {
+                clock: es_entity::clock::ClockHandle,
+            }
+        };
+        let err = derive(input).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("clock field") && msg.contains("begin_op"),
             "unexpected error: {msg}"
         );
     }

--- a/es-entity-macros/src/repo/options/mod.rs
+++ b/es-entity-macros/src/repo/options/mod.rs
@@ -230,12 +230,6 @@ pub struct RepositoryOptions {
 
     #[darling(default)]
     persist_event_context: Option<bool>,
-    /// Generate only the `_in_op` variants of every repo fn, making it
-    /// impossible to reach the database without passing an operation
-    /// (`AtomicOperation` for writes, `IntoOneTimeExecutor` for reads).
-    ///
-    /// With this set the pool field becomes optional: a repo that holds no
-    /// pool cannot begin its own operation, which is the point.
     #[darling(default)]
     in_op_only: bool,
     #[darling(default)]
@@ -449,10 +443,6 @@ impl RepositoryOptions {
         self.ident.to_string().to_case(Case::Snake)
     }
 
-    /// The pool field, if the repo has one.
-    ///
-    /// `None` is only reachable for an `in_op_only` repo — [`Self::validate_in_op_only`]
-    /// rejects a pool-less repo that has not opted in.
     pub fn pool_field(&self) -> Option<&syn::Ident> {
         match &self.data {
             darling::ast::Data::Struct(fields) => fields.iter().find_map(|field| {
@@ -466,11 +456,6 @@ impl RepositoryOptions {
         }
     }
 
-    /// Whether only the `_in_op` variants of the repo fns are generated.
-    ///
-    /// The standalone fns are exactly the ones that open (or borrow) the pool
-    /// on the caller's behalf, so suppressing them makes passing an operation
-    /// the only way to reach the database.
     pub fn in_op_only(&self) -> bool {
         self.in_op_only
     }
@@ -604,11 +589,6 @@ impl RepositoryOptions {
         Ok(())
     }
 
-    /// Validates the pool field against `in_op_only`.
-    ///
-    /// Both errors below used to be either a raw `.expect()` panic (missing
-    /// pool) or a silently dead struct field (clock without a pool), so this
-    /// trades a confusing failure for a pointed one.
     pub fn validate_in_op_only(&self) -> darling::Result<()> {
         if self.pool_field().is_some() {
             return Ok(());
@@ -623,9 +603,6 @@ impl RepositoryOptions {
             .with_span(&self.ident));
         }
 
-        // The clock is read only by `begin_op`, which needs a pool to build the
-        // `DbOp`. Without one the field would be silently dead: an `in_op_only`
-        // repo takes its time from the operation (`op.maybe_now()`) instead.
         if !matches!(self.clock_field(), ClockFieldInfo::None) {
             return Err(darling::Error::custom(
                 "repo has a clock field but no pool field: the clock is only used by \

--- a/es-entity-macros/src/repo/options/mod.rs
+++ b/es-entity-macros/src/repo/options/mod.rs
@@ -230,6 +230,14 @@ pub struct RepositoryOptions {
 
     #[darling(default)]
     persist_event_context: Option<bool>,
+    /// Generate only the `_in_op` variants of every repo fn, making it
+    /// impossible to reach the database without passing an operation
+    /// (`AtomicOperation` for writes, `IntoOneTimeExecutor` for reads).
+    ///
+    /// With this set the pool field becomes optional: a repo that holds no
+    /// pool cannot begin its own operation, which is the point.
+    #[darling(default)]
+    in_op_only: bool,
     #[darling(default)]
     forgettable: bool,
     #[darling(default, rename = "forgettable_tbl")]
@@ -441,8 +449,12 @@ impl RepositoryOptions {
         self.ident.to_string().to_case(Case::Snake)
     }
 
-    pub fn pool_field(&self) -> &syn::Ident {
-        let field = match &self.data {
+    /// The pool field, if the repo has one.
+    ///
+    /// `None` is only reachable for an `in_op_only` repo — [`Self::validate_in_op_only`]
+    /// rejects a pool-less repo that has not opted in.
+    pub fn pool_field(&self) -> Option<&syn::Ident> {
+        match &self.data {
             darling::ast::Data::Struct(fields) => fields.iter().find_map(|field| {
                 if field.is_pool_field() {
                     Some(field.ident.as_ref().unwrap())
@@ -451,8 +463,16 @@ impl RepositoryOptions {
                 }
             }),
             _ => None,
-        };
-        field.expect("Repo must have a field named 'pool' or marked with #[es_repo(pool)]")
+        }
+    }
+
+    /// Whether only the `_in_op` variants of the repo fns are generated.
+    ///
+    /// The standalone fns are exactly the ones that open (or borrow) the pool
+    /// on the caller's behalf, so suppressing them makes passing an operation
+    /// the only way to reach the database.
+    pub fn in_op_only(&self) -> bool {
+        self.in_op_only
     }
 
     pub fn clock_field(&self) -> ClockFieldInfo<'_> {
@@ -581,6 +601,40 @@ impl RepositoryOptions {
                  add `forgettable` to #[es_repo(...)]",
             ));
         }
+        Ok(())
+    }
+
+    /// Validates the pool field against `in_op_only`.
+    ///
+    /// Both errors below used to be either a raw `.expect()` panic (missing
+    /// pool) or a silently dead struct field (clock without a pool), so this
+    /// trades a confusing failure for a pointed one.
+    pub fn validate_in_op_only(&self) -> darling::Result<()> {
+        if self.pool_field().is_some() {
+            return Ok(());
+        }
+
+        if !self.in_op_only {
+            return Err(darling::Error::custom(
+                "repo has no pool field: add a field named `pool` (or one marked \
+                 `#[es_repo(pool)]`), or add `in_op_only` to #[es_repo(...)] to generate \
+                 only the `_in_op` fns, which take the operation from the caller",
+            )
+            .with_span(&self.ident));
+        }
+
+        // The clock is read only by `begin_op`, which needs a pool to build the
+        // `DbOp`. Without one the field would be silently dead: an `in_op_only`
+        // repo takes its time from the operation (`op.maybe_now()`) instead.
+        if !matches!(self.clock_field(), ClockFieldInfo::None) {
+            return Err(darling::Error::custom(
+                "repo has a clock field but no pool field: the clock is only used by \
+                 `begin_op`, which an `in_op_only` repo without a pool does not generate. \
+                 Remove the clock field — the operation supplies the time — or add a pool field",
+            )
+            .with_span(&self.ident));
+        }
+
         Ok(())
     }
 

--- a/es-entity-macros/src/repo/update_all_fn.rs
+++ b/es-entity-macros/src/repo/update_all_fn.rs
@@ -8,6 +8,7 @@ use super::{
 };
 
 pub struct UpdateAllFn<'a> {
+    in_op_only: bool,
     entity: &'a syn::Ident,
     id: &'a syn::Ident,
     event: &'a syn::Ident,
@@ -26,6 +27,7 @@ pub struct UpdateAllFn<'a> {
 impl<'a> From<&'a RepositoryOptions> for UpdateAllFn<'a> {
     fn from(opts: &'a RepositoryOptions) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             entity: opts.entity(),
             id: opts.id(),
             event: opts.event(),
@@ -311,19 +313,20 @@ impl UpdateAllFn<'_> {
             quote! {}
         };
 
-        let standalone_wrapper = matches!(mode, BatchMode::OwnedSlice).then(|| {
-            quote! {
-                pub async fn update_all(
-                    &self,
-                    entities: &mut [#entity]
-                ) -> Result<usize, #modify_error> {
-                    let mut op = self.begin_op().await?;
-                    let res = self.update_all_in_op(&mut op, entities).await?;
-                    op.commit().await?;
-                    Ok(res)
+        let standalone_wrapper =
+            (matches!(mode, BatchMode::OwnedSlice) && !self.in_op_only).then(|| {
+                quote! {
+                    pub async fn update_all(
+                        &self,
+                        entities: &mut [#entity]
+                    ) -> Result<usize, #modify_error> {
+                        let mut op = self.begin_op().await?;
+                        let res = self.update_all_in_op(&mut op, entities).await?;
+                        op.commit().await?;
+                        Ok(res)
+                    }
                 }
-            }
-        });
+            });
 
         quote! {
             #standalone_wrapper
@@ -410,6 +413,7 @@ mod tests {
 
         let event = Ident::new("EntityEvent", Span::call_site());
         let update_all_fn = UpdateAllFn {
+            in_op_only: false,
             entity: &entity,
             id: &id,
             event: &event,
@@ -643,6 +647,7 @@ mod tests {
 
         let event = Ident::new("EntityEvent", Span::call_site());
         let update_all_fn = UpdateAllFn {
+            in_op_only: false,
             entity: &entity,
             id: &id,
             event: &event,

--- a/es-entity-macros/src/repo/update_fn.rs
+++ b/es-entity-macros/src/repo/update_fn.rs
@@ -8,6 +8,7 @@ use super::{
 };
 
 pub struct UpdateFn<'a> {
+    in_op_only: bool,
     entity: &'a syn::Ident,
     id: &'a syn::Ident,
     event: &'a syn::Ident,
@@ -26,6 +27,7 @@ pub struct UpdateFn<'a> {
 impl<'a> From<&'a RepositoryOptions> for UpdateFn<'a> {
     fn from(opts: &'a RepositoryOptions) -> Self {
         Self {
+            in_op_only: opts.in_op_only(),
             entity: opts.entity(),
             id: opts.id(),
             event: opts.event(),
@@ -174,6 +176,20 @@ impl ToTokens for UpdateFn<'_> {
             quote! {}
         };
 
+        let standalone = (!self.in_op_only).then(|| {
+            quote! {
+                pub async fn update(
+                    &self,
+                    entity: &mut #entity
+                ) -> Result<usize, #modify_error> {
+                    let mut op = self.begin_op().await?;
+                    let res = self.update_in_op(&mut op, entity).await?;
+                    op.commit().await?;
+                    Ok(res)
+                }
+            }
+        });
+
         tokens.append_all(quote! {
             #[inline(always)]
             fn extract_events<Entity, Event>(entity: &mut Entity) -> &mut es_entity::EntityEvents<Event>
@@ -184,15 +200,7 @@ impl ToTokens for UpdateFn<'_> {
                 entity.events_mut()
             }
 
-            pub async fn update(
-                &self,
-                entity: &mut #entity
-            ) -> Result<usize, #modify_error> {
-                let mut op = self.begin_op().await?;
-                let res = self.update_in_op(&mut op, entity).await?;
-                op.commit().await?;
-                Ok(res)
-            }
+            #standalone
 
             #instrument_attr
             pub async fn update_in_op<OP>(
@@ -246,6 +254,7 @@ mod tests {
 
         let event = Ident::new("EntityEvent", Span::call_site());
         let update_fn = UpdateFn {
+            in_op_only: false,
             entity: &entity,
             id: &id,
             event: &event,
@@ -342,6 +351,7 @@ mod tests {
 
         let event = Ident::new("EntityEvent", Span::call_site());
         let update_fn = UpdateFn {
+            in_op_only: false,
             entity: &entity,
             id: &id,
             event: &event,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -287,6 +287,106 @@ pub trait EsEntity: TryFromEvents<Self::Event> + Send {
 ///    }
 /// }
 /// ```
+///
+/// # `in_op_only`: making the operation mandatory
+///
+/// `#[es_repo(in_op_only)]` generates **only** the `_in_op` variants of every
+/// repo fn. The standalone fns are exactly the ones that open (or borrow) the
+/// pool on the caller's behalf, so removing them makes passing an operation —
+/// an [`AtomicOperation`][crate::AtomicOperation] for writes, an
+/// [`IntoOneTimeExecutor`][crate::IntoOneTimeExecutor] for reads — the only way
+/// to reach the database.
+///
+/// With no standalone fn left to open one, the pool field becomes optional. A
+/// repo that holds no pool cannot begin its own operation, which is the point:
+/// the discipline is enforced by construction rather than by convention.
+///
+/// Calling a non-`_in_op` fn on such a repo does not compile — the method does
+/// not exist (note the two tests below compile a real repo, so they need the
+/// test database, like the book's examples):
+///
+/// ```compile_fail,E0599
+/// use es_entity::*;
+/// use serde::{Deserialize, Serialize};
+/// # fn main() {}
+/// # es_entity::entity_id! { UserId }
+/// # #[derive(EsEvent, Debug, Serialize, Deserialize)]
+/// # #[serde(tag = "type", rename_all = "snake_case")]
+/// # #[es_event(id = "UserId")]
+/// # pub enum UserEvent {
+/// #     Initialized { id: UserId, name: String },
+/// # }
+/// # pub struct NewUser { id: UserId, name: String }
+/// # impl IntoEvents<UserEvent> for NewUser {
+/// #     fn into_events(self) -> EntityEvents<UserEvent> { unimplemented!() }
+/// # }
+/// # #[derive(EsEntity)]
+/// # pub struct User {
+/// #     pub id: UserId,
+/// #     pub name: String,
+/// #     events: EntityEvents<UserEvent>,
+/// # }
+/// # impl TryFromEvents<UserEvent> for User {
+/// #     fn try_from_events(events: EntityEvents<UserEvent>) -> Result<Self, EntityHydrationError> {
+/// #         unimplemented!()
+/// #     }
+/// # }
+/// // This repo deliberately KEEPS its pool, so that `create`, were it ever
+/// // generated again, would compile: that makes the E0599 below prove the fn
+/// // is absent, rather than merely that its body could not build an operation.
+/// #[derive(EsRepo)]
+/// #[es_repo(entity = "User", in_op_only, columns(name(ty = "String")))]
+/// pub struct Users {
+///     pool: es_entity::db::Pool,
+/// }
+///
+/// async fn reaches_the_db_without_an_op(repo: &Users, new_user: NewUser) {
+///     // error[E0599]: no method named `create` found — `in_op_only` leaves
+///     // only `create_in_op`, which demands an operation from the caller.
+///     repo.create(new_user).await.unwrap();
+/// }
+/// ```
+///
+/// The `_in_op` twin of the very same call compiles:
+///
+/// ```
+/// use es_entity::*;
+/// use serde::{Deserialize, Serialize};
+/// # fn main() {}
+/// # es_entity::entity_id! { UserId }
+/// # #[derive(EsEvent, Debug, Serialize, Deserialize)]
+/// # #[serde(tag = "type", rename_all = "snake_case")]
+/// # #[es_event(id = "UserId")]
+/// # pub enum UserEvent {
+/// #     Initialized { id: UserId, name: String },
+/// # }
+/// # pub struct NewUser { id: UserId, name: String }
+/// # impl IntoEvents<UserEvent> for NewUser {
+/// #     fn into_events(self) -> EntityEvents<UserEvent> { unimplemented!() }
+/// # }
+/// # #[derive(EsEntity)]
+/// # pub struct User {
+/// #     pub id: UserId,
+/// #     pub name: String,
+/// #     events: EntityEvents<UserEvent>,
+/// # }
+/// # impl TryFromEvents<UserEvent> for User {
+/// #     fn try_from_events(events: EntityEvents<UserEvent>) -> Result<Self, EntityHydrationError> {
+/// #         unimplemented!()
+/// #     }
+/// # }
+/// #[derive(EsRepo)]
+/// #[es_repo(entity = "User", in_op_only, columns(name(ty = "String")))]
+/// pub struct Users {}
+///
+/// async fn takes_the_op_from_its_caller(
+///     repo: &Users,
+///     op: &mut impl AtomicOperation,
+///     new_user: NewUser,
+/// ) {
+///     repo.create_in_op(op, new_user).await.unwrap();
+/// }
+/// ```
 pub trait EsRepo: Send {
     type Entity: EsEntity;
     type CreateError;

--- a/tests/in_op_only.rs
+++ b/tests/in_op_only.rs
@@ -1,0 +1,189 @@
+//! `#[es_repo(in_op_only)]`: only the `_in_op` variants of the repo fns are
+//! generated, so there is no way to reach the database without passing an
+//! operation. With no standalone fn left to open one, the pool field itself
+//! becomes optional — the repo below holds nothing at all.
+//!
+//! The *enforcement* half of this property (that calling a non-`_in_op` form
+//! fails to compile) is pinned by a `compile_fail` doctest on
+//! `es_entity::EsRepo`, and by token-level assertions in
+//! `es-entity-macros/src/repo/mod.rs`. What this file proves is the other
+//! half: that the surviving `_in_op`-only surface actually works end to end
+//! against Postgres, pool-less.
+
+mod entities;
+mod helpers;
+
+use entities::user::*;
+use es_entity::{DbOp, *};
+
+/// A repo with no fields whatsoever: no pool, no clock. Every fn it exposes
+/// takes the operation from its caller.
+#[derive(EsRepo, Debug)]
+#[es_repo(
+    entity = "User",
+    in_op_only,
+    columns(name(ty = "String", list_by, list_for))
+)]
+pub struct Users {}
+
+fn new_user(name: &str) -> NewUser {
+    NewUser::builder()
+        .id(UserId::new())
+        .name(name.to_string())
+        .build()
+        .expect("failed to build user")
+}
+
+#[tokio::test]
+async fn pool_less_repo_writes_and_reads_through_a_passed_op() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let users = Users {};
+
+    // Writes: the caller owns the transaction from beginning to commit.
+    let mut op = DbOp::init(&pool).await?;
+    let mut user = users
+        .create_in_op(&mut op, new_user("in_op_only create"))
+        .await?;
+    let id = user.id;
+    op.commit().await?;
+
+    let mut op = DbOp::init(&pool).await?;
+    let _ = user.update_name("in_op_only updated");
+    users.update_in_op(&mut op, &mut user).await?;
+    op.commit().await?;
+
+    // Reads take a one-shot executor. A borrowed pool is one...
+    let found = users.find_by_id_in_op(&pool, id).await?;
+    assert_eq!(found.name, "in_op_only updated");
+
+    // ...and so is a live operation, so a read can observe uncommitted state
+    // written earlier in the same transaction.
+    let mut op = DbOp::init(&pool).await?;
+    let mut uncommitted = users.create_in_op(&mut op, new_user("uncommitted")).await?;
+    let uncommitted_id = uncommitted.id;
+    let seen = users.find_by_id_in_op(&mut op, uncommitted_id).await?;
+    assert_eq!(seen.name, "uncommitted");
+    let _ = uncommitted.update_name("still uncommitted");
+    users.update_in_op(&mut op, &mut uncommitted).await?;
+    op.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pool_less_repo_serves_every_read_family_in_op() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let users = Users {};
+
+    let unique = format!("in_op_only_reads_{}", UserId::new());
+    let mut op = DbOp::init(&pool).await?;
+    let user = users.create_in_op(&mut op, new_user(&unique)).await?;
+    op.commit().await?;
+
+    // find_all
+    let all: std::collections::HashMap<UserId, User> =
+        users.find_all_in_op(&pool, &[user.id]).await?;
+    assert!(all.contains_key(&user.id));
+
+    // list_by_<column>
+    let by_name = users
+        .list_by_name_in_op(
+            &pool,
+            PaginatedQueryArgs {
+                first: 10,
+                after: None,
+            },
+            ListDirection::Descending,
+        )
+        .await?;
+    assert!(!by_name.entities.is_empty());
+
+    // list_for_<column>_by_<column>
+    let for_name = users
+        .list_for_name_by_id_in_op(
+            &pool,
+            unique.clone(),
+            PaginatedQueryArgs {
+                first: 10,
+                after: None,
+            },
+            ListDirection::Ascending,
+        )
+        .await?;
+    assert_eq!(for_name.entities.len(), 1);
+    assert_eq!(for_name.entities[0].id, user.id);
+
+    // The `list_for_filters` dispatcher, which had no `_in_op` twin before
+    // this option existed. Filtered: routes to the single-filter sibling.
+    let filtered = users
+        .list_for_filters_in_op(
+            &pool,
+            UserFilters {
+                name: Some(unique.clone()),
+            },
+            Sort {
+                by: UserSortBy::Id,
+                direction: ListDirection::Ascending,
+            },
+            PaginatedQueryArgs {
+                first: 10,
+                after: None,
+            },
+        )
+        .await?;
+    assert_eq!(filtered.entities.len(), 1);
+    assert_eq!(filtered.entities[0].id, user.id);
+
+    // Unfiltered: routes to the plain `list_by_*` sibling.
+    let unfiltered = users
+        .list_for_filters_in_op(
+            &pool,
+            UserFilters::default(),
+            Sort {
+                by: UserSortBy::Id,
+                direction: ListDirection::Descending,
+            },
+            PaginatedQueryArgs {
+                first: 10,
+                after: None,
+            },
+        )
+        .await?;
+    assert!(!unfiltered.entities.is_empty());
+
+    Ok(())
+}
+
+/// `in_op_only` only *permits* dropping the pool. A repo that keeps one still
+/// gets `pool()` and `begin_op()` — holding a pool does not weaken the
+/// discipline, because the op still has to be passed in explicitly.
+mod with_pool {
+    use super::{entities::user::*, helpers, new_user};
+    use es_entity::*;
+    use sqlx::PgPool;
+
+    #[derive(EsRepo, Debug)]
+    #[es_repo(entity = "User", in_op_only, columns(name(ty = "String")))]
+    pub struct Users {
+        pool: PgPool,
+    }
+
+    #[tokio::test]
+    async fn in_op_only_repo_with_a_pool_can_still_begin_its_own_op() -> anyhow::Result<()> {
+        let pool = helpers::init_pool().await?;
+        let users = Users { pool: pool.clone() };
+
+        // `begin_op` survives: it is the pool-owning constructor of an op, not
+        // a way to skip passing one.
+        let mut op = users.begin_op().await?;
+        let user = users
+            .create_in_op(&mut op, new_user("in_op_only with pool"))
+            .await?;
+        op.commit().await?;
+
+        let found = users.find_by_id_in_op(users.pool(), user.id).await?;
+        assert_eq!(found.name, "in_op_only with pool");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

Adds `#[es_repo(in_op_only)]`, which generates **only** the `_in_op` variants of the repo fns. The standalone fns are exactly the ones that open (or borrow) the pool on the caller's behalf, so removing them makes passing an operation — `AtomicOperation` for writes, `IntoOneTimeExecutor` for reads — the only way to reach the database. Enforced by the compiler rather than by convention.

With no standalone fn left to open one, **the pool field becomes optional**: a repo that holds no pool cannot begin an operation of its own, which is the point.

```rust
#[derive(EsRepo)]
#[es_repo(entity = "User", in_op_only, columns(name(ty = "String")))]
pub struct Users {}   // no pool, no clock — nothing at all

users.create(new_user).await          // error[E0599]: no method named `create`
users.create_in_op(op, new_user).await // the only way in
```

## Option shape, and why

Declared per repo on `RepositoryOptions` (`es-entity-macros/src/repo/options/mod.rs`) — **the same declaration site as the event-context setting** (`persist_event_context`), which confirmed the per-repo instinct in the original ask.

It is a plain `bool` rather than that setting's `Option<bool>`: the `Option` exists there only to take a default from the `event-context-enabled` cargo feature. There is no analogous global here, and a workspace-wide default would be a footgun — flipping it would silently delete methods from every repo in the workspace. `forgettable: bool` on the same struct is the precedent for the simple form.

## What the option suppresses

**Writes:** `create`, `create_all`, `update`, `update_all`, `delete`, `forget`, `verify_forgotten`
**Reads:** `find_by_*` / `maybe_find_by_*` (+ `_include_deleted`), `find_all`, `list_by_*`, `list_for_*_by_*`, `list_for_filters_by_*`, `list_for_filters` (+ `_include_deleted`)
**Scoped view:** the standalone half of every `Scoped{Repo}` delegate; the `_in_op` delegates stay.

Everything pool-dependent, and what happens to it:

| Generated item | Under `in_op_only` |
|---|---|
| `pub fn pool()` | emitted only when a pool field exists |
| `begin_op` / `begin_op_with_clock` | emitted only when a pool field exists — they *are* the pool→`DbOp` constructor |
| `RepositoryOptions::pool_field()` | no longer mandatory (was a raw `.expect()` panic) |
| `nested.rs` / `hydrate_nested.rs` | unchanged — they forward the parent's `op`, never a child's pool |
| constructors | none are generated; repos are hand-written structs, so no signature changes and nothing constructs them generically |

Keeping a pool **and** setting `in_op_only` is legal: `pool()`/`begin_op()` are still generated. Holding a pool does not weaken the discipline, because the op must still be passed explicitly to every call.

## The one fn that could not exist as-is

`list_for_filters` was the only generated fn with **no `_in_op` twin** — a dispatcher whose body is a `match` over sort columns, each arm calling a sibling *standalone* fn. Under the option it would have lost its implementation, not just its wrapper.

Rather than excluding it or erroring, it now gets a real **`list_for_filters_in_op`** (plus `_include_deleted` and the scoped-view delegate), **generated for every repo** — purely additive, and it fixes a pre-existing asymmetry. Every dispatch path is mutually exclusive (one match arm, one if/else branch), so the one-shot executor is moved exactly once. The standalone dispatcher becomes a thin delegate over it, exactly like every other read pair; the instrumentation span moves onto the `_in_op` fn, matching the crate's convention.

## Errors, not confusion

| Situation | Before | Now |
|---|---|---|
| No pool field, no `in_op_only` | raw `.expect()` panic | pointed `darling` error naming both fixes |
| `clock` field on a pool-less repo | silently dead field | error — the clock is read *only* by `begin_op`; an `in_op_only` repo takes its time from `op.maybe_now()` |

The first is a strict improvement for existing users too.

## Proving the enforcement

There is no trybuild in this repo, so this uses the two mechanisms that exist:

1. **A real compile-fail test** — a `compile_fail,E0599` rustdoc doctest on `EsRepo` (the convention already used in `src/traits.rs` / `src/forgettable.rs`), paired with a passing doctest calling the `_in_op` twin. The error code is pinned, so it cannot pass for an unrelated reason. Its repo **deliberately keeps a pool**, so that a regression re-emitting `create` would produce a *compiling* `create` and turn the test red — an earlier pool-less version passed for the wrong reason (missing `begin_op`), which the revert-to-red check caught.
2. **Token-level absence assertions** in `repo/mod.rs`, mirroring the existing `scoped_repo_is_ok` test. The suppressed-fn list is a shared `const` used by both the suppression test and its regression twin, so the two cannot drift.

Plus `tests/in_op_only.rs`: a pool-less repo exercised end to end against Postgres — writes, reads through both a borrowed pool and a live op (including reading own uncommitted state), every read family, and both `list_for_filters_in_op` dispatch paths.

**Revert-to-red performed** on each: disabling the suppression turns the compile-fail doctest, the passing doctest and 3 token tests red, deterministically and for the stated reason.

## Not breaking

Opt-in, so every existing repo is unchanged — verified rather than assumed:

- A **scratch external consumer crate** (separate crate, so E0603/E0624 privacy errors would surface) written entirely against the pre-existing API — pool field, every standalone fn, `pool()`, `begin_op()` — compiles clean, and also compiles the newly added `list_for_filters_in_op`.
- The full suite is unchanged and green: **476 tests pass**.

The only generated-output change for an ordinary repo is that `list_for_filters` now delegates to its new `_in_op` twin instead of inlining the dispatch. Same signature, same behaviour, same statement count.

## Concurrent work

**PR #210** (`feat(macros)!: aggregate version for nested entities`, open/draft) touches 14 of the same files. It is already unrebased against `main` (still has `populate_nested.rs` where `main` has `hydrate_nested.rs`); whoever rebases second takes the conflict. My edits are additive gating, so they should merge mechanically.

#215, #209, #220, #221, #222, #223 are all merged and already present here.

## Test notes

- `cargo nextest run --workspace` → 476 passed.
- `cargo clippy --workspace --all-features -- --deny warnings` → clean.
- Doctests green, including both new ones.
- Two **pre-existing** failures unrelated to this change, confirmed identical with the work stashed: `--all-features` trips a `fail-on-warnings` dead-code lint in `src/lib.rs`'s own test module, and `--features instrument` has 22 failing token tests on `main` (byte-identical failure set before and after).
- No SQL, no migrations, no `.sqlx` movement — codegen only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaWssc9QbzmXLTfzPWLVBa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Macro codegen changes affect every generated repo API surface (opt-in only), including a new `list_for_filters_in_op` path for all repos; incorrect gating could break compilation or transaction boundaries for adopters of `in_op_only`.
> 
> **Overview**
> Adds opt-in **`#[es_repo(in_op_only)]`**, which stops generating the standalone repo methods that open or borrow a pool (`create`, `update`, `find_by_*`, `list_*`, etc.) and leaves only the **`_in_op`** entry points. Callers must pass an operation (`AtomicOperation` for writes, `IntoOneTimeExecutor` for reads), enforced at compile time when those methods are absent.
> 
> **Pool and transaction helpers:** `pool_field()` is optional; repos without a pool must set `in_op_only`. `pool()`, `begin_op`, and scoped standalone delegates are emitted only when a pool exists (or when not `in_op_only` for the delegates). Missing pool without the flag, or a `clock` field on a pool-less `in_op_only` repo, now fails derive with explicit errors instead of a panic.
> 
> **`list_for_filters`:** New **`list_for_filters_in_op`** (and scoped/nested dispatch paths updated to call `*_in_op` siblings). For normal repos, the standalone dispatcher becomes a thin wrapper over the `_in_op` implementation.
> 
> Docs (`EsRepo` trait), macro token tests, and Postgres integration tests cover pool-less and pool-retaining `in_op_only` repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e36b329e6dd75565f0f20f4a64678fcd4faa06cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->